### PR TITLE
fix #346

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,7 +11,6 @@
 
 int main(int argc, char *argv[])
 {
-    QApplication::setDesktopSettingsAware(false);
     QApplication app (argc, argv);
     // Set application information
     app.setApplicationName ("Notes");


### PR DESCRIPTION
Fixes #346 by removing the line that sets `setDesktopSettingsAware` to false.