### PR TITLE
Implemented staying always on top

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -986,6 +986,13 @@ void MainWindow::onDotsButtonClicked()
         exportNotesFileAction->setDisabled(true);
     }
 
+    // Stay on top action
+    QAction* stayOnTopAction = viewMenu->addAction(tr("Always stay on top"));
+    stayOnTopAction->setToolTip(tr("Always keep the notes application on top of all windows"));
+    stayOnTopAction->setCheckable(true);
+    stayOnTopAction->setChecked(m_alwaysStayOnTop);
+    connect(stayOnTopAction, SIGNAL(triggered(bool)), this, SLOT(stayOnTop(bool)));
+
     mainMenu.exec(m_dotsButton->mapToGlobal(QPoint(0, m_dotsButton->height())));
 }
 
@@ -2556,4 +2563,25 @@ bool MainWindow::eventFilter (QObject *object, QEvent *event)
     }
 
     return QObject::eventFilter(object, event);
+}
+
+void MainWindow::stayOnTop(bool checked) {
+    Qt::WindowFlags flags;
+#ifdef Q_OS_LINUX
+    flags = Qt::Window | Qt::FramelessWindowHint;
+#elif _WIN32
+    flags = Qt::CustomizeWindowHint;
+#elif __APPLE__
+    flags = Qt::Window | Qt::FramelessWindowHint;
+#else
+#error "We don't support that version yet..."
+#endif
+    if (checked) {
+        flags |= Qt::WindowStaysOnTopHint;
+        m_alwaysStayOnTop = true;
+    } else {
+        m_alwaysStayOnTop = false;
+    }
+    this->setWindowFlags(flags);
+    setMainWindowVisibility(true);
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -288,6 +288,7 @@ void MainWindow::setupKeyboardShortcuts ()
     new QShortcut(QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_L), this, SLOT(maximizeWindow()));
     new QShortcut(QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_M), this, SLOT(minimizeWindow()));
     new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_Q), this, SLOT(QuitApplication()));
+    new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_K), this, SLOT(toggleStayOnTop()));
 
     QxtGlobalShortcut *shortcut = new QxtGlobalShortcut(this);
     shortcut->setShortcut(QKeySequence("META+N"));
@@ -2584,4 +2585,8 @@ void MainWindow::stayOnTop(bool checked) {
     }
     this->setWindowFlags(flags);
     setMainWindowVisibility(true);
+}
+
+void MainWindow::toggleStayOnTop() {
+    this->stayOnTop(!m_alwaysStayOnTop);
 }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -222,6 +222,7 @@ private slots:
     void exportNotesFile(const bool clicked);
     void restoreNotesFile (const bool clicked);
     void stayOnTop(bool checked);
+    void toggleStayOnTop();
 };
 
 #endif // MAINWINDOW_H

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -141,6 +141,7 @@ private:
     bool m_isContentModified;
     bool m_isOperationRunning;
     bool m_dontShowUpdateWindow;
+    bool m_alwaysStayOnTop;
 
     void setupMainWindow();
     void setupFonts();
@@ -220,6 +221,7 @@ private slots:
     void importNotesFile(const bool clicked);
     void exportNotesFile(const bool clicked);
     void restoreNotesFile (const bool clicked);
+    void stayOnTop(bool checked);
 };
 
 #endif // MAINWINDOW_H


### PR DESCRIPTION
See issue #65 

Option is located in the dots menu > View > Always stay on top.

Worked with Ubuntu 17.04 Zesty. Can't test under Windows or macOS

At the moment it does not have a keyboard shortcut but I think it should have one. Which one would you prefer?