### PR TITLE
Fix bug #210

### DIFF
--- a/src/noteview.h
+++ b/src/noteview.h
@@ -15,7 +15,7 @@ public:
     ~NoteView();
 
     void animateAddedRow(const QModelIndex &parent, int start, int end);
-    void setSearching(bool isSearching);
+    void setAnimationEnabled(bool isEnabled);
     void setCurrentRowActive(bool isActive);
 
 protected:
@@ -27,7 +27,7 @@ protected:
 
 private:
     bool m_isScrollBarHidden;
-    bool m_isSearching;
+    bool m_animationEnabled;
     bool m_isMousePressed;
     int m_rowHeight;
 


### PR DESCRIPTION
- Move the note to top in the source list when there is just one note in search result and it was modified.
- replace setSearching function by setAnimationEnabled to enable/disable animation when actions are applied to the noteview
- wrap actions with animation condition to check whether to use animation or not.