### PR TITLE
Generate AppImage on each git push

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ dist: trusty
 language: cpp
 
 env:
-#  - QT_BASE=56
-#  - QT_BASE=57
+  - QT_BASE=56
+  - QT_BASE=57
   - QT_BASE=58
 
 before_install:
@@ -36,7 +36,7 @@ script:
   - chmod a+x linuxdeployqt*.AppImage 
   - ./linuxdeployqt*.AppImage ./appdir/usr/bin/notes -bundle-non-qt-libs
   - ./linuxdeployqt*.AppImage ./appdir/usr/bin/notes -appimage 
-  - curl --upload-file ./Notes-*.AppImage https://transfer.sh/notes-x86_64.AppImage 
+  - curl --upload-file ./Notes-*.AppImage https://transfer.sh/notes-qt$QT_BASE-x86_64.AppImage 
   
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ script:
   - cd .. 
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/3/linuxdeployqt-3-x86_64.AppImage" 
   - chmod a+x linuxdeployqt*.AppImage 
+  - unset QTDIR
   - ./linuxdeployqt*.AppImage ./appdir/usr/bin/notes -bundle-non-qt-libs
   - ./linuxdeployqt*.AppImage ./appdir/usr/bin/notes -appimage 
   - curl --upload-file ./Notes-*.AppImage https://transfer.sh/notes-qt$QT_BASE-x86_64.AppImage 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,9 @@ script:
   - sudo apt-get -y install checkinstall
   - sudo checkinstall --pkgname=app --pkgversion="1" --backup=no --fstrans=no --default --deldoc 
   - mkdir appdir ; cd appdir
