### PR TITLE
Only allow dragging from top part of window

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2596,8 +2596,7 @@ bool MainWindow::eventFilter (QObject *object, QEvent *event)
         // from the top part of the window
         if(object == ui->frame){
             QMouseEvent* mouseEvent = static_cast<QMouseEvent*>(event);
-            const int lowerBound = ui->verticalSpacer_upSearchEdit->geometry().bottom();
-            if(mouseEvent->y() > lowerBound){
+            if(mouseEvent->y() >= ui->searchEdit->y()){
                 return true;
             }
         }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2596,7 +2596,8 @@ bool MainWindow::eventFilter (QObject *object, QEvent *event)
         // from the top part of the window
         if(object == ui->frame){
             QMouseEvent* mouseEvent = static_cast<QMouseEvent*>(event);
-            if(mouseEvent->y() >= ui->searchEdit->y()){
+            const int lowerBound = ui->verticalSpacer_upSearchEdit->geometry().bottom();
+            if(mouseEvent->y() > lowerBound){
                 return true;
             }
         }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2590,6 +2590,17 @@ bool MainWindow::eventFilter (QObject *object, QEvent *event)
             m_updater.setGeometry(QRect(x, y, rect.width(), rect.height()));
         }
         break;
+    case QEvent::MouseButtonPress:
+    case QEvent::MouseButtonDblClick:
+        // Only allow double click (maximise/minimise) or dragging (move)
+        // from the top part of the window
+        if(object == ui->frame){
+            QMouseEvent* mouseEvent = static_cast<QMouseEvent*>(event);
+            if(mouseEvent->y() >= ui->searchEdit->y()){
+                return true;
+            }
+        }
+        break;
     default:
         break;
     }


### PR DESCRIPTION
`QMainWindow` allows dragging any empty part of the window to move
it, as well as double clicking to maximize/minimize.
This patch adds to the existing event filter for `frame`, listening
for `MouseButtonPress` and `MouseButtonDblClick` events, only
allowing them through if the click's Y coordinate is anywhere above
the search text edit field (`ui->searchEdit`).

Fixes #173