### PR TITLE
Add keyboard shortcuts for text formatting: bold, italics, strikethrough

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -459,9 +459,9 @@ void MainWindow::setupKeyboardShortcuts()
     new QShortcut(QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_S), this, SLOT(onStyleEditorButtonClicked()));
     new QShortcut(QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_J), this, SLOT(toggleNodeTree()));
     new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_A), this, SLOT(selectAllNotesInList()));
-    new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_B), this, [this](){applyFormat("**");});
-    new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_I), this, [this](){applyFormat("*");});
-    new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_S), this, [this](){applyFormat("~");});
+    new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_B), this, SLOT(makeBold()));
+    new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_I), this, SLOT(makeItalic()));
+    new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_S), this, SLOT(makeStrikethrough()));
 
     QxtGlobalShortcut *shortcut = new QxtGlobalShortcut(this);
 #if defined(Q_OS_LINUX)
@@ -1904,6 +1904,21 @@ void MainWindow::fullscreenWindow()
         showFullScreen();
     }
 #endif
+}
+
+void MainWindow::makeBold()
+{
+    applyFormat("**");
+}
+
+void MainWindow::makeItalic()
+{
+    applyFormat("*");
+}
+
+void MainWindow::makeStrikethrough()
+{
+    applyFormat("~");
 }
 
 /*!

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1311,14 +1311,14 @@ void MainWindow::resetFormat(const QString &formatChars)
     QTextCursor cursor = m_textEdit->textCursor();
     if(!cursor.hasSelection()){
         cursor.select(QTextCursor::WordUnderCursor);
-        if(cursor.selectedText().contains(formatChars)){
-            cursor.deleteChar();
-            return;
-        }
     }
     QString selectedText = cursor.selectedText();
     int start = cursor.selectionStart();
     int end = cursor.selectionEnd();
+    if(cursor.selectedText().startsWith(formatChars) && cursor.selectedText().endsWith(formatChars)){
+        start += formatChars.length();
+        end -= formatChars.length();
+    }
     cursor.beginEditBlock();
     cursor.setPosition(start - formatChars.length(), QTextCursor::MoveAnchor);
     cursor.setPosition(start, QTextCursor::KeepAnchor);
@@ -3317,9 +3317,9 @@ bool MainWindow::alreadyAppliedFormat(const QString &formatChars)
         if(!cursor.hasSelection()){
             return false;
         }
-        if(cursor.selectedText().contains(formatChars)){
-            return true;
-        }
+    }
+    if(cursor.selectedText().contains(formatChars)){
+        return true;
     }
     QString selectedText = cursor.selectedText();
     QTextDocument *doc = m_textEdit->document();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1312,6 +1312,15 @@ void MainWindow::resetFormat(const QString &formatChars)
     QTextCursor cursor = m_textEdit->textCursor();
     if(!cursor.hasSelection()){
         cursor.select(QTextCursor::WordUnderCursor);
+        if(cursor.selectedText().startsWith(formatChars + formatChars) || cursor.selectedText().endsWith(formatChars + formatChars)){
+            QTextDocument *doc = m_textEdit->document();
+            QTextCursor found = doc->find(formatChars + formatChars, cursor.selectionStart());
+            m_textEdit->setTextCursor(found);
+            cursor.deleteChar();
+            return;
+        } else if(cursor.selectedText().startsWith(formatChars) || cursor.selectedText().endsWith(formatChars)){
+            return;
+        }
     }
     QString selectedText = cursor.selectedText();
     int start = cursor.selectionStart();
@@ -1319,6 +1328,8 @@ void MainWindow::resetFormat(const QString &formatChars)
     if(cursor.selectedText().startsWith(formatChars) && cursor.selectedText().endsWith(formatChars)){
         start += formatChars.length();
         end -= formatChars.length();
+    }else if(cursor.selectedText().startsWith(formatChars) || cursor.selectedText().endsWith(formatChars)){
+        return;
     }
     cursor.beginEditBlock();
     cursor.setPosition(start - formatChars.length(), QTextCursor::MoveAnchor);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -459,6 +459,9 @@ void MainWindow::setupKeyboardShortcuts()
     new QShortcut(QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_S), this, SLOT(onStyleEditorButtonClicked()));
     new QShortcut(QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_J), this, SLOT(toggleNodeTree()));
     new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_A), this, SLOT(selectAllNotesInList()));
+    new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_B), this, SLOT(makeBold()));
+    new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_I), this, SLOT(makeItalic()));
+    new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_S), this, SLOT(makeStrikethrough()));
 
     QxtGlobalShortcut *shortcut = new QxtGlobalShortcut(this);
 #if defined(Q_OS_LINUX)
@@ -1873,6 +1876,46 @@ void MainWindow::fullscreenWindow()
         showFullScreen();
     }
 #endif
+}
+
+/*!
+ * \brief MainWindow::makeBold
+ * Make selected text bold, or, if nothing selected insert formating char for bold
+ */
+void MainWindow::makeBold()
+{
+    QTextCursor cursor = ui->textEdit->textCursor();
+    cursor.insertText("**" + cursor.selectedText() + "**");
+    if(cursor.selectedText().isEmpty()){
+        ui->textEdit->moveCursor(QTextCursor::Left, QTextCursor::MoveAnchor);
+        ui->textEdit->moveCursor(QTextCursor::Left, QTextCursor::MoveAnchor);
+    }
+}
+
+/*!
+ * \brief MainWindow::makeItalic
+ * Italicize selected text, or, if nothing selected insert formating char for italics
+ */
+void MainWindow::makeItalic()
+{
+    QTextCursor cursor = ui->textEdit->textCursor();
+    cursor.insertText("*" + cursor.selectedText() + "*");
+    if(cursor.selectedText().isEmpty()){
+        ui->textEdit->moveCursor(QTextCursor::Left, QTextCursor::MoveAnchor);
+    }
+}
+
+/*!
+ * \brief MainWindow::makeStrikethrough
+ * Strikethrough selected text, or, if nothing selected insert the formatting char for strikethough
+ */
+void MainWindow::makeStrikethrough()
+{
+    QTextCursor cursor = ui->textEdit->textCursor();
+    cursor.insertText("~" + cursor.selectedText() + "~");
+    if(cursor.selectedText().isEmpty()){
+        ui->textEdit->moveCursor(QTextCursor::Left, QTextCursor::MoveAnchor);
+    }
 }
 
 /*!

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -459,6 +459,7 @@ void MainWindow::setupKeyboardShortcuts()
     new QShortcut(QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_S), this, SLOT(onStyleEditorButtonClicked()));
     new QShortcut(QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_J), this, SLOT(toggleNodeTree()));
     new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_A), this, SLOT(selectAllNotesInList()));
+    new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_QuoteLeft), this, SLOT(makeCode()));
     new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_B), this, SLOT(makeBold()));
     new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_I), this, SLOT(makeItalic()));
     new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_S), this, SLOT(makeStrikethrough()));
@@ -1904,6 +1905,11 @@ void MainWindow::fullscreenWindow()
         showFullScreen();
     }
 #endif
+}
+
+void MainWindow::makeCode()
+{
+    applyFormat("`");
 }
 
 void MainWindow::makeBold()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2509,7 +2509,7 @@ void MainWindow::mouseMoveEvent(QMouseEvent* event)
         int newWidth = width();
         int newHeight = height();
 
-        int minY =  QApplication::desktop()->availableGeometry().y();
+        int minY = QGuiApplication::primaryScreen()->availableGeometry().y();
 
         switch (m_stretchSide) {
         case StretchSide::Right:
@@ -3222,6 +3222,7 @@ bool MainWindow::eventFilter(QObject *object, QEvent *event)
         setCurrentFontBasedOnTypeface(m_currentFontTypeface);
 
         //        alignTextEditText();
+        break;
     }
     case QEvent::Show:
         if(object == &m_updater){

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3332,17 +3332,17 @@ void MainWindow::adjustUpperWidgets(bool shouldPushUp)
     const QSizePolicy policy = ui->verticalSpacer_upSearchEdit->sizePolicy();
     ui->verticalSpacer_upSearchEdit->setMinimumSize(0,
                                                     shouldPushUp ? ui->verticalSpacer_upScrollArea->sizeHint().height() : 25);
-    ui->verticalLayout_scrollArea->invalidate();
     ui->verticalSpacer_upTreeView->setMinimumSize(0,
                                                     shouldPushUp ? 9 : 25);
 
-    // TODO: For some reason the layout update itself only when a button is being hovered upon
-    // Adjust space above text editor
     ui->verticalSpacer_upEditorDateLabel->changeSize(0,
                                                      shouldPushUp ? ui->verticalSpacer_upScrollArea->sizeHint().height() : 25,
                                                      policy.horizontalPolicy(),
                                                      policy.verticalPolicy());
-    ui->verticalLayout_textEdit->invalidate();
+
+    // Force a full re-layout of the top right frame.
+    // This fixes some widgets not properly updating after switching between native and non-native window decoration modes.
+    ui->frameRightTop->setStyleSheet(ui->frameRightTop->styleSheet());
 }
 
 /*!

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2139,9 +2139,11 @@ void MainWindow::expandNodeTree()
 #ifdef __APPLE__
     this->setStandardWindowButtonsMacVisibility(true);
 #else
-    m_redCloseButton->setVisible(true);
-    m_yellowMinimizeButton->setVisible(true);
-    m_greenMaximizeButton->setVisible(true);
+    if (!m_useNativeWindowFrame) {
+        m_redCloseButton->setVisible(true);
+        m_yellowMinimizeButton->setVisible(true);
+        m_greenMaximizeButton->setVisible(true);
+    }
 #endif
 }
 
@@ -2202,9 +2204,11 @@ void MainWindow::expandNoteList()
 #ifdef __APPLE__
     this->setStandardWindowButtonsMacVisibility(true);
 #else
-    m_redCloseButton->setVisible(true);
-    m_yellowMinimizeButton->setVisible(true);
-    m_greenMaximizeButton->setVisible(true);
+    if (!m_useNativeWindowFrame) {
+        m_redCloseButton->setVisible(true);
+        m_yellowMinimizeButton->setVisible(true);
+        m_greenMaximizeButton->setVisible(true);
+    }
 #endif
 }
 
@@ -2968,9 +2972,11 @@ void MainWindow::setVisibilityOfFrameRightNonEditor(bool isVisible)
 
             this->setStandardWindowButtonsMacVisibility(isVisible);
 #else
-            m_redCloseButton->setVisible(isVisible);
-            m_yellowMinimizeButton->setVisible(isVisible);
-            m_greenMaximizeButton->setVisible(isVisible);
+            if (!m_useNativeWindowFrame) {
+                m_redCloseButton->setVisible(isVisible);
+                m_yellowMinimizeButton->setVisible(isVisible);
+                m_greenMaximizeButton->setVisible(isVisible);
+            }
 #endif
         }
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -268,6 +268,9 @@ private slots:
     void toggleNoteList();
     void collapseNodeTree();
     void expandNodeTree();
+    void makeBold();
+    void makeItalic();
+    void makeStrikethrough();
     void toggleNodeTree();
     void importNotesFile(const bool clicked);
     void exportNotesFile(const bool clicked);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -199,7 +199,8 @@ private:
     bool m_areNonEditorWidgetsVisible;
     bool m_isFrameRightTopWidgetsVisible;
 
-    void insertFormat(const QString &formatChars);
+    bool alreadyAppliedFormat(const QString &formatChars);
+    void applyFormat(const QString &formatChars);
     void setupMainWindow();
     void setupFonts();
     void setupTrayIcon();
@@ -221,6 +222,7 @@ private:
     void initializeSettingsDatabase();
     void setLayoutForScrollArea();
     void setButtonsAndFieldsEnabled(bool doEnable);
+    void resetFormat(const QString &formatChars);
     void restoreStates();
     void migrateFromV0_9_0();
     void executeImport(const bool replace);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -262,6 +262,9 @@ private slots:
     void selectNoteUp();
     void setFocusOnText();
     void fullscreenWindow();
+    void makeBold();
+    void makeItalic();
+    void makeStrikethrough();
     void maximizeWindow();
     void minimizeWindow();
     void QuitApplication();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -199,6 +199,7 @@ private:
     bool m_areNonEditorWidgetsVisible;
     bool m_isFrameRightTopWidgetsVisible;
 
+    void insertFormat(const QString &formatChars);
     void setupMainWindow();
     void setupFonts();
     void setupTrayIcon();
@@ -268,9 +269,6 @@ private slots:
     void toggleNoteList();
     void collapseNodeTree();
     void expandNodeTree();
-    void makeBold();
-    void makeItalic();
-    void makeStrikethrough();
     void toggleNodeTree();
     void importNotesFile(const bool clicked);
     void exportNotesFile(const bool clicked);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -262,6 +262,7 @@ private slots:
     void selectNoteUp();
     void setFocusOnText();
     void fullscreenWindow();
+    void makeCode();
     void makeBold();
     void makeItalic();
     void makeStrikethrough();

--- a/src/notelistdelegate.cpp
+++ b/src/notelistdelegate.cpp
@@ -55,7 +55,7 @@ NoteListDelegate::NoteListDelegate(NoteListView *view, TagPool *tagPool, QObject
     m_timeLine = new QTimeLine(300, this);
     m_timeLine->setFrameRange(0,m_maxFrame);
     m_timeLine->setUpdateInterval(10);
-    m_timeLine->setCurveShape(QTimeLine::EaseInCurve);
+    m_timeLine->easingCurve();
     m_folderIcon = QImage(":/images/folder.png");
     m_pinnedExpandIcon = QImage(":/images/pinned-expand.png");
     m_pinnedCollapseIcon = QImage(":/images/pinned-collasped.png");


### PR DESCRIPTION
Add Ctrl+B, Ctrl+I, Ctrl+S shortcuts for bold, italics, and strikethrough. It's a nice feature as it stands, but it will need improvements to handle the cases when the text is already formatted.