### PR TITLE
ScrollArea's scrollBar issue (#37) fixed

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1004,6 +1004,15 @@ void MainWindow::deleteNoteWithAnimation(NoteData *note, bool isFromUser)
 
         animation->start(QAbstractAnimation::DeleteWhenStopped);
     }
+
+    if(!m_visibleNotesList.isEmpty()){
+        int contentHeight = m_visibleNotesList[0]->height() * m_visibleNotesList.size();
+        if((contentHeight > ui->scrollArea->height()
+                && m_isScrollAreaScrollBarHidden)
+                ||(contentHeight < ui->scrollArea->height()
+                && !m_isScrollAreaScrollBarHidden))
+        setScrollAreaStyleSheet();
+    }
 }
 
 /**

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -837,6 +837,19 @@ void MainWindow::onLineEditTextChanged (const QString &keyword)
     }else{
         findNotesContain(keyword);
     }
+
+    if(!m_visibleNotesList.isEmpty()){
+        int contentHeight = m_visibleNotesList[0]->height() * m_visibleNotesList.size();
+        if((contentHeight > ui->scrollArea->height()
+                && m_isScrollAreaScrollBarHidden)
+                ||(contentHeight < ui->scrollArea->height()
+                && !m_isScrollAreaScrollBarHidden))
+        setScrollAreaStyleSheet();
+    }
+    else
+    {
+        setScrollAreaStyleSheet();
+    }
 }
 
 /**
@@ -984,6 +997,15 @@ void MainWindow::deleteNote(NoteData *note, bool isFromUser)
             m_currentSelectedNote = Q_NULLPTR;
         }
     }
+
+    if(!m_visibleNotesList.isEmpty()){
+        int contentHeight = m_visibleNotesList[0]->height() * m_visibleNotesList.size();
+        if((contentHeight > ui->scrollArea->height()
+                && m_isScrollAreaScrollBarHidden)
+                ||(contentHeight < ui->scrollArea->height()
+                && !m_isScrollAreaScrollBarHidden))
+        setScrollAreaStyleSheet();
+    }
 }
 
 /**
@@ -1005,14 +1027,7 @@ void MainWindow::deleteNoteWithAnimation(NoteData *note, bool isFromUser)
         animation->start(QAbstractAnimation::DeleteWhenStopped);
     }
 
-    if(!m_visibleNotesList.isEmpty()){
-        int contentHeight = m_visibleNotesList[0]->height() * m_visibleNotesList.size();
-        if((contentHeight > ui->scrollArea->height()
-                && m_isScrollAreaScrollBarHidden)
-                ||(contentHeight < ui->scrollArea->height()
-                && !m_isScrollAreaScrollBarHidden))
-        setScrollAreaStyleSheet();
-    }
+
 }
 
 /**


### PR DESCRIPTION
Description: Whenever a note is deleted, the scrollBar is either displayed or
hidden based on if the size of the list is smaller than scrollArea's height