### PR TITLE
Replace Travis CI badge with GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Notes
 
 [![Join the chat at https://gitter.im/nuttyartist/notes](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/nuttyartist/notes?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Build Status](https://travis-ci.org/nuttyartist/notes.svg?branch=dev)](https://travis-ci.org/nuttyartist/notes)
-[![Build status](https://ci.appveyor.com/api/projects/status/rgque4o6x2y0i92i?svg=true)](https://ci.appveyor.com/project/nuttyartist/notes)
+[![GitHub Actions status on Linux](https://github.com/nuttyartist/notes/actions/workflows/ubuntu.yml/badge.svg?branch=dev)](https://github.com/github/docs/actions/workflows/ubuntu.yml?query=branch%3Adev)
+[![GitHub Actions status on macOS](https://github.com/nuttyartist/notes/actions/workflows/macos.yml/badge.svg?branch=dev)](https://github.com/github/docs/actions/workflows/macos.yml?query=branch%3Adev)
+[![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/github/nuttyartist/notes?branch=dev&svg=true)](https://ci.appveyor.com/project/nuttyartist/notes)
 
 Notes is an open source and cross-platform note-taking app that is both beautiful and powerful.
 


### PR DESCRIPTION
Remove `.travis.yml` and Travis CI badge as they haven't been building this project for a very long time now; if we visit the Travis CI page for this project, https://travis-ci.org/github/nuttyartist/notes says it last ran "2 years ago".

Additionally, at the top of that page, it says:

> Since June 15th, 2021, the building on travis-ci.org is ceased. Please use
> travis-ci.com from now on.

Also replaced the Travis CI badge in the `README.md` with 2 separate badges for GitHub Actions, one for Ubuntu and one for macOS since they are different workflows and have separate statuses.

Added separate alt text for all build status badges to make it easy to distinguish them from each other for folks who are navigating the web based on alt text (e.g., those using screen readers).

Since we're not actually modifying any code, we can [skip ci] for this commit.