### PR TITLE
Update GitHub Actions badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Notes
 
 [![Join the chat at https://gitter.im/nuttyartist/notes](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/nuttyartist/notes?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![GitHub Actions status on Linux](https://github.com/nuttyartist/notes/actions/workflows/ubuntu.yml/badge.svg?branch=dev)](https://github.com/nuttyartist/notes/actions/workflows/ubuntu.yml?query=branch%3Adev)
+[![GitHub Actions status on Linux](https://github.com/nuttyartist/notes/actions/workflows/linux.yml/badge.svg?branch=dev)](https://github.com/nuttyartist/notes/actions/workflows/linux.yml?query=branch%3Adev)
 [![GitHub Actions status on macOS](https://github.com/nuttyartist/notes/actions/workflows/macos.yml/badge.svg?branch=dev)](https://github.com/nuttyartist/notes/actions/workflows/macos.yml?query=branch%3Adev)
+[![GitHub Actions status on Windows](https://github.com/nuttyartist/notes/actions/workflows/windows.yml/badge.svg?branch=dev)](https://github.com/nuttyartist/notes/actions/workflows/windows.yml?query=branch%3Adev)
 [![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/github/nuttyartist/notes?branch=dev&svg=true)](https://ci.appveyor.com/project/nuttyartist/notes)
 
 Notes is an open source and cross-platform note-taking app that is both beautiful and powerful.


### PR DESCRIPTION
PR https://github.com/nuttyartist/notes/pull/367 replaced `ubuntu.yml` with `linux.yml` and created a new `windows.yml` so now we need to update the badges in the `README.md` appropriately to refer to the new workflows.

Since we're not modifying code, we can [skip ci] for this change.