### PR TITLE
General CI fixes

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -61,7 +61,13 @@ jobs:
         if: matrix.build-type == 'release'
         run: |
           Set-Location bin
-          Copy-Item -Path $env:VCToolsRedistDir\${{ matrix.arch }}\Microsoft.VC142.CRT\* -Include msvcp140.dll,msvcp140_1.dll,vcruntime140.dll,vcruntime140_1.dll
+          Copy-Item $env:VCToolsRedistDir\${{ matrix.arch }}\Microsoft.VC142.CRT\msvcp140.dll
+          Copy-Item $env:VCToolsRedistDir\${{ matrix.arch }}\Microsoft.VC142.CRT\msvcp140_1.dll
+          Copy-Item $env:VCToolsRedistDir\${{ matrix.arch }}\Microsoft.VC142.CRT\vcruntime140.dll
+          if ('${{ matrix.arch }}' -ieq 'x64') {
+              # Only 64-bit builds also need 'vcruntime140_1.dll' (tested on Windows 7)
+              Copy-Item $env:VCToolsRedistDir\${{ matrix.arch }}\Microsoft.VC142.CRT\vcruntime140_1.dll
+          }
           Remove-Item vc_redist.*.exe
 
       - name: Upload artifacts (${{ matrix.build-type }}, ${{ matrix.arch }})

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -45,6 +45,7 @@ jobs:
           version: ${{ matrix.qt-version }}
           cache: true
           arch: ${{ matrix.arch == 'x86' && 'win32_msvc2019' || 'win64_msvc2019_64' }}
+          tools: tools_openssl_${{ matrix.arch }}
 
       - name: Build (${{ matrix.build-type }}, ${{ matrix.arch }})
         run: |
@@ -57,18 +58,42 @@ jobs:
         run: |
           windeployqt bin
 
-      - name: Include required runtime libraries (release-only, ${{ matrix.arch }})
-        if: matrix.build-type == 'release'
+      - name: Include required runtime libraries (${{ matrix.build-type }}, ${{ matrix.arch }})
         run: |
           Set-Location bin
-          Copy-Item $env:VCToolsRedistDir\${{ matrix.arch }}\Microsoft.VC142.CRT\msvcp140.dll
-          Copy-Item $env:VCToolsRedistDir\${{ matrix.arch }}\Microsoft.VC142.CRT\msvcp140_1.dll
-          Copy-Item $env:VCToolsRedistDir\${{ matrix.arch }}\Microsoft.VC142.CRT\vcruntime140.dll
+
           if ('${{ matrix.arch }}' -ieq 'x64') {
-              # Only 64-bit builds also need 'vcruntime140_1.dll' (tested on Windows 7)
-              Copy-Item $env:VCToolsRedistDir\${{ matrix.arch }}\Microsoft.VC142.CRT\vcruntime140_1.dll
+              $openssl_lib_suffix = '-x64'
+          } else {
+              $openssl_lib_suffix = ''
           }
-          Remove-Item vc_redist.*.exe
+
+          # Include OpenSSL libraries.
+          Copy-Item ..\..\Qt\Tools\OpenSSL\Win_${{ matrix.arch }}\bin\libcrypto-1_1$openssl_lib_suffix.dll
+          Copy-Item ..\..\Qt\Tools\OpenSSL\Win_${{ matrix.arch }}\bin\libssl-1_1$openssl_lib_suffix.dll
+          # NOTE: Due to OpenSSL libraries being built with MSVC 2010, we must also include 'msvcr100.dll'.
+          Copy-Item $env:WINDIR\${{ matrix.arch == 'x64' && 'System32' || 'SysWOW64' }}\msvcr100.dll
+
+          # Also include OpenSSL debug symbols (when building Notes in debug mode).
+          if ('${{ matrix.build-type }}' -ieq 'debug') {
+              Copy-Item ..\..\Qt\Tools\OpenSSL\Win_${{ matrix.arch }}\bin\libcrypto-1_1$openssl_lib_suffix.pdb
+              Copy-Item ..\..\Qt\Tools\OpenSSL\Win_${{ matrix.arch }}\bin\libssl-1_1$openssl_lib_suffix.pdb
+          }
+
+          # Include MSVC 2019 runtime libraries.
+          if ('${{ matrix.build-type }}' -ieq 'release') {
+              Copy-Item $env:VCToolsRedistDir\${{ matrix.arch }}\Microsoft.VC142.CRT\msvcp140.dll
+              Copy-Item $env:VCToolsRedistDir\${{ matrix.arch }}\Microsoft.VC142.CRT\msvcp140_1.dll
+              Copy-Item $env:VCToolsRedistDir\${{ matrix.arch }}\Microsoft.VC142.CRT\vcruntime140.dll
+              if ('${{ matrix.arch }}' -ieq 'x64') {
+                  # Only 64-bit builds also need 'vcruntime140_1.dll' (tested on Windows 7)
+                  Copy-Item $env:VCToolsRedistDir\${{ matrix.arch }}\Microsoft.VC142.CRT\vcruntime140_1.dll
+              }
+              Remove-Item vc_redist.*.exe
+          } else {
+              # On debug builds, the libraries above are included automatically, so we only need 'urtcbased.dll'.
+              Copy-Item $env:WindowsSdkBinPath\${{ matrix.arch }}\ucrt\ucrtbased.dll
+          }
 
       - name: Upload artifacts (${{ matrix.build-type }}, ${{ matrix.arch }})
         uses: actions/upload-artifact@v3

