### PR TITLE
General fixes for native window decorations

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3289,17 +3289,17 @@ void MainWindow::adjustUpperWidgets(bool shouldPushUp)
     const QSizePolicy policy = ui->verticalSpacer_upSearchEdit->sizePolicy();
     ui->verticalSpacer_upSearchEdit->setMinimumSize(0,
                                                     shouldPushUp ? ui->verticalSpacer_upScrollArea->sizeHint().height() : 25);
-    ui->verticalLayout_scrollArea->invalidate();
     ui->verticalSpacer_upTreeView->setMinimumSize(0,
                                                     shouldPushUp ? 9 : 25);
 
-    // TODO: For some reason the layout update itself only when a button is being hovered upon
-    // Adjust space above text editor
     ui->verticalSpacer_upEditorDateLabel->changeSize(0,
                                                      shouldPushUp ? ui->verticalSpacer_upScrollArea->sizeHint().height() : 25,
                                                      policy.horizontalPolicy(),
                                                      policy.verticalPolicy());
-    ui->verticalLayout_textEdit->invalidate();
+
+    // Force a full re-layout of the top right frame.
+    // This fixes some widgets not properly updating after switching between native and non-native window decoration modes.
+    ui->frameRightTop->setStyleSheet(ui->frameRightTop->styleSheet());
 }
 
 /*!

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2096,9 +2096,11 @@ void MainWindow::expandNodeTree()
 #ifdef __APPLE__
     this->setStandardWindowButtonsMacVisibility(true);
 #else
-    m_redCloseButton->setVisible(true);
-    m_yellowMinimizeButton->setVisible(true);
-    m_greenMaximizeButton->setVisible(true);
+    if (!m_useNativeWindowFrame) {
+        m_redCloseButton->setVisible(true);
+        m_yellowMinimizeButton->setVisible(true);
+        m_greenMaximizeButton->setVisible(true);
+    }
 #endif
 }
 
@@ -2159,9 +2161,11 @@ void MainWindow::expandNoteList()
 #ifdef __APPLE__
     this->setStandardWindowButtonsMacVisibility(true);
 #else
-    m_redCloseButton->setVisible(true);
-    m_yellowMinimizeButton->setVisible(true);
-    m_greenMaximizeButton->setVisible(true);
+    if (!m_useNativeWindowFrame) {
+        m_redCloseButton->setVisible(true);
+        m_yellowMinimizeButton->setVisible(true);
+        m_greenMaximizeButton->setVisible(true);
+    }
 #endif
 }
 
@@ -2925,9 +2929,11 @@ void MainWindow::setVisibilityOfFrameRightNonEditor(bool isVisible)
 
             this->setStandardWindowButtonsMacVisibility(isVisible);
 #else
-            m_redCloseButton->setVisible(isVisible);
-            m_yellowMinimizeButton->setVisible(isVisible);
-            m_greenMaximizeButton->setVisible(isVisible);
+            if (!m_useNativeWindowFrame) {
+                m_redCloseButton->setVisible(isVisible);
+                m_yellowMinimizeButton->setVisible(isVisible);
+                m_greenMaximizeButton->setVisible(isVisible);
+            }
 #endif
         }
 


### PR DESCRIPTION
This fixes 4 visual bugs, in total. Most of them are only visible when using native window decorations.

<details>
<summary><h4>Bug 1: Expanding the folders tree (<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>J</kbd>) would incorrectly display non-native window decorations.</h4></summary>

![bug1](https://user-images.githubusercontent.com/626206/190849377-8001db37-f65d-4797-800b-f239a4e7e797.gif)

### Fix:

![bug1-fixed](https://user-images.githubusercontent.com/626206/190849426-2a0351ff-cf12-4345-bcf4-979c1e6f4876.gif)
</details>

<details>
<summary><h4>Bug 2: Expanding the notes list (<kbd>Ctrl</kbd>+<kbd>J</kbd>) would incorrectly display non-native window decorations.</h4></summary>

![bug2](https://user-images.githubusercontent.com/626206/190849643-4fd57fd4-280d-41b5-b14e-45a7ddadd0b0.gif)

### Fix:

![bug2-fixed](https://user-images.githubusercontent.com/626206/190849649-02f3a8ff-e602-428d-b635-a3b373fe4a95.gif)
</details>

<details>
<summary><h4>Bug 3: When in "editor-only mode", hovering over the top bar would incorrectly display non-native window decorations.</h4></summary>

![bug3](https://user-images.githubusercontent.com/626206/190849760-e039f8b7-e888-4053-afec-4926ea2b1c28.gif)

### Fix:

![bug3-fixed](https://user-images.githubusercontent.com/626206/190849763-5292e46f-e905-4343-9c03-a218847c2e36.gif)
</details>

<details>
<summary><h4>Bug 4: A widget would be incorrectly positioned after switching between native/non-native window decoration modes.</h4></summary>

![bug4](https://user-images.githubusercontent.com/626206/190849772-d45fb388-af89-4148-908a-f844d5b7dd5c.gif)

### Fix:

![bug4-fixed](https://user-images.githubusercontent.com/626206/190849775-c96d6429-223b-4b81-93cb-78053164227d.gif)
</details>