### PR TITLE
Add updater dialog

### DIFF
--- a/3rdParty/QSimpleUpdater/QSimpleUpdater.pri
+++ b/3rdParty/QSimpleUpdater/QSimpleUpdater.pri
@@ -33,6 +33,16 @@ QT += widgets
 
 INCLUDEPATH += $$PWD/include
 
+win32* {
+    LIBS += -L$$PWD/bin/OpenSSL/ -llibeay32
+    LIBS += -L$$PWD/bin/OpenSSL/ -llibssl32
+    LIBS += -L$$PWD/bin/OpenSSL/ -lssleay32
+}
+
+linux:!android {
+    LIBS += -lcrypto -lssl
+}
+
 SOURCES += \
     $$PWD/src/Updater.cpp \
     $$PWD/src/Downloader.cpp \

--- a/3rdParty/QSimpleUpdater/QSimpleUpdater.pri
+++ b/3rdParty/QSimpleUpdater/QSimpleUpdater.pri
@@ -33,12 +33,6 @@ QT += widgets
 
 INCLUDEPATH += $$PWD/include
 
-win32* {
-    LIBS += -L$$PWD/bin/OpenSSL/ -llibeay32
-    LIBS += -L$$PWD/bin/OpenSSL/ -llibssl32
-    LIBS += -L$$PWD/bin/OpenSSL/ -lssleay32
-}
-
 linux:!android {
     LIBS += -lcrypto -lssl
 }

--- a/3rdParty/QSimpleUpdater/src/Updater.cpp
+++ b/3rdParty/QSimpleUpdater/src/Updater.cpp
@@ -354,5 +354,5 @@ bool Updater::compare (const QString& x, const QString& y) {
             return false;
     }
 
-    return versionsY.count() < versionsX.count();
+    return false;
 }

