### PR TITLE
Travis CI: Removed the failing 'trusty' build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@ dist: trusty
 language: cpp
 
 env:
+  - QT_BASE=53
   - QT_BASE=55
   - QT_BASE=56
   - QT_BASE=57
   - QT_BASE=58
-  - QT_BASE=trusty
   - QT_BASE=xenial
   - QT_BASE=yakkety
   - QT_BASE=zesty
@@ -19,6 +19,7 @@ service:
 
 before_install:
   - git fetch --unshallow
+  - if [ "$QT_BASE" = "53" ]; then sudo add-apt-repository ppa:beineri/opt-qt532-trusty -y; fi
   - if [ "$QT_BASE" = "55" ]; then sudo add-apt-repository ppa:beineri/opt-qt551-trusty -y; fi
   - if [ "$QT_BASE" = "56" ]; then sudo add-apt-repository ppa:beineri/opt-qt562-trusty -y; fi
   - if [ "$QT_BASE" = "57" ]; then sudo add-apt-repository ppa:beineri/opt-qt571-trusty -y; fi
@@ -31,19 +32,19 @@ before_install:
 
 install:
   - sudo apt-get -y install software-properties-common checkinstall xvfb dh-make fakeroot gpgv2 tree
+  - if [ "$QT_BASE" == "53" ]; then sudo apt-get install -qq qt53base; source /opt/qt53/bin/qt53-env.sh; fi
   - if [ "$QT_BASE" == "55" ]; then sudo apt-get install -qq qt55base; source /opt/qt55/bin/qt55-env.sh; fi
   - if [ "$QT_BASE" == "56" ]; then sudo apt-get install -qq qt56base; source /opt/qt56/bin/qt56-env.sh; fi
   - if [ "$QT_BASE" == "57" ]; then sudo apt-get install -qq qt57base; source /opt/qt57/bin/qt57-env.sh; fi
   - if [ "$QT_BASE" == "58" ]; then sudo apt-get install -qq qt58base; source /opt/qt58/bin/qt58-env.sh; fi
-  - if [ "$QT_BASE" == "trusty" ]; then sudo apt-get install -y qt5-default qtbase5-private-dev; fi
 
 before_script:
     - echo "$QT_BASE:$TRAVIS_BRANCH----------------------------------------------------------------------------------------------"
+    - if [ "$QT_BASE" == "53" ]; then qmake -v; fi
     - if [ "$QT_BASE" == "55" ]; then qmake -v; fi
     - if [ "$QT_BASE" == "56" ]; then qmake -v; fi
     - if [ "$QT_BASE" == "57" ]; then qmake -v; fi
     - if [ "$QT_BASE" == "58" ]; then qmake -v; fi
-    - if [ "$QT_BASE" == "trusty" ]; then qmake -v; fi
     - if [ "$QT_BASE" == "xenial" ]; then docker run --rm -it theshadowx/qt5:default_qt5_xenial qmake -v; fi
     - if [ "$QT_BASE" == "yakkety" ]; then docker run --rm -it theshadowx/qt5:default_qt5_yakkety qmake -v; fi
     - if [ "$QT_BASE" == "zesty" ]; then docker run --rm -it theshadowx/qt5:default_qt5_zesty qmake -v; fi
@@ -76,9 +77,7 @@ script:
 after_success:
 
   - if [ "$TRAVIS_BRANCH" != "master" ]; then
-        if [ "$QT_BASE" == "trusty" ]; then
-            curl --upload-file deb/notes*.deb https://transfer.sh/notes_$(git describe --always --tags HEAD | cut -d- -f1 | sed 's/^v//')-git$(git rev-parse --short HEAD)_amd64-$QT_BASE.deb ;
-        elif [ "$QT_BASE" == "xenial" ]; then
+        if [ "$QT_BASE" == "xenial" ]; then
             curl --upload-file deb/notes*.deb https://transfer.sh/notes_$(git describe --always --tags HEAD | cut -d- -f1 | sed 's/^v//')-git$(git rev-parse --short HEAD)_amd64-$QT_BASE.deb ;
         elif [ "$QT_BASE" == "yakkety" ]; then
             curl --upload-file deb/notes*.deb https://transfer.sh/notes_$(git describe --always --tags HEAD | cut -d- -f1 | sed 's/^v//')-git$(git rev-parse --short HEAD)_amd64-$QT_BASE.deb ;
@@ -90,9 +89,7 @@ after_success:
             curl --upload-file snap/notes*.snap https://transfer.sh/notes_$(git describe --always --tags HEAD | cut -d- -f1 | sed 's/^v//')-git$(git rev-parse --short HEAD)_amd64-xenial.snap ;
         fi
     else
-        if [ "$QT_BASE" == "trusty" ]; then
-            curl --upload-file deb/notes*.deb https://transfer.sh/notes_$(git describe --always --tags HEAD | cut -d- -f1 | sed 's/^v//')_amd64-trusty.deb ;
-        elif [ "$QT_BASE" == "xenial" ]; then
+        if [ "$QT_BASE" == "xenial" ]; then
             curl --upload-file deb/notes*.deb https://transfer.sh/notes_$(git describe --always --tags HEAD | cut -d- -f1 | sed 's/^v//')_amd64-xenial.deb ;
         elif [ "$QT_BASE" == "yakkety" ]; then
             curl --upload-file deb/notes*.deb https://transfer.sh/notes_$(git describe --always --tags HEAD | cut -d- -f1 | sed 's/^v//')_amd64-yakkety.deb ;

--- a/Project.pro
+++ b/Project.pro
@@ -1,8 +1,34 @@
+# Taken from Qt Creator project files
+defineTest(minQtVersion) {
+    maj = $$1
+    min = $$2
+    patch = $$3
+    isEqual(QT_MAJOR_VERSION, $$maj) {
+        isEqual(QT_MINOR_VERSION, $$min) {
+            isEqual(QT_PATCH_VERSION, $$patch) {
+                return(true)
+            }
+            greaterThan(QT_PATCH_VERSION, $$patch) {
+                return(true)
+            }
+        }
+        greaterThan(QT_MINOR_VERSION, $$min) {
+            return(true)
+        }
+    }
+    greaterThan(QT_MAJOR_VERSION, $$maj) {
+        return(true)
+    }
+    return(false)
+}
+
+!minQtVersion(5, 3, 0) {
+    message("Cannot build Notes with Qt version $${QT_VERSION}")
+    error("Use at least Qt 5.3.0.")
+}
+
 TEMPLATE = subdirs
-
-SUBDIRS = \
-    src
-
+SUBDIRS = src
 CONFIG += ordered
 
 src.file = src/Notes.pro

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $> git clone --recursive  https://github.com/nuttyartist/notes.git
 ```
 
 ## Dependencies
-Make sure the Qt (>= 5.2.1) development libraries are installed:
+Make sure the Qt (>= 5.3) development libraries are installed:
 
 - Debian/Ubuntu : qt5-default build-essential qtbase5-private-dev sqlite3
 


### PR DESCRIPTION
Since the addition of qmarkdowntextedit, APIs are used that were added in Qt 5.3. Unless we're interested in restoring compatibility with Qt 5.2 (probably possible by changing qmarkdowntextedit), I would suggest we simply drop this Trusty build, who's end of support was reached in April 2019.

I've also added a Qt version check, along with a Qt 5.3 build to check whether Notes really does compile against that Qt version. Of course, we may want to raise the minimum Qt version further, say to Qt 5.5, which is the version in the current oldest supported Ubuntu (xenial).