### PR TITLE
Fix Ubuntu 22.04 package names

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,26 +1,34 @@
-name: Default Qt on ubuntu
+name: Ubuntu
 
 on: [push, pull_request]
 
 jobs:
   build:
-
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         # https://github.com/actions/runner-images#available-images
-        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
+        os: ['ubuntu-18.04', 'ubuntu-20.04', 'ubuntu-22.04']
 
     steps:
-    - uses: actions/checkout@v1
+    - name: Checkout repo
+      uses: actions/checkout@v1
       with:
         submodules: recursive
-    - name: install dependencies
-      run: |
-        sudo apt update
-        sudo apt install qt5-default qtbase5-private-dev
-    - name: build
+
+    - name: Update APT repo
+      run: sudo apt update
+
+    - name: "Install dependencies (Ubuntu 18.04, 20.04)"
+      run: sudo apt install qt5-default qtbase5-private-dev
+      if: ${{ matrix.os == 'ubuntu-18.04' || matrix.os == 'ubuntu-20.04' }}
+
+    - name: "Install dependencies (Ubuntu 22.04)"
+      run: sudo apt install qtbase5-dev qtbase5-private-dev
+      if: ${{ matrix.os == 'ubuntu-22.04' }}
+
+    - name: Build
       run: |
         mkdir build
         cd build


### PR DESCRIPTION
The Qt 5 package names are different in Ubuntu 22.04 from prior releases (18.04 and 20.04), so we need to have a different package installation command in CI.

This is a follow-up to PR https://github.com/nuttyartist/notes/pull/365 which disabled fast-fail so we can see all Ubuntu failures independently per-version.