### PR TITLE
snapcraft.yaml: add indicator-qt5 remote part

### DIFF
--- a/packaging/linux/snap/snapcraft.yaml
+++ b/packaging/linux/snap/snapcraft.yaml
@@ -8,6 +8,7 @@ description: |
   source and cross-platform project, and you're welcome to be part
   of it and contribute. We hope you will love it as much as we do.
 confinement: strict
+grade: "stable"
 
 apps:
   notes:
@@ -16,10 +17,10 @@ apps:
 
 parts:
   notes:
-    source: ../../../src
+    source: ../../..
     plugin: qmake
     qt-version: qt5
-    project-files: [Notes.pro]
+    project-files: [src/Notes.pro]
     build-packages:
       - qtbase5-dev
       - qtbase5-dev-tools

--- a/packaging/linux/snap/snapcraft.yaml
+++ b/packaging/linux/snap/snapcraft.yaml
@@ -33,4 +33,7 @@ parts:
       - libqt5core5a
       - libqt5libqgtk2
       - xcursor-themes
-    after: [desktop/qt5]
+    after: [desktop-qt5, indicator-qt5]
+
+  desktop-qt5:
+    stage: [ -./**/lib/*/qt5/**/libappmenu-qt5.so ]


### PR DESCRIPTION
It allows to show the proper indicator icon in unity.

Also fix compilation due the 3rdparty libraries being excluded.
This to work however needs this fix to snapcraft to be applied: https://github.com/snapcore/snapcraft/pull/926