### PR TITLE
Disable fast-fail on Ubuntu in GitHub Actions

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -7,10 +7,11 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         # https://github.com/actions/runner-images#available-images
         os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
-    
+
     steps:
     - uses: actions/checkout@v1
       with:


### PR DESCRIPTION
The current failure may be due to Ubuntu 22.04 missing packages that we expect to see on 18.04 and 20.04, so it may need a different set of packages, but the current approach is cancelling all builds as soon as the 22.04 build fails, so we're not learning everything we need to know.