### PR TITLE
Fixed possible crash on exit

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -58,7 +58,7 @@ MainWindow::MainWindow(QWidget *parent) :
     m_quitAction(new QAction(tr("&Quit"), this)),
     m_trayIconMenu(new QMenu(this)),
     m_listView(Q_NULLPTR),
-    m_listModel(new NoteListModel(this)),
+    m_listModel(Q_NULLPTR),
     m_listViewLogic(Q_NULLPTR),
     m_treeView(Q_NULLPTR),
     m_treeModel(new NodeTreeModel(this)),
@@ -1134,8 +1134,9 @@ void MainWindow::setupDatabases()
  */
 void MainWindow::setupModelView()
 {
-    m_listView = static_cast<NoteListView*>(ui->listView);
+    m_listView = ui->listView;
     m_tagPool = new TagPool(m_dbManager);
+    m_listModel = new NoteListModel(m_listView);
     m_listView->setTagPool(m_tagPool);
     m_listView->setModel(m_listModel);
     m_listViewLogic = new ListViewLogic(m_listView,

--- a/src/notelistdelegateeditor.cpp
+++ b/src/notelistdelegateeditor.cpp
@@ -19,7 +19,7 @@
 #include "taglistdelegate.h"
 
 NoteListDelegateEditor::NoteListDelegateEditor(const NoteListDelegate *delegate,
-                                               QListView *view,
+                                               NoteListView *view,
                                                const QStyleOptionViewItem &option,
                                                const QModelIndex &index,
                                                TagPool *tagPool,
@@ -91,7 +91,7 @@ NoteListDelegateEditor::NoteListDelegateEditor(const NoteListDelegate *delegate,
             fouthYOffset = NoteListConstant::unpinnedHeaderToNoteSpace;
         }
         int fifthYOffset = 0;
-        if (model && model->hasPinnedNote() && !dynamic_cast<NoteListView*>(m_view)->isPinnedNotesCollapsed()
+        if (model && model->hasPinnedNote() && !m_view->isPinnedNotesCollapsed()
                 && model->isFirstUnpinnedNote(index)) {
             fifthYOffset = NoteListConstant::lastPinnedToUnpinnedHeader;
         }
@@ -114,7 +114,7 @@ NoteListDelegateEditor::NoteListDelegateEditor(const NoteListDelegate *delegate,
             fouthYOffset = NoteListConstant::unpinnedHeaderToNoteSpace;
         }
         int fifthYOffset = 0;
-        if (model && model->hasPinnedNote() && !dynamic_cast<NoteListView*>(m_view)->isPinnedNotesCollapsed()
+        if (model && model->hasPinnedNote() && !m_view->isPinnedNotesCollapsed()
                 && model->isFirstUnpinnedNote(index)) {
             fifthYOffset = NoteListConstant::lastPinnedToUnpinnedHeader;
         }
@@ -133,14 +133,14 @@ NoteListDelegateEditor::NoteListDelegateEditor(const NoteListDelegate *delegate,
         auto index = dynamic_cast<NoteListModel*>(m_view->model())->getNoteIndex(m_id);
         setScrollBarPos(index.data(NoteListModel::NoteTagListScrollbarPos).toInt());
     });
-    dynamic_cast<NoteListView*>(m_view)->setEditorWidget(m_id, this);
+    m_view->setEditorWidget(m_id, this);
     setMouseTracking(true);
     setAcceptDrops(true);
 }
 
 NoteListDelegateEditor::~NoteListDelegateEditor()
 {
-    dynamic_cast<NoteListView*>(m_view)->unsetEditorWidget(m_id, nullptr);
+    m_view->unsetEditorWidget(m_id, nullptr);
 }
 
 void NoteListDelegateEditor::paintBackground(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
@@ -155,7 +155,7 @@ void NoteListDelegateEditor::paintBackground(QPainter *painter, const QStyleOpti
     if (model && model->hasPinnedNote() &&
             (model->isFirstPinnedNote(index) || model->isFirstUnpinnedNote(index))) {
         int fifthYOffset = 0;
-        if (model && model->hasPinnedNote() && !dynamic_cast<NoteListView*>(m_view)->isPinnedNotesCollapsed()
+        if (model && model->hasPinnedNote() && !m_view->isPinnedNotesCollapsed()
                 && model->isFirstUnpinnedNote(index)) {
             fifthYOffset = NoteListConstant::lastPinnedToUnpinnedHeader;
         }
@@ -176,7 +176,7 @@ void NoteListDelegateEditor::paintBackground(QPainter *painter, const QStyleOpti
             m_tagListView->setBackground(m_applicationInactiveColor);
         }
     }else if (underMouseC()){
-        if (dynamic_cast<NoteListView*>(m_view)->isDragging()) {
+        if (m_view->isDragging()) {
             if (isPinned) {
                 auto rect = bufferRect;
                 rect.setTop(rect.bottom() - 5);
@@ -187,9 +187,8 @@ void NoteListDelegateEditor::paintBackground(QPainter *painter, const QStyleOpti
             m_tagListView->setBackground(m_hoverColor);
         }
     } else {
-        auto view = dynamic_cast<NoteListView*>(m_view);
         auto isPinned = index.data(NoteListModel::NoteIsPinned).value<bool>();
-        if (view && view->isPinnedNotesCollapsed() && !isPinned) {
+        if (m_view->isPinnedNotesCollapsed() && !isPinned) {
                 bufferPainter.fillRect(bufferRect, QBrush(m_defaultColor));
                 m_tagListView->setBackground(m_defaultColor);
         } else {
@@ -197,8 +196,7 @@ void NoteListDelegateEditor::paintBackground(QPainter *painter, const QStyleOpti
             m_tagListView->setBackground(m_defaultColor);
         }
     }
-    if (dynamic_cast<NoteListView*>(m_view)->isDragging() && !isPinned
-            && !dynamic_cast<NoteListView*>(m_view)->isDraggingInsidePinned()) {
+    if (m_view->isDragging() && !isPinned && !m_view->isDraggingInsidePinned()) {
         if (model && model->isFirstUnpinnedNote(index) && (index.row() == (model->rowCount() - 1))) {
             auto rect = bufferRect;
             rect.setHeight(4);
@@ -276,9 +274,8 @@ void NoteListDelegateEditor::paintLabels(QPainter* painter, const QStyleOptionVi
     double rowPosY = rect().y();
     double rowWidth = rect().width();
     auto model = dynamic_cast<NoteListModel*>(m_view->model());
-    auto view = dynamic_cast<NoteListView*>(m_view);
     int fifthYOffset = 0;
-    if (model && model->hasPinnedNote() && !dynamic_cast<NoteListView*>(m_view)->isPinnedNotesCollapsed()
+    if (model && model->hasPinnedNote() && !m_view->isPinnedNotesCollapsed()
             && model->isFirstUnpinnedNote(index)) {
         fifthYOffset = NoteListConstant::lastPinnedToUnpinnedHeader;
     }
@@ -286,7 +283,7 @@ void NoteListDelegateEditor::paintLabels(QPainter* painter, const QStyleOptionVi
         if (model->isFirstPinnedNote(index)) {
             QRect headerRect(rowPosX + NoteListConstant::leftOffsetX, rowPosY,
                              rowWidth - NoteListConstant::leftOffsetX, 25);
-            if (view && view->isPinnedNotesCollapsed()) {
+            if (m_view->isPinnedNotesCollapsed()) {
                 painter->drawImage(QRect(headerRect.right() - 25,
                                               headerRect.y() + 2,
                                               20, 20), m_pinnedCollapseIcon);
@@ -309,7 +306,7 @@ void NoteListDelegateEditor::paintLabels(QPainter* painter, const QStyleOptionVi
             rowPosY += 25;
         }
     }
-    if (view && view->isPinnedNotesCollapsed()) {
+    if (m_view->isPinnedNotesCollapsed()) {
         auto isPinned = index.data(NoteListModel::NoteIsPinned).value<bool>();
         if (isPinned) {
             return;
@@ -458,7 +455,7 @@ void NoteListDelegateEditor::resizeEvent(QResizeEvent *event)
                 fouthYOffset = NoteListConstant::unpinnedHeaderToNoteSpace;
             }
             int fifthYOffset = 0;
-            if (model && model->hasPinnedNote() && !dynamic_cast<NoteListView*>(m_view)->isPinnedNotesCollapsed()
+            if (model && model->hasPinnedNote() && !m_view->isPinnedNotesCollapsed()
                     && model->isFirstUnpinnedNote(m_index)) {
                 fifthYOffset = NoteListConstant::lastPinnedToUnpinnedHeader;
             }
@@ -481,7 +478,7 @@ void NoteListDelegateEditor::resizeEvent(QResizeEvent *event)
                 fouthYOffset = NoteListConstant::unpinnedHeaderToNoteSpace;
             }
             int fifthYOffset = 0;
-            if (model && model->hasPinnedNote() && !dynamic_cast<NoteListView*>(m_view)->isPinnedNotesCollapsed()
+            if (model && model->hasPinnedNote() && !m_view->isPinnedNotesCollapsed()
                     && model->isFirstUnpinnedNote(m_index)) {
                 fifthYOffset = NoteListConstant::lastPinnedToUnpinnedHeader;
             }
@@ -551,8 +548,7 @@ void NoteListDelegateEditor::recalculateSize()
                 (model->isFirstPinnedNote(m_index) || model->isFirstUnpinnedNote(m_index))) {
             result.setHeight(result.height() + 25);
         }
-        auto view = dynamic_cast<NoteListView*>(m_view);
-        if (view && model->hasPinnedNote() && view->isPinnedNotesCollapsed()) {
+        if (model->hasPinnedNote() && m_view->isPinnedNotesCollapsed()) {
             auto isPinned = m_index.data(NoteListModel::NoteIsPinned).value<bool>();
             if (isPinned) {
                 if (model->isFirstPinnedNote(m_index)) {
@@ -578,7 +574,7 @@ void NoteListDelegateEditor::recalculateSize()
         }
 
         int fifthYOffset = 0;
-        if (model && model->hasPinnedNote() && !dynamic_cast<NoteListView*>(m_view)->isPinnedNotesCollapsed()
+        if (model && model->hasPinnedNote() && !m_view->isPinnedNotesCollapsed()
                 && model->isFirstUnpinnedNote(m_index)) {
             fifthYOffset = NoteListConstant::lastPinnedToUnpinnedHeader;
         }

--- a/src/notelistdelegateeditor.h
+++ b/src/notelistdelegateeditor.h
@@ -28,7 +28,7 @@ class NoteListDelegateEditor : public QWidget
     Q_OBJECT
 public:
     explicit NoteListDelegateEditor(const NoteListDelegate* delegate,
-                                    QListView *view,
+                                    NoteListView *view,
                                     const QStyleOptionViewItem &option,
                                     const QModelIndex &index,
                                     TagPool *tagPool,
@@ -58,7 +58,7 @@ private:
     const NoteListDelegate* m_delegate;
     QStyleOptionViewItem m_option;
     int m_id;
-    QListView *m_view;
+    NoteListView *m_view;
 
     TagPool* m_tagPool;
     QString m_displayFont;

--- a/src/notelistview.cpp
+++ b/src/notelistview.cpp
@@ -38,7 +38,7 @@ NoteListView::NoteListView(QWidget *parent)
       m_isPinnedNotesCollapsed{false},
       m_isDraggingInsidePinned{false}
 {
-    this->setAttribute(Qt::WA_MacShowFocusRect, 0);
+    setAttribute(Qt::WA_MacShowFocusRect, false);
 
     QTimer::singleShot(0, this, SLOT(init()));
     setContextMenuPolicy(Qt::CustomContextMenu);
@@ -80,6 +80,8 @@ NoteListView::NoteListView(QWidget *parent)
 
 NoteListView::~NoteListView()
 {
+    // Make sure any editors are closed before the view is destroyed
+    closeAllEditor();
 }
 
 void NoteListView::animateAddedRow(const QModelIndexList& indexes)


### PR DESCRIPTION
This change makes sure that any `NoteListDelegateEditor` instances are deleted before their `NoteListView` is destroyed. Previously, such instances could get destroyed after the `NoteListDelegateEditor` destructor, at which point the call to `unsetEditorWidget` would crash.

At the same time, it was also necessary to make sure the `NoteListModel` outlives the `NoteListView`, since the model is being used by `NoteListView::closeAllEditor`.

Changed `m_view` in `NoteListDelegateEditor` from `QListView*` to `NoteListView*`, which allowed getting rid of many instances of `dynamic_cast`.