### PR TITLE
Remove threading on all db operations

### DIFF
--- a/src/dbmanager.cpp
+++ b/src/dbmanager.cpp
@@ -3,7 +3,6 @@
 #include <QTimeZone>
 #include <QDateTime>
 #include <QDebug>
-#include <QtConcurrent>
 
 DBManager::DBManager(const QString& path, bool doCreate, QObject *parent) : QObject(parent)
 {
@@ -291,7 +290,11 @@ bool DBManager::forceLastRowIndexValue(const int indexValue)
 
 void DBManager::importNotes(QList<NoteData*> noteList) {
     QSqlDatabase::database().transaction();
-    QtConcurrent::blockingMap(noteList, [this] (NoteData* note) { this->addNote(note); });
+
+    for (NoteData* note : noteList) {
+      this->addNote(note);
+    }
+
     QSqlDatabase::database().commit();
 }
 


### PR DESCRIPTION
This is proposed as a workaround for a silent bug present when using QT 5.11:

When called via a `QtConcurrent` thread, the query would not complete yielding:

`QSqlDatabasePrivate::database:requested database does not belong to the calling thread`

Which would result in a note potentially not being persisted, and thus effectively removed once the application closes.

Now I understand that performing I/O operations synchronously in the main thread could lead to freezes, so this is definitely not the best workaround. It would be nice if someone else could have another look at this issue.