-  - dpkg -x ../app_1-1_amd64.deb . ; find . 
-  - cp ./usr/share/applications/*.desktop . 
-  - cp ./usr/share/icons/hicolor/256x256/apps/*.png . 
+  - dpkg -x ../app_1-1_amd64.deb . ; find .
+  - cp ../../packaging/linux/common/notes.desktop .
+  - cp ../../packaging/linux/common/icons/256x256/notes.png .
   - cd .. 
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/3/linuxdeployqt-3-x86_64.AppImage" 
   - chmod a+x linuxdeployqt*.AppImage 

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ script:
   - chmod a+x linuxdeployqt*.AppImage 
   - ./linuxdeployqt*.AppImage ./appdir/usr/bin/notes -bundle-non-qt-libs
   - ./linuxdeployqt*.AppImage ./appdir/usr/bin/notes -appimage 
-  - curl --upload-file ./notes-*.AppImage https://transfer.sh/notes-x86_64.AppImage 
+  - curl --upload-file ./Notes-*.AppImage https://transfer.sh/notes-x86_64.AppImage 
   
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ script:
   - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
   - ./linuxdeployqt*.AppImage ./appdir/usr/bin/notes -bundle-non-qt-libs
   - ./linuxdeployqt*.AppImage ./appdir/usr/bin/notes -bundle-non-qt-libs 
-  - ./linuxdeployqt*.AppImage --appimage-extract "usr/bin/appimagetool" # https://github.com/probonopd/AppImageKit/issues/363
+  - ./linuxdeployqt*.AppImage --appimage-extract
   - wget -c https://github.com/probonopd/AppImageKit/raw/master/desktopintegration -O ./appdir/usr/bin/notes.wrapper
   - chmod a+x ./appdir/usr/bin/notes.wrapper
   - sed -i -e 's|^Version=0.9$|Version=1.0|g' ./appdir/notes.desktop # Bugifx, see https://standards.freedesktop.org/desktop-entry-spec/latest/

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,8 @@ script:
   - ./linuxdeployqt*.AppImage ./appdir/usr/bin/notes -bundle-non-qt-libs
   - ./linuxdeployqt*.AppImage ./appdir/usr/bin/notes -bundle-non-qt-libs 
   - ./linuxdeployqt*.AppImage --appimage-extract
-  - wget -c https://github.com/probonopd/AppImageKit/raw/master/desktopintegration -O ./appdir/usr/bin/notes.wrappper
-  - chmod a+x ./appdir/usr/bin/notes.wrappper
+  - wget -c https://github.com/probonopd/AppImageKit/raw/master/desktopintegration -O ./appdir/usr/bin/notes.wrapper
+  - chmod a+x ./appdir/usr/bin/notes.wrapper
   - sed -i -e 's|^Version=0.9$|Version=1.0|g' ./appdir/notes.desktop # Bugifx, see https://standards.freedesktop.org/desktop-entry-spec/latest/
   - ( cd ./appdir/ ; rm AppRun ; ln -s ./usr/bin/notes.wrappper AppRun )
   - ./squashfs-root/usr/bin/appimagetool ./appdir/

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ script:
   - wget -c https://github.com/probonopd/AppImageKit/raw/master/desktopintegration -O ./appdir/usr/bin/notes.wrappper
   - chmod a+x ./appdir/usr/bin/notes.wrappper
   - sed -i -e 's|^Version=0.9$|Version=1.0|g' ./appdir/notes.desktop # Bugifx, see https://standards.freedesktop.org/desktop-entry-spec/latest/
-  - ( cd ./appdir/ ; rm AppRun ; ln -s ./usr/bin/notes.wrapper AppRun )
+  - ( cd ./appdir/ ; rm AppRun ; ln -s ./usr/bin/notes.wrappper AppRun )
   - ./squashfs-root/usr/bin/appimagetool ./appdir/
   - curl --upload-file ./Notes-*.AppImage https://transfer.sh/notes-git.$(git rev-parse --short HEAD).qt$QT_BASE-x86_64.AppImage 
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ script:
   - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
   - ./linuxdeployqt*.AppImage ./appdir/usr/bin/notes -bundle-non-qt-libs
   - ./linuxdeployqt*.AppImage ./appdir/usr/bin/notes -appimage 
-  - curl --upload-file ./Notes-*.AppImage https://transfer.sh/notes-qt$QT_BASE-x86_64.AppImage 
+  - curl --upload-file ./Notes-*.AppImage https://transfer.sh/notes-git$(git rev-parse --short HEAD).qt$QT_BASE-x86_64.AppImage 
   
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ script:
   - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
   - ./linuxdeployqt*.AppImage ./appdir/usr/bin/notes -bundle-non-qt-libs
   - ./linuxdeployqt*.AppImage ./appdir/usr/bin/notes -bundle-non-qt-libs 
-  - ./linuxdeployqt*.AppImage --appimage-extract
+  - ./linuxdeployqt*.AppImage --appimage-extract "usr/bin/appimagetool" # https://github.com/probonopd/AppImageKit/issues/363
   - wget -c https://github.com/probonopd/AppImageKit/raw/master/desktopintegration -O ./appdir/usr/bin/notes.wrapper
   - chmod a+x ./appdir/usr/bin/notes.wrapper
   - sed -i -e 's|^Version=0.9$|Version=1.0|g' ./appdir/notes.desktop # Bugifx, see https://standards.freedesktop.org/desktop-entry-spec/latest/

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ script:
   - cd .. 
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/3/linuxdeployqt-3-x86_64.AppImage" 
   - chmod a+x linuxdeployqt*.AppImage 
-  - unset QTDIR
+  - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
   - ./linuxdeployqt*.AppImage ./appdir/usr/bin/notes -bundle-non-qt-libs
   - ./linuxdeployqt*.AppImage ./appdir/usr/bin/notes -appimage 
   - curl --upload-file ./Notes-*.AppImage https://transfer.sh/notes-qt$QT_BASE-x86_64.AppImage 

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,13 @@ script:
   - chmod a+x linuxdeployqt*.AppImage 
   - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
   - ./linuxdeployqt*.AppImage ./appdir/usr/bin/notes -bundle-non-qt-libs
-  - ./linuxdeployqt*.AppImage ./appdir/usr/bin/notes -appimage 
+  - ./linuxdeployqt*.AppImage ./appdir/usr/bin/notes -bundle-non-qt-libs 
+  - ./linuxdeployqt*.AppImage --appimage-extract
+  - wget -c https://github.com/probonopd/AppImageKit/raw/master/desktopintegration -O ./appdir/usr/bin/notes.wrappper
+  - chmod a+x ./appdir/usr/bin/notes.wrappper
+  - sed -i -e 's|^Version=0.9$|Version=1.0|g' ./appdir/notes.desktop # Bugifx, see https://standards.freedesktop.org/desktop-entry-spec/latest/
+  - ( cd ./appdir/ ; rm AppRun ; ln -s ./usr/bin/notes.wrapper AppRun )
+  - ./squashfs-root/usr/bin/appimagetool ./appdir/
   - curl --upload-file ./Notes-*.AppImage https://transfer.sh/notes-git.$(git rev-parse --short HEAD).qt$QT_BASE-x86_64.AppImage 
   
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ script:
   - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
   - ./linuxdeployqt*.AppImage ./appdir/usr/bin/notes -bundle-non-qt-libs
   - ./linuxdeployqt*.AppImage ./appdir/usr/bin/notes -appimage 
-  - curl --upload-file ./Notes-*.AppImage https://transfer.sh/notes-git$(git rev-parse --short HEAD).qt$QT_BASE-x86_64.AppImage 
+  - curl --upload-file ./Notes-*.AppImage https://transfer.sh/notes-git.$(git rev-parse --short HEAD).qt$QT_BASE-x86_64.AppImage 
   
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ script:
   - dpkg -x ../app_1-1_amd64.deb . ; find .
   - cp ../../packaging/linux/common/notes.desktop .
   - cp ../../packaging/linux/common/icons/256x256/notes.png .
+  - mkdir -p ./usr/share/icons/default/256x256/apps/ ; cp ../../packaging/linux/common/icons/256x256/notes.png ./usr/share/icons/default/256x256/apps/
   - cd .. 
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/3/linuxdeployqt-3-x86_64.AppImage" 
   - chmod a+x linuxdeployqt*.AppImage 

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ script:
   - wget -c https://github.com/probonopd/AppImageKit/raw/master/desktopintegration -O ./appdir/usr/bin/notes.wrapper
   - chmod a+x ./appdir/usr/bin/notes.wrapper
   - sed -i -e 's|^Version=0.9$|Version=1.0|g' ./appdir/notes.desktop # Bugifx, see https://standards.freedesktop.org/desktop-entry-spec/latest/
-  - ( cd ./appdir/ ; rm AppRun ; ln -s ./usr/bin/notes.wrappper AppRun )
+  - ( cd ./appdir/ ; rm AppRun ; ln -s ./usr/bin/notes.wrapper AppRun )
   - ./squashfs-root/usr/bin/appimagetool ./appdir/
   - curl --upload-file ./Notes-*.AppImage https://transfer.sh/notes-git.$(git rev-parse --short HEAD).qt$QT_BASE-x86_64.AppImage 
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ dist: trusty
 language: cpp
 
 env:
-  - QT_BASE=56
-  - QT_BASE=57
+#  - QT_BASE=56
+#  - QT_BASE=57
   - QT_BASE=58
 
 before_install:
@@ -23,8 +23,20 @@ install:
 script:
   - mkdir build
   - cd build
-  - qmake .. && make
+  - qmake PREFIX=/usr .. && make
   - xvfb-run -a -s "-screen 0 800x600x24" tests/test
-
+  - sudo apt-get -y install checkinstall
+  - sudo checkinstall --pkgname=app --pkgversion="1" --backup=no --fstrans=no --default --deldoc 
+  - mkdir appdir ; cd appdir
+  - dpkg -x ../app_1-1_amd64.deb . ; find . 
+  - cp ./usr/share/applications/*.desktop . 
+  - cp ./usr/share/icons/hicolor/256x256/apps/*.png . 
+  - cd .. 
+  - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/3/linuxdeployqt-3-x86_64.AppImage" 
+  - chmod a+x linuxdeployqt*.AppImage 
+  - ./linuxdeployqt*.AppImage ./appdir/usr/bin/notes -bundle-non-qt-libs
+  - ./linuxdeployqt*.AppImage ./appdir/usr/bin/notes -appimage 
+  - curl --upload-file ./notes-*.AppImage https://transfer.sh/notes-x86_64.AppImage 
+  
 notifications:
   email: false


### PR DESCRIPTION
In response to https://github.com/nuttyartist/notes/issues/13. __The download links are in the Travis CI build log.__

Providing an [AppImage](http://appimage.org/) would have, among others, these advantages:
- Works for most Linux distributions (including Ubuntu, Fedora, openSUSE, CentOS, elementaryOS, Linux Mint, and others)
- One app = one file = super simple for users: just download one AppImage file, [make it executable](http://discourse.appimage.org/t/how-to-make-an-appimage-executable/80), and run
- No unpacking or installation necessary
- No root needed
- No system libraries changed
- Just one format for all major distributions
- Works out of the box, no installation of runtimes needed
- Optional(!) desktop integration with `appimaged`
- Binary delta updates, e.g., for continuous builds (only download the binary diff) using AppImageUpdate
- Can GPG2-sign your AppImages (inside the file)

[Here is an overview](https://github.com/probonopd/AppImageKit/wiki/AppImages) of projects that are already distributing upstream-provided, official AppImages.