### PR TITLE
Fix GitHub Actions links to point to this project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Notes
 
 [![Join the chat at https://gitter.im/nuttyartist/notes](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/nuttyartist/notes?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![GitHub Actions status on Linux](https://github.com/nuttyartist/notes/actions/workflows/ubuntu.yml/badge.svg?branch=dev)](https://github.com/github/docs/actions/workflows/ubuntu.yml?query=branch%3Adev)
-[![GitHub Actions status on macOS](https://github.com/nuttyartist/notes/actions/workflows/macos.yml/badge.svg?branch=dev)](https://github.com/github/docs/actions/workflows/macos.yml?query=branch%3Adev)
+[![GitHub Actions status on Linux](https://github.com/nuttyartist/notes/actions/workflows/ubuntu.yml/badge.svg?branch=dev)](https://github.com/nuttyartist/notes/actions/workflows/ubuntu.yml?query=branch%3Adev)
+[![GitHub Actions status on macOS](https://github.com/nuttyartist/notes/actions/workflows/macos.yml/badge.svg?branch=dev)](https://github.com/nuttyartist/notes/actions/workflows/macos.yml?query=branch%3Adev)
 [![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/github/nuttyartist/notes?branch=dev&svg=true)](https://ci.appveyor.com/project/nuttyartist/notes)
 
 Notes is an open source and cross-platform note-taking app that is both beautiful and powerful.


### PR DESCRIPTION
Earlier change incorrectly used GitHub Docs sample URLs and updated the badge URL, but not the target URL to point to this project's actions page.

Since this is not changing code, we can [skip ci].