### PR TITLE
Add keyboard shortcuts for text formatting: bold, italics, strikethrough (take 2)

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -459,9 +459,9 @@ void MainWindow::setupKeyboardShortcuts()
     new QShortcut(QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_S), this, SLOT(onStyleEditorButtonClicked()));
     new QShortcut(QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_J), this, SLOT(toggleNodeTree()));
     new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_A), this, SLOT(selectAllNotesInList()));
-    new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_B), this, [this](){applyFormat("**");});
-    new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_I), this, [this](){applyFormat("*");});
-    new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_S), this, [this](){applyFormat("~");});
+    new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_B), this, SLOT(makeBold()));
+    new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_I), this, SLOT(makeItalic()));
+    new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_S), this, SLOT(makeStrikethrough()));
 
     QxtGlobalShortcut *shortcut = new QxtGlobalShortcut(this);
 #if defined(Q_OS_LINUX)
@@ -1904,6 +1904,21 @@ void MainWindow::fullscreenWindow()
         showFullScreen();
     }
 #endif
+}
+
+void MainWindow::makeBold()
+{
+    applyFormat("**");
+}
+
+void MainWindow::makeItalic()
+{
+    applyFormat("*");
+}
+
+void MainWindow::makeStrikethrough()
+{
+    applyFormat("~");
 }
 
 /*!

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1311,14 +1311,14 @@ void MainWindow::resetFormat(const QString &formatChars)
     QTextCursor cursor = m_textEdit->textCursor();
     if(!cursor.hasSelection()){
         cursor.select(QTextCursor::WordUnderCursor);
-        if(cursor.selectedText().contains(formatChars)){
-            cursor.deleteChar();
-            return;
-        }
     }
     QString selectedText = cursor.selectedText();
     int start = cursor.selectionStart();
     int end = cursor.selectionEnd();
+    if(cursor.selectedText().startsWith(formatChars) && cursor.selectedText().endsWith(formatChars)){
+        start += formatChars.length();
+        end -= formatChars.length();
+    }
     cursor.beginEditBlock();
     cursor.setPosition(start - formatChars.length(), QTextCursor::MoveAnchor);
     cursor.setPosition(start, QTextCursor::KeepAnchor);
@@ -3317,9 +3317,9 @@ bool MainWindow::alreadyAppliedFormat(const QString &formatChars)
         if(!cursor.hasSelection()){
             return false;
         }
-        if(cursor.selectedText().contains(formatChars)){
-            return true;
-        }
+    }
+    if(cursor.selectedText().contains(formatChars)){
+        return true;
     }
     QString selectedText = cursor.selectedText();
     QTextDocument *doc = m_textEdit->document();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1312,6 +1312,15 @@ void MainWindow::resetFormat(const QString &formatChars)
     QTextCursor cursor = m_textEdit->textCursor();
     if(!cursor.hasSelection()){
         cursor.select(QTextCursor::WordUnderCursor);
+        if(cursor.selectedText().startsWith(formatChars + formatChars) || cursor.selectedText().endsWith(formatChars + formatChars)){
+            QTextDocument *doc = m_textEdit->document();
+            QTextCursor found = doc->find(formatChars + formatChars, cursor.selectionStart());
+            m_textEdit->setTextCursor(found);
+            cursor.deleteChar();
+            return;
+        } else if(cursor.selectedText().startsWith(formatChars) || cursor.selectedText().endsWith(formatChars)){
+            return;
+        }
     }
     QString selectedText = cursor.selectedText();
     int start = cursor.selectionStart();
@@ -1319,6 +1328,8 @@ void MainWindow::resetFormat(const QString &formatChars)
     if(cursor.selectedText().startsWith(formatChars) && cursor.selectedText().endsWith(formatChars)){
         start += formatChars.length();
         end -= formatChars.length();
+    }else if(cursor.selectedText().startsWith(formatChars) || cursor.selectedText().endsWith(formatChars)){
+        return;
     }
     cursor.beginEditBlock();
     cursor.setPosition(start - formatChars.length(), QTextCursor::MoveAnchor);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -459,6 +459,9 @@ void MainWindow::setupKeyboardShortcuts()
     new QShortcut(QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_S), this, SLOT(onStyleEditorButtonClicked()));
     new QShortcut(QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_J), this, SLOT(toggleNodeTree()));
     new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_A), this, SLOT(selectAllNotesInList()));
+    new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_B), this, SLOT(makeBold()));
+    new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_I), this, SLOT(makeItalic()));
+    new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_S), this, SLOT(makeStrikethrough()));
 
     QxtGlobalShortcut *shortcut = new QxtGlobalShortcut(this);
 #if defined(Q_OS_LINUX)
@@ -1873,6 +1876,46 @@ void MainWindow::fullscreenWindow()
         showFullScreen();
     }
 #endif
+}
+
+/*!
+ * \brief MainWindow::makeBold
+ * Make selected text bold, or, if nothing selected insert formating char for bold
+ */
+void MainWindow::makeBold()
+{
+    QTextCursor cursor = ui->textEdit->textCursor();
+    cursor.insertText("**" + cursor.selectedText() + "**");
+    if(cursor.selectedText().isEmpty()){
+        ui->textEdit->moveCursor(QTextCursor::Left, QTextCursor::MoveAnchor);
+        ui->textEdit->moveCursor(QTextCursor::Left, QTextCursor::MoveAnchor);
+    }
+}
+
+/*!
+ * \brief MainWindow::makeItalic
+ * Italicize selected text, or, if nothing selected insert formating char for italics
+ */
+void MainWindow::makeItalic()
+{
+    QTextCursor cursor = ui->textEdit->textCursor();
+    cursor.insertText("*" + cursor.selectedText() + "*");
+    if(cursor.selectedText().isEmpty()){
+        ui->textEdit->moveCursor(QTextCursor::Left, QTextCursor::MoveAnchor);
+    }
+}
+
+/*!
+ * \brief MainWindow::makeStrikethrough
+ * Strikethrough selected text, or, if nothing selected insert the formatting char for strikethough
+ */
+void MainWindow::makeStrikethrough()
+{
+    QTextCursor cursor = ui->textEdit->textCursor();
+    cursor.insertText("~" + cursor.selectedText() + "~");
+    if(cursor.selectedText().isEmpty()){
+        ui->textEdit->moveCursor(QTextCursor::Left, QTextCursor::MoveAnchor);
+    }
 }
 
 /*!

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1325,10 +1325,13 @@ void MainWindow::resetFormat(const QString &formatChars)
     QString selectedText = cursor.selectedText();
     int start = cursor.selectionStart();
     int end = cursor.selectionEnd();
-    if(cursor.selectedText().startsWith(formatChars) && cursor.selectedText().endsWith(formatChars)){
+    if(selectedText.startsWith(formatChars) && selectedText.endsWith(formatChars)){
+        if(selectedText.length() == formatChars.length()){
+            return;
+        }
         start += formatChars.length();
         end -= formatChars.length();
-    }else if(cursor.selectedText().startsWith(formatChars) || cursor.selectedText().endsWith(formatChars)){
+    }else if(selectedText.startsWith(formatChars) || selectedText.endsWith(formatChars)){
         return;
     }
     cursor.beginEditBlock();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -459,6 +459,7 @@ void MainWindow::setupKeyboardShortcuts()
     new QShortcut(QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_S), this, SLOT(onStyleEditorButtonClicked()));
     new QShortcut(QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_J), this, SLOT(toggleNodeTree()));
     new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_A), this, SLOT(selectAllNotesInList()));
+    new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_QuoteLeft), this, SLOT(makeCode()));
     new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_B), this, SLOT(makeBold()));
     new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_I), this, SLOT(makeItalic()));
     new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_S), this, SLOT(makeStrikethrough()));
@@ -1904,6 +1905,11 @@ void MainWindow::fullscreenWindow()
         showFullScreen();
     }
 #endif
+}
+
+void MainWindow::makeCode()
+{
+    applyFormat("`");
 }
 
 void MainWindow::makeBold()

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -268,6 +268,9 @@ private slots:
     void toggleNoteList();
     void collapseNodeTree();
     void expandNodeTree();
+    void makeBold();
+    void makeItalic();
+    void makeStrikethrough();
     void toggleNodeTree();
     void importNotesFile(const bool clicked);
     void exportNotesFile(const bool clicked);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -199,7 +199,8 @@ private:
     bool m_areNonEditorWidgetsVisible;
     bool m_isFrameRightTopWidgetsVisible;
 
-    void insertFormat(const QString &formatChars);
+    bool alreadyAppliedFormat(const QString &formatChars);
+    void applyFormat(const QString &formatChars);
     void setupMainWindow();
     void setupFonts();
     void setupTrayIcon();
@@ -221,6 +222,7 @@ private:
     void initializeSettingsDatabase();
     void setLayoutForScrollArea();
     void setButtonsAndFieldsEnabled(bool doEnable);
+    void resetFormat(const QString &formatChars);
     void restoreStates();
     void migrateFromV0_9_0();
     void executeImport(const bool replace);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -262,6 +262,9 @@ private slots:
     void selectNoteUp();
     void setFocusOnText();
     void fullscreenWindow();
+    void makeBold();
+    void makeItalic();
+    void makeStrikethrough();
     void maximizeWindow();
     void minimizeWindow();
     void QuitApplication();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -199,6 +199,7 @@ private:
     bool m_areNonEditorWidgetsVisible;
     bool m_isFrameRightTopWidgetsVisible;
 
+    void insertFormat(const QString &formatChars);
     void setupMainWindow();
     void setupFonts();
     void setupTrayIcon();
@@ -268,9 +269,6 @@ private slots:
     void toggleNoteList();
     void collapseNodeTree();
     void expandNodeTree();
-    void makeBold();
-    void makeItalic();
-    void makeStrikethrough();
     void toggleNodeTree();
     void importNotesFile(const bool clicked);
     void exportNotesFile(const bool clicked);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -262,6 +262,7 @@ private slots:
     void selectNoteUp();
     void setFocusOnText();
     void fullscreenWindow();
+    void makeCode();
     void makeBold();
     void makeItalic();
     void makeStrikethrough();


### PR DESCRIPTION
Started a new pull request, I think this is from a cleaner state.

I think I addressed your request. It might need some polish in some edge cases but I think it should work fine as is.