### PR TITLE
Enabled autostart option on macOS

### DIFF
--- a/src/Notes.pro
+++ b/src/Notes.pro
@@ -24,10 +24,7 @@ greaterThan (QT_MAJOR_VERSION, 4): QT += widgets
 include ($$PWD/../3rdParty/qxt/qxt.pri)
 include ($$PWD/../3rdParty/QSimpleUpdater/QSimpleUpdater.pri)
 include ($$PWD/../3rdParty/qmarkdowntextedit/qmarkdowntextedit.pri)
-
-!macx {
 include ($$PWD/../3rdParty/qautostart/src/qautostart.pri)
-}
 
 SOURCES += \
     $$PWD/main.cpp\

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1047,7 +1047,6 @@ void MainWindow::onDotsButtonClicked()
     QAction* checkForUpdatesAction = mainMenu.addAction(tr("Check For Updates"));
     connect (checkForUpdatesAction, &QAction::triggered, this, &MainWindow::checkForUpdates);
 
-#if !defined (Q_OS_MACOS)
     // Autostart
     QAction* autostartAction = mainMenu.addAction(tr("Start automatically"));
     connect (autostartAction, &QAction::triggered, this, [&]() {
@@ -1055,7 +1054,6 @@ void MainWindow::onDotsButtonClicked()
     });
     autostartAction->setCheckable(true);
     autostartAction->setChecked(m_autostart.isAutostart());
-#endif
 
     mainMenu.addSeparator();
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -24,9 +24,7 @@
 #include <QProgressDialog>
 #include <QAction>
 
-#if !defined (Q_OS_MACOS)
 #include <QAutostart>
-#endif
 
 #include "notedata.h"
 #include "notemodel.h"
@@ -133,9 +131,7 @@ private:
 
     UpdaterWindow m_updater;
     StretchSide m_stretchSide;
-#if !defined (Q_OS_MACOS)
     Autostart m_autostart;
-#endif
     int m_mousePressX;
     int m_mousePressY;
     int m_noteCounter;


### PR DESCRIPTION
This change makes it compile, but the commands executed by QAutostart on macOS do not seem to work, though they appear close to something that should work.

I can look deeper into it and test things later.

See issue #195.