--- a/UPDATES.json
+++ b/UPDATES.json
@@ -1,21 +1,21 @@
 {
   "updates": {
     "windows": {
-      "open-url": "",
+      "open-url": "https://github.com/nuttyartist/notes/releases/latest",
       "latest-version": "0.9.0",
-      "download-url": "",
+      "download-url": "https://github.com/nuttyartist/notes/releases/latest",
       "changelog": ""
     },
     "osx": {
-      "open-url": "",
+      "open-url": "https://github.com/nuttyartist/notes/releases/latest",
       "latest-version": "0.9.0",
-      "download-url": "",
+      "download-url": "https://github.com/nuttyartist/notes/releases/latest",
       "changelog": ""
     },
     "linux": {
-      "open-url": "",
+      "open-url": "https://github.com/nuttyartist/notes/releases/latest",
       "latest-version": "0.9.0",
-      "download-url": "",
+      "download-url": "https://github.com/nuttyartist/notes/releases/latest",
       "changelog": ""
     }
   }

--- a/src/Notes.pro
+++ b/src/Notes.pro
@@ -32,7 +32,8 @@ SOURCES += \
     $$PWD/notemodel.cpp \
     $$PWD/noteview.cpp \
     $$PWD/singleinstance.cpp \
-    dbmanager.cpp
+    dbmanager.cpp \
+    updaterwindow.cpp
 
 HEADERS  += \
     $$PWD/mainwindow.h \
@@ -41,9 +42,11 @@ HEADERS  += \
     $$PWD/notemodel.h \
     $$PWD/noteview.h \
     $$PWD/singleinstance.h \
-    dbmanager.h
+    dbmanager.h \
+    updaterwindow.h
 
-FORMS += $$PWD/mainwindow.ui
+FORMS += $$PWD/mainwindow.ui \
+    updaterwindow.ui
 RESOURCES += $$PWD/images.qrc \
     fonts.qrc
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,14 +5,11 @@
 *********************************************************************************************/
 
 #include "mainwindow.h"
+#include "updaterwindow.h"
 #include "singleinstance.h"
-#include "QSimpleUpdater.h"
 
 #include <QApplication>
-
-// Define from where we download update definitions.
-// This should be changed from "dev" to "master" for production releases.
-const QString UPDATES_URL = "https://raw.githubusercontent.com/nuttyartist/notes/dev/UPDATES.json";
+#include <QStyleFactory>
 
 int main(int argc, char *argv[])
 {
@@ -33,27 +30,17 @@ int main(int argc, char *argv[])
     instance.listen (name);
 
     // Create and Show the app
-    MainWindow w;
-    w.show();
+    MainWindow window;
+    window.show();
+
+    // Create the updater window
+    UpdaterWindow updater;
+    updater.checkForUpdates();
 
     // Bring the Notes window to the front
     QObject::connect(&instance, &SingleInstance::newInstance, [&](){
-        (&w)->setMainWindowVisibility(true);
+        (&window)->setMainWindowVisibility(true);
     });
-
-#if defined Q_OS_WIN || defined Q_OS_MAC
-    // Disable the integrated downloader, just open a link in a web browser
-    QSimpleUpdater::getInstance()->setDownloaderEnabled (UPDATES_URL, false);
-
-    // Only notify the user when an update is available
-    QSimpleUpdater::getInstance()->setNotifyOnUpdate (UPDATES_URL, true);
-    QSimpleUpdater::getInstance()->setNotifyOnFinish (UPDATES_URL, false);
-
-    // Check for updates
-    QSimpleUpdater::getInstance()->checkForUpdates (UPDATES_URL);
-#else
-    Q_UNUSED (UPDATES_URL);
-#endif
 
     return app.exec();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,7 +9,6 @@
 #include "singleinstance.h"
 
 #include <QApplication>
-#include <QStyleFactory>
 
 int main(int argc, char *argv[])
 {

--- a/src/updaterwindow.cpp
+++ b/src/updaterwindow.cpp
@@ -7,8 +7,11 @@
 #include "updaterwindow.h"
 #include "ui_updaterwindow.h"
 
-const QString UPDATES_URL = "https://raw.githubusercontent.com/nuttyartist/"
-                            "notes/dev/UPDATES.json";
+#include <qdebug.h>
+#include <QDesktopServices>
+#include <QSimpleUpdater.h>
+
+const QString UPDATES_URL = "https://raw.githubusercontent.com/nuttyartist/notes/dev/UPDATES.json";
 
 UpdaterWindow::UpdaterWindow (QWidget *parent) : QWidget (parent)
 {
@@ -16,11 +19,23 @@ UpdaterWindow::UpdaterWindow (QWidget *parent) : QWidget (parent)
     ui = new Ui::UpdaterWindow;
     ui->setupUi (this);
 
+    /* Set window title to app name */
+    setWindowTitle (qApp->applicationName());
+
     /* Setup the color palettes */
     QPalette pal (palette());
     pal.setColor (QPalette::Background, QColor (248, 248, 248));
     setAutoFillBackground (true);
     setPalette (pal);
+
+    /* Connect UI signals/slots */
+    connect (ui->closeButton,  SIGNAL (clicked()), this, SLOT (close()));
+    connect (ui->updateButton, SIGNAL (clicked()), this, SLOT (download()));
+
+    /* Connect signals/slots of the QSU */
+    m_updater = QSimpleUpdater::getInstance();
+    connect (m_updater, SIGNAL (checkingFinished (QString)),
+             this,      SLOT (onCheckFinished  (QString)));
 }
 
 UpdaterWindow::~UpdaterWindow()
@@ -30,5 +45,45 @@ UpdaterWindow::~UpdaterWindow()
 
 void UpdaterWindow::checkForUpdates()
 {
-    show();
+    /* Set module properties */
+    m_updater->setNotifyOnFinish (UPDATES_URL, false);
+    m_updater->setNotifyOnUpdate (UPDATES_URL, false);
+    m_updater->setDownloaderEnabled (UPDATES_URL, false);
+    m_updater->setUseCustomInstallProcedures (UPDATES_URL, true);
+    m_updater->setModuleVersion (UPDATES_URL, qApp->applicationVersion());
+
+    /* Check for updates */
+    m_updater->checkForUpdates (UPDATES_URL);
+}
+
+void UpdaterWindow::download()
+{
+    if (m_updater->getUpdateAvailable (UPDATES_URL))
+        QDesktopServices::openUrl (QUrl (m_updater->getDownloadUrl (UPDATES_URL)));
+}
+
+void UpdaterWindow::showWindow (const QString& url)
+{
+    /* Set version labels */
+    ui->installedVersion->setText (qApp->applicationVersion());
+    ui->availableVersion->setText (m_updater->getLatestVersion (url));
+
+    /* Set changelog text */
+    ui->changelog->setText (m_updater->getChangelog (url));
+    if (ui->changelog->toPlainText().isEmpty())
+        ui->changelog->setText ("<p>No Changelog found...</p>");
+
+    /* Enable/disable update button */
+    ui->updateButton->setEnabled (m_updater->getUpdateAvailable (url));
+
+    /* Show the window if update button is enabled */
+    if (ui->updateButton->isEnabled())
+        show();
+}
+
+void UpdaterWindow::onCheckFinished (const QString &url)
+{
+    /* There is an update available, show the window */
+    if (m_updater->getUpdateAvailable (url) && (UPDATES_URL == url))
+        showWindow (url);
 }

--- a/src/updaterwindow.cpp
+++ b/src/updaterwindow.cpp
@@ -1,0 +1,34 @@
+/*********************************************************************************************
+* Mozila License
+* Just a meantime project to see the ability of qt, the framework that my OS might be based on
+* And for those linux users that beleive in the power of notes
+*********************************************************************************************/
+
+#include "updaterwindow.h"
+#include "ui_updaterwindow.h"
+
+const QString UPDATES_URL = "https://raw.githubusercontent.com/nuttyartist/"
+                            "notes/dev/UPDATES.json";
+
+UpdaterWindow::UpdaterWindow (QWidget *parent) : QWidget (parent)
+{
+    /* Initialize the UI */
+    ui = new Ui::UpdaterWindow;
+    ui->setupUi (this);
+
+    /* Setup the color palettes */
+    QPalette pal (palette());
+    pal.setColor (QPalette::Background, QColor (248, 248, 248));
+    setAutoFillBackground (true);
+    setPalette (pal);
+}
+
+UpdaterWindow::~UpdaterWindow()
+{
+    delete ui;
+}
+
+void UpdaterWindow::checkForUpdates()
+{
+    show();
+}

--- a/src/updaterwindow.h
+++ b/src/updaterwindow.h
@@ -1,0 +1,31 @@
+/*********************************************************************************************
+* Mozila License
+* Just a meantime project to see the ability of qt, the framework that my OS might be based on
+* And for those linux users that beleive in the power of notes
+*********************************************************************************************/
+
+#ifndef UPDATERWINDOW_H
+#define UPDATERWINDOW_H
+
+#include <QWidget>
+
+namespace Ui {
+class UpdaterWindow;
+}
+
+class UpdaterWindow : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit UpdaterWindow (QWidget *parent = 0);
+    ~UpdaterWindow();
+
+public slots:
+    void checkForUpdates();
+
+private:
+    Ui::UpdaterWindow *ui;
+};
+
+#endif

--- a/src/updaterwindow.h
+++ b/src/updaterwindow.h
@@ -13,6 +13,8 @@ namespace Ui {
 class UpdaterWindow;
 }
 
+class QSimpleUpdater;
+
 class UpdaterWindow : public QWidget
 {
     Q_OBJECT
@@ -24,8 +26,14 @@ public:
 public slots:
     void checkForUpdates();
 
+private slots:
+    void download();
+    void showWindow(const QString &url);
+    void onCheckFinished (const QString& url);
+
 private:
     Ui::UpdaterWindow *ui;
+    QSimpleUpdater* m_updater;
 };
 
 #endif

--- a/src/updaterwindow.ui
+++ b/src/updaterwindow.ui
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>UpdaterWindow</class>
+ <widget class="QWidget" name="UpdaterWindow">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>319</width>
+    <height>419</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="title">
+     <property name="font">
+      <font>
+       <pointsize>16</pointsize>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>A Newer Version is Available</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QWidget" name="versionsWidget" native="true">
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="1">
+       <widget class="QLabel" name="installedVersion">
+        <property name="text">
+         <string>%1</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="installedVersion_Label">
+        <property name="text">
+         <string>Installed Version: </string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="availableVersion_Label">
+        <property name="text">
+         <string>Available Version:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLabel" name="availableVersion">
+        <property name="text">
+         <string>%1</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="1" column="2">
+       <spacer name="horizontalSpacer_3">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QWidget" name="changesWidget" native="true">
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QLabel" name="changeslabel">
+        <property name="font">
+         <font>
+          <weight>75</weight>
+          <bold>true</bold>
+         </font>
+        </property>
+        <property name="text">
+         <string>What's New:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QTextBrowser" name="changelog"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QWidget" name="downloaderWidget" native="true">
+     <layout class="QVBoxLayout" name="verticalLayout_3">
+      <item>
+       <widget class="QLabel" name="downloaderTitle">
+        <property name="font">
+         <font>
+          <weight>75</weight>
+          <bold>true</bold>
+         </font>
+        </property>
+        <property name="text">
+         <string>Downloading Update...</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QProgressBar" name="downloadProgress">
+        <property name="value">
+         <number>24</number>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="timeRemaining">
+        <property name="text">
+         <string>Time Remaining: %1</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QWidget" name="buttonsWidget" native="true">
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="closeButton">
+        <property name="text">
+         <string>Close</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="updateButton">
+        <property name="text">
+         <string>Update</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/updaterwindow.ui
+++ b/src/updaterwindow.ui
@@ -6,25 +6,25 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>319</width>
-    <height>419</height>
+    <width>314</width>
+    <height>280</height>
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string/>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QLabel" name="title">
      <property name="font">
       <font>
-       <pointsize>16</pointsize>
+       <pointsize>14</pointsize>
        <weight>75</weight>
        <bold>true</bold>
       </font>
      </property>
      <property name="text">
-      <string>A Newer Version is Available</string>
+      <string>A New Version is Available!</string>
      </property>
     </widget>
    </item>
@@ -122,39 +122,6 @@
       </size>
      </property>
     </spacer>
-   </item>
-   <item>
-    <widget class="QWidget" name="downloaderWidget" native="true">
-     <layout class="QVBoxLayout" name="verticalLayout_3">
-      <item>
-       <widget class="QLabel" name="downloaderTitle">
-        <property name="font">
-         <font>
-          <weight>75</weight>
-          <bold>true</bold>
-         </font>
-        </property>
-        <property name="text">
-         <string>Downloading Update...</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QProgressBar" name="downloadProgress">
-        <property name="value">
-         <number>24</number>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QLabel" name="timeRemaining">
-        <property name="text">
-         <string>Time Remaining: %1</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
    </item>
    <item>
     <widget class="QWidget" name="buttonsWidget" native="true">


### PR DESCRIPTION
Hello,

I have finished integrating the QSimpleUpdater with Notes by creating a dialog similar to the mockup in Gitter. For the moment, the dialog has the following features:

- Version comparison
- Changelog
- Update and Close buttons

When the user clicks the 'Update' button, Notes will open a web browser with the download URL for each operating system. I have not implemented an integrated downloader because GitHub does not handle downloads directly: it uses a system of HTML redirections which must be interpreted by a browser or a more advanced algorithm for the download to take place.

@nuttyartist Thanks for your patience!