--- a/packaging/windows/Notes_Inno_Script_Github.iss
+++ b/packaging/windows/Notes_Inno_Script_Github.iss
@@ -29,8 +29,11 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 [Files]
 ;x-64
 Source: "{#SourcePath}\Notes64\Notes.exe"; DestDir: "{app}"; Flags: ignoreversion; Check: Is64BitInstallMode
+Source: "{#SourcePath}\Notes64\libcrypto-1_1-x64.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: Is64BitInstallMode
+Source: "{#SourcePath}\Notes64\libssl-1_1-x64.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: Is64BitInstallMode
 Source: "{#SourcePath}\Notes64\msvcp140.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: Is64BitInstallMode
 Source: "{#SourcePath}\Notes64\msvcp140_1.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: Is64BitInstallMode
+Source: "{#SourcePath}\Notes64\msvcr100.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: Is64BitInstallMode
 Source: "{#SourcePath}\Notes64\vcruntime140.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: Is64BitInstallMode
 Source: "{#SourcePath}\Notes64\vcruntime140_1.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: Is64BitInstallMode
 Source: "{#SourcePath}\Notes64\d3dcompiler_47.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: Is64BitInstallMode
@@ -52,8 +55,11 @@ Source: "{#SourcePath}\Notes64\styles\*"; DestDir: "{app}\translations"; Flags: 
 Source: "{#SourcePath}\Notes64\translations\*"; DestDir: "{app}\translations"; Flags: ignoreversion recursesubdirs createallsubdirs; Check: Is64BitInstallMode
 ;x-86
 Source: "{#SourcePath}\Notes32\Notes.exe"; DestDir: "{app}"; Flags: ignoreversion; Check: not Is64BitInstallMode
+Source: "{#SourcePath}\Notes32\libcrypto-1_1.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: not Is64BitInstallMode
+Source: "{#SourcePath}\Notes32\libssl-1_1.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: not Is64BitInstallMode
 Source: "{#SourcePath}\Notes32\msvcp140.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: not Is64BitInstallMode
 Source: "{#SourcePath}\Notes32\msvcp140_1.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: not Is64BitInstallMode
+Source: "{#SourcePath}\Notes32\msvcr100.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: not Is64BitInstallMode
 Source: "{#SourcePath}\Notes32\vcruntime140.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: not Is64BitInstallMode
 Source: "{#SourcePath}\Notes32\d3dcompiler_47.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: not Is64BitInstallMode
 Source: "{#SourcePath}\Notes32\libEGL.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: not Is64BitInstallMode

--- a/packaging/windows/Notes_Inno_Script_Github.iss
+++ b/packaging/windows/Notes_Inno_Script_Github.iss
@@ -32,6 +32,7 @@ Source: "{#SourcePath}\Notes64\Notes.exe"; DestDir: "{app}"; Flags: ignoreversio
 Source: "{#SourcePath}\Notes64\msvcp140.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: Is64BitInstallMode
 Source: "{#SourcePath}\Notes64\msvcp140_1.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: Is64BitInstallMode
 Source: "{#SourcePath}\Notes64\vcruntime140.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: Is64BitInstallMode
+Source: "{#SourcePath}\Notes64\vcruntime140_1.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: Is64BitInstallMode
 Source: "{#SourcePath}\Notes64\d3dcompiler_47.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: Is64BitInstallMode
 Source: "{#SourcePath}\Notes64\libEGL.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: Is64BitInstallMode
 Source: "{#SourcePath}\Notes64\libGLESV2.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: Is64BitInstallMode


### PR DESCRIPTION
This PR mainly includes the required OpenSSL runtime libraries to make the auto-update feature work properly on Windows. These are the dlls:

- `libcrypto-1_1.dll` (32-bit) / `libcrypto-1_1-x64.dll` (64-bit)
- `libssl-1_1.dll` (32-bit) / `libssl-1_1-x64.dll` (64-bit)
- `msvcr100.dll` (required because these OpenSSL libraries were [compiled with MSVC 2010 :(](https://bugreports.qt.io/browse/QTBUG-78242))

I also included a forgotten dll *only* required for the x64 build:

- `vcruntime140_1.dll`

I only tested this on a Windows 7 (64-bit) virtual machine and everything seems to work just fine, but please test it on Windows 10 / Windows 11 as well.

Fixes #310.