### PR TITLE
Update Ubuntu versions used in GitHub Actions

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -8,7 +8,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-latest]
+        # https://github.com/actions/runner-images#available-images
+        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
     
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
* Ubuntu 16.04 was removed on Sep 20, 2021, as per https://github.com/actions/runner-images/issues/3287
* Currently-available versions are 18.04 (deprecated), 20.04, and 22.04 as per https://github.com/actions/runner-images#available-images

Added a comment pointing to the list of currently-available Ubuntu versions in a comment in the workflow config to make it easire to find the full list and update it in the future.