### PR TITLE
Fix #218

### DIFF
--- a/packaging/linux/common/notes.desktop
+++ b/packaging/linux/common/notes.desktop
@@ -1,10 +1,9 @@
 [Desktop Entry]
-Version=1.0.0
 Type=Application
 Terminal=false
 StartupNotify=true
 Name=Notes
 Comment=Write down your thoughts
-Categories=Utility;Application;
+Categories=Utility;
 Exec=notes
 Icon=notes


### PR DESCRIPTION
Should make it pass `desktop-file-validate` in Ubuntu trusty.

References:
* https://travis-ci.org/AppImage/appimage.github.io/builds/397914644#L559
* https://github.com/AppImage/appimage.github.io/pull/662