### PR TITLE
* Closing a window will now call close() instead of hide(), triggerin…

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -144,7 +144,7 @@ void MainWindow::setMainWindowVisibility(bool state)
         m_restoreAction->setText(tr("&Hide Notes"));
     }else{
         m_restoreAction->setText(tr("&Show Notes"));
-        hide();
+        close();
     }
 }
 
@@ -644,9 +644,11 @@ void MainWindow::setupDatabases ()
     QString noteDBFilePath(dir.path() + QDir::separator() + QStringLiteral("notes.db"));
 
     if(!QFile::exists(noteDBFilePath)){
+        qDebug() << "DEBUG: Note DB File does not exist";
         QFile noteDBFile(noteDBFilePath);
-        if(!noteDBFile.open(QIODevice::WriteOnly))
+        if(!noteDBFile.open(QIODevice::WriteOnly)){
             qFatal("ERROR : Can't create database file");
+        }
 
         noteDBFile.close();
         doCreate = true;


### PR DESCRIPTION
* Call close() vs hide() to trigger 'closeEvent' code on Ubuntu 18.04
* Explicit scope around noteDBFile creation
* Debug message on noteDBFile creation