### PR TITLE
 Fix some compiler warnings 

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2462,7 +2462,7 @@ void MainWindow::mouseMoveEvent(QMouseEvent* event)
         int newWidth = width();
         int newHeight = height();
 
-        int minY =  QApplication::desktop()->availableGeometry().y();
+        int minY = QGuiApplication::primaryScreen()->availableGeometry().y();
 
         switch (m_stretchSide) {
         case StretchSide::Right:
@@ -3173,6 +3173,7 @@ bool MainWindow::eventFilter(QObject *object, QEvent *event)
         setCurrentFontBasedOnTypeface(m_currentFontTypeface);
 
         //        alignTextEditText();
+        break;
     }
     case QEvent::Show:
         if(object == &m_updater){

--- a/src/notelistdelegate.cpp
+++ b/src/notelistdelegate.cpp
@@ -55,7 +55,7 @@ NoteListDelegate::NoteListDelegate(NoteListView *view, TagPool *tagPool, QObject
     m_timeLine = new QTimeLine(300, this);
     m_timeLine->setFrameRange(0,m_maxFrame);
     m_timeLine->setUpdateInterval(10);
-    m_timeLine->setCurveShape(QTimeLine::EaseInCurve);
+    m_timeLine->easingCurve();
     m_folderIcon = QImage(":/images/folder.png");
     m_pinnedExpandIcon = QImage(":/images/pinned-expand.png");
     m_pinnedCollapseIcon = QImage(":/images/pinned-collasped.png");


### PR DESCRIPTION
Should now have a clean output when compiling with Qt 5.15+.

These are the warnings:

```
notelistdelegate.cpp: In constructor ‘NoteListDelegate::NoteListDelegate(NoteListView*, TagPool*, QObject*)’:
notelistdelegate.cpp:58:30: warning: ‘void QTimeLine::setCurveShape(CurveShape)’ is deprecated: Access easingCurve directly [-Wdeprecated-declarations]
   58 |     m_timeLine->setCurveShape(QTimeLine::EaseInCurve);
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/QtCore/QTimeLine:1,
                 from notelistdelegate.h:6,
                 from notelistdelegate.cpp:1:
/usr/include/QtCore/qtimeline.h:114:10: note: declared here
  114 |     void setCurveShape(CurveShape shape);
      |          ^~~~~~~~~~~~~
mainwindow.cpp: In member function ‘virtual void MainWindow::mouseMoveEvent(QMouseEvent*)’:
mainwindow.cpp:2465:63: warning: ‘const QRect QDesktopWidget::availableGeometry(int) const’ is deprecated: Use QGuiApplication::screens() [-Wdeprecated-declarations]
 2465 |         int minY =  QApplication::desktop()->availableGeometry().y();
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
In file included from /usr/include/QtWidgets/QDesktopWidget:1,
                 from mainwindow.cpp:24:
/usr/include/QtWidgets/qdesktopwidget.h:88:67: note: declared here
   88 |     QT_DEPRECATED_X("Use QGuiApplication::screens()") const QRect availableGeometry(int screen = -1) const;
      |                                                                   ^~~~~~~~~~~~~~~~~
g++ -c -pipe -O2 -std=gnu++1y -Wall -Wextra -D_REENTRANT -fPIC -DQT_NO_DEBUG -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_SQL_LIB -DQT_CONCURRENT_LIB -DQT_CORE_LIB -I. -I../3rdParty/qxt -I../3rdParty/QSimpleUpdater/include -I../3rdParty/qmarkdowntextedit -I../3rdParty/qmarkdowntextedit -I../3rdParty/qmarkdowntextedit -I../3rdParty/qautostart/src -I/usr/include/QtWidgets/5.15.6 -I/usr/include/QtWidgets/5.15.6/QtWidgets -I/usr/include/QtWidgets -I/usr/include/QtGui/5.15.6 -I/usr/include/QtGui/5.15.6/QtGui -I/usr/include/QtGui -I/usr/include/QtNetwork -I/usr/include/QtSql -I/usr/include/QtCore/5.15.6 -I/usr/include/QtCore/5.15.6/QtCore -I/usr/include/QtConcurrent -I/usr/include/QtCore -Imoc -Iuic -I/usr/lib/mkspecs/linux-g++ -o obj/notelistdelegateeditor.o notelistdelegateeditor.cpp
mainwindow.cpp: In member function ‘virtual bool MainWindow::eventFilter(QObject*, QEvent*)’:
mainwindow.cpp:3173:38: warning: this statement may fall through [-Wimplicit-fallthrough=]
 3173 |         setCurrentFontBasedOnTypeface(m_currentFontTypeface);
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~
mainwindow.cpp:3177:5: note: here
 3177 |     case QEvent::Show:
      |     ^~~~
```