### PR TITLE
More CI fixes

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -7,21 +7,41 @@ jobs:
   # So it doesn't make much sense to have different build types other than 'debug' here.
   # The release AppImage is built using aqtinstall instead (the job below this one).
   build-apt:
-    name: Build (${{ matrix.build-type }}, apt, ${{ matrix.os }})
+    name: Build (${{ matrix.build-type }}, apt, ${{ matrix.container != '' && matrix.container || matrix.os }})
     runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container }}
     strategy:
       fail-fast: false
       matrix:
-        build-type:
-          - debug
-        # NOTE: Ubuntu 18.04 is deprecated and will be removed by GitHub in April, 2023.
-        # Source: https://github.com/actions/runner-images/issues/6002#issuecomment-1251883705
-        #
-        # TODO: Replace 'ubuntu-18.04' by 'ubuntu-20.04' when the time comes.
-        os:
-          - ubuntu-18.04
-          - ubuntu-latest
+        include:
+          - os: ubuntu-20.04
+            # TODO: Replace 'ubuntu:18.04' by 'ubuntu:20.04' when:
+            # - Ubuntu 18.04 officially reaches EOL (scheduled to April, 2023 - https://wiki.ubuntu.com/Releases)
+            # - A new build of linuxdeployqt allows us to build on Ubuntu 20.04, without having to use -unsupported-allow-new-glibc.
+            container: ubuntu:18.04
+            build-type: debug
+          - os: ubuntu-latest
+            build-type: debug
     steps:
+      - name: Install newer git in docker container
+        # A more recent version of git is required by the checkout action: https://github.com/actions/checkout/issues/758
+        # TODO: Once we upgrade to Ubuntu 20.04, remove this and install git normally through apt.
+        if: matrix.container != ''
+        run: |
+          apt update
+          apt install -y ca-certificates curl gnupg
+          # Add the git PPA manually (https://launchpad.net/~git-core/+archive/ubuntu/ppa), because 'add-apt-repository' pulls a bunch of unnecessary dependencies.
+          curl -fL --retry 10 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xE1DD270288B4E6030699E45FA1715D88E1DF1F24' | gpg --dearmor > /etc/apt/trusted.gpg.d/git.gpg
+          echo 'deb https://ppa.launchpadcontent.net/git-core/ppa/ubuntu bionic main' > /etc/apt/sources.list.d/git.list
+          apt update
+          apt install -y git
+
+      - name: Install other dependencies in docker container
+        # - sudo: Used by most GitHub actions to install things.
+        if: matrix.container != ''
+        run: |
+          apt install -y sudo
+
       - name: Checkout code
         uses: actions/checkout@v3
         with:
@@ -40,30 +60,54 @@ jobs:
           qmake -config ${{ matrix.build-type }} ../src/Notes.pro
           make -j$(nproc)
 
-  # Build the AppImage using the official Qt 5 release downloaded by aqtinstall.
+  # Build the AppImage using official Qt releases, downloaded by aqtinstall.
   # This is also done for macOS and Windows, just to make sure we use the exact same Qt version across all three OSes.
   #
   # NOTE: This job uses a fixed Qt version (set in the 'qt-version' key below)!
   # So, remember to keep it updated whenever a new Qt version is available on aqtinstall.
   appimage-aqtinstall:
-    name: AppImage (${{ matrix.build-type }}, Qt ${{ matrix.qt-version }}, ${{ matrix.os }})
+    name: AppImage (${{ matrix.build-type }}, Qt ${{ matrix.qt-version }}, ${{ matrix.container != '' && matrix.container || matrix.os }})
     runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container }}
     strategy:
       matrix:
-        # If you want build artifacts with debug symbols, just add 'debug' to the 'build-type' key below.
-        build-type:
-          - release
-        os:
-          - ubuntu-18.04
-        qt-version:
-          - 5.15.2
+        include:
+          - os: ubuntu-20.04
+            container: ubuntu:18.04
+            build-type: release
+            qt-version: 5.15.2
     steps:
+      - name: Install newer git in docker container
+        # A more recent version of git is required by the checkout action: https://github.com/actions/checkout/issues/758
+        # TODO: Once we upgrade to Ubuntu 20.04, remove this and install git normally through apt.
+        if: matrix.container != ''
+        run: |
+          apt update
+          apt install -y ca-certificates curl gnupg
+          # Add the git PPA manually (https://launchpad.net/~git-core/+archive/ubuntu/ppa), because 'add-apt-repository' pulls a bunch of unnecessary dependencies.
+          curl -fL --retry 10 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xE1DD270288B4E6030699E45FA1715D88E1DF1F24' | gpg --dearmor > /etc/apt/trusted.gpg.d/git.gpg
+          echo 'deb https://ppa.launchpadcontent.net/git-core/ppa/ubuntu bionic main' > /etc/apt/sources.list.d/git.list
+          apt update
+          apt install -y git
+
+      - name: Install other dependencies in docker container
+        # - curl: Used to download the linuxdeployqt AppImage tool.
+        # - libfontconfig1: Used as dependency of the resulting AppImage.
+        # - python3/python3-pip: Used by aqtinstall.
+        # - sudo: Used by most GitHub actions to install things.
+        if: matrix.container != ''
+        run: |
+          apt install -y libfontconfig1 python3 python3-pip sudo
+          # Upgrade to the latest setuptools, as Ubuntu's python3-setuptools package has compatibility issues with aqtinstall.
+          python3 -m pip install --upgrade setuptools
+
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           submodules: recursive
 
       - name: Update version
+        shell: bash
         run: |
           sed -i.bak "/^VERSION *=/ s/$/-g${GITHUB_SHA::7}/" src/Notes.pro
 
@@ -81,6 +125,8 @@ jobs:
         uses: jurplel/install-qt-action@v3
         with:
           version: ${{ matrix.qt-version }}
+          # Prevents the installation of a custom Python build, potentially linked against an unsupported version of glibc.
+          setup-python: false
           cache: true
 
       - name: Build (${{ matrix.build-type }})
@@ -94,17 +140,25 @@ jobs:
         if: matrix.build-type == 'release'
         run: strip -s build/notes
 
+      - name: Setup linuxdeployqt tool
+        run: |
+          cd build
+          curl -fL --retry 10 https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage -o linuxdeployqt.AppImage
+          chmod +x linuxdeployqt.AppImage
+          # Extract the AppImage before running it, as we might not have FUSE setup.
+          # https://github.com/AppImage/AppImageKit/wiki/FUSE
+          ./linuxdeployqt.AppImage --appimage-extract
+          mv squashfs-root linuxdeployqt
+
       - name: Build AppImage (${{ matrix.build-type }})
         run: |
           cd build
-          curl -LO https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage --retry 3 --retry-delay 20
-          chmod +x linuxdeployqt*
           install -Dm755 -t Notes/usr/bin notes
           install -Dm755 -t Notes/usr/share/applications ../packaging/linux/common/notes.desktop
           mkdir -p Notes/usr/share/icons/hicolor
           cp -r ../packaging/linux/common/icons/* Notes/usr/share/icons/hicolor
           export VERSION='${{ steps.vars.outputs.version }}'
-          ./linuxdeployqt* Notes/usr/share/applications/notes.desktop -appimage -exclude-libs=libqsqlibase,libqsqlodbc,libqsqlpsql,libqsqltds
+          ./linuxdeployqt/AppRun Notes/usr/share/applications/notes.desktop -appimage -exclude-libs=libqsqlibase,libqsqlodbc,libqsqlpsql,libqsqltds
           mv Notes*.AppImage '${{ steps.vars.outputs.file_name }}'
 
       - name: Upload AppImage artifact (${{ matrix.build-type }})

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -73,9 +73,9 @@ jobs:
           version=$(grep -m 1 VERSION src/Notes.pro | sed 's/^VERSION *= *//')
           artifact_name="Notes_${version}-x86_64"
           file_name="$artifact_name${{ matrix.build-type == 'debug' && '-debug.' || '.' }}AppImage"
-          echo "::set-output name=version::$version"
-          echo "::set-output name=artifact_name::$artifact_name"
-          echo "::set-output name=file_name::$file_name"
+          echo "version=$version" >> $GITHUB_OUTPUT
+          echo "artifact_name=$artifact_name" >> $GITHUB_OUTPUT
+          echo "file_name=$file_name" >> $GITHUB_OUTPUT
 
       - name: Install Qt ${{ matrix.qt-version }} (aqtinstall)
         uses: jurplel/install-qt-action@v3

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,7 +1,9 @@
 name: Linux
-on: [ push, pull_request ]
+on:
+  push:
+  pull_request:
 jobs:
-  # This job is mainly to make sure Notes will compile with Qt 5 from Ubuntu's repository.
+  # This job is mainly to make sure Notes will compile with Qt from Ubuntu's repository.
   # So it doesn't make much sense to have different build types other than 'debug' here.
   # The release AppImage is built using aqtinstall instead (the job below this one).
   build-apt:
@@ -10,12 +12,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build-type: [ debug ]
+        build-type:
+          - debug
         # NOTE: Ubuntu 18.04 is deprecated and will be removed by GitHub in April, 2023.
         # Source: https://github.com/actions/runner-images/issues/6002#issuecomment-1251883705
         #
         # TODO: Replace 'ubuntu-18.04' by 'ubuntu-20.04' when the time comes.
-        os: [ ubuntu-18.04, ubuntu-latest ]
+        os:
+          - ubuntu-18.04
+          - ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -25,7 +30,7 @@ jobs:
       - name: Install Qt 5 (apt)
         run: |
           sudo apt update
-          sudo apt install qtbase5-private-dev qttools5-dev-tools
+          sudo apt install -y qtbase5-private-dev qttools5-dev-tools
 
       - name: Build (${{ matrix.build-type }})
         run: |
@@ -46,9 +51,12 @@ jobs:
     strategy:
       matrix:
         # If you want build artifacts with debug symbols, just add 'debug' to the 'build-type' key below.
-        build-type: [ release ]
-        os: [ ubuntu-18.04 ]
-        qt-version: [ 5.15.2 ]
+        build-type:
+          - release
+        os:
+          - ubuntu-18.04
+        qt-version:
+          - 5.15.2
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -52,6 +52,10 @@ jobs:
           sudo apt update
           sudo apt install -y qtbase5-private-dev qttools5-dev-tools
 
+      - name: Setup GCC problem matcher
+        if: matrix.build-type == 'debug'
+        uses: ammaraskar/gcc-problem-matcher@0.2.0
+
       - name: Build (${{ matrix.build-type }})
         run: |
           mkdir build

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,7 +1,9 @@
 name: macOS
-on: [ push, pull_request ]
+on:
+  push:
+  pull_request:
 jobs:
-  # This job is mainly to make sure Notes will compile with Qt 5 from homebrew's repository.
+  # This job is mainly to make sure Notes will compile with Qt from homebrew's repository.
   # So it doesn't make much sense to have different build types other than 'debug' here.
   # The release dmg is built using aqtinstall instead (the job below this one).
   build-homebrew:
@@ -10,8 +12,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build-type: [ debug ]
-        os: [ macos-11 ]
+        build-type:
+          - debug
+        os:
+          - macos-11
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -58,9 +62,12 @@ jobs:
     strategy:
       matrix:
         # If you want build artifacts with debug symbols, just add 'debug' to the 'build-type' key below.
-        build-type: [ release ]
-        os: [ macos-11 ]
-        qt-version: [ 5.15.2 ]
+        build-type:
+          - release
+        os:
+          - macos-11
+        qt-version:
+          - 5.15.2
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -44,6 +44,11 @@ jobs:
           export PATH="/usr/local/opt/qt@5/bin:$PATH"
           EOF >> ~/.bashrc
 
+      - name: Setup CLang problem matcher
+        # Technically, this action only supports GCC, but it seems to work well for Clang too.
+        if: matrix.build-type == 'debug'
+        uses: ammaraskar/gcc-problem-matcher@0.2.0
+
       - name: Build (${{ matrix.build-type }})
         run: |
           mkdir build

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -84,9 +84,9 @@ jobs:
           version=$(grep -m 1 VERSION src/Notes.pro | sed 's/^VERSION *= *//')
           artifact_name="Notes_${version}-x86_64"
           file_name="$artifact_name${{ matrix.build-type == 'debug' && '-debug.' || '.' }}dmg"
-          echo "::set-output name=version::$version"
-          echo "::set-output name=artifact_name::$artifact_name"
-          echo "::set-output name=file_name::$file_name"
+          echo "version=$version" >> $GITHUB_OUTPUT
+          echo "artifact_name=$artifact_name" >> $GITHUB_OUTPUT
+          echo "file_name=$file_name" >> $GITHUB_OUTPUT
 
       - name: Install Qt ${{ matrix.qt-version }} (aqtinstall)
         uses: jurplel/install-qt-action@v3

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,5 +1,7 @@
 name: Windows
-on: [ push, pull_request ]
+on:
+  push:
+  pull_request:
 jobs:
   # NOTE: This job uses a fixed Qt version (set in the 'qt-version' key below)!
   # So, remember to keep it updated whenever a new Qt version is available on aqtinstall.
@@ -9,11 +11,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [ x64, x86 ]
+        arch:
+          - x64
+          - x86
         # If you want build artifacts with debug symbols, just add 'debug' to the 'build-type' key below.
-        build-type: [ release ]
-        os: [ windows-2019 ]
-        qt-version: [ 5.15.2 ]
+        build-type:
+          - release
+        os:
+          - windows-2019
+        qt-version:
+          - 5.15.2
     outputs:
       version: ${{ steps.vars.outputs.version }}
     steps:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -38,8 +38,8 @@ jobs:
         run: |
           $version = Select-String -Path src\Notes.pro -Pattern '^VERSION *= *(.+)$' | %{$_.Matches.Groups[1].value}
           $artifact_name = "Notes_$version-${{ matrix.arch }}"
-          Write-Output "::set-output name=version::$version"
-          Write-Output "::set-output name=artifact_name::$artifact_name"
+          Write-Output "version=$version" >> $env:GITHUB_OUTPUT
+          Write-Output "artifact_name=$artifact_name" >> $env:GITHUB_OUTPUT
 
       - name: Setup MSVC (${{ matrix.arch }})
         uses: ilammy/msvc-dev-cmd@v1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -54,6 +54,9 @@ jobs:
           arch: ${{ matrix.arch == 'x86' && 'win32_msvc2019' || 'win64_msvc2019_64' }}
           tools: tools_openssl_${{ matrix.arch }}
 
+      - name: Setup MSVC problem matcher
+        uses: ammaraskar/msvc-problem-matcher@0.2.0
+
       - name: Build (${{ matrix.build-type }}, ${{ matrix.arch }})
         run: |
           New-Item build -ItemType Directory


### PR DESCRIPTION
More details in the commit's description.

Highlights:

- Fix [deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) `::set-output` command:
    ![image](https://user-images.githubusercontent.com/626206/196569150-e4f0ea08-b8ac-47ae-955e-55a5992e4de7.png)

- Introduce [problem matching](https://github.com/actions/toolkit/blob/main/docs/problem-matchers.md) for GCC, MSVC and Clang, which is especially helpful on PRs:
    ![image](https://user-images.githubusercontent.com/626206/196569277-d6b2f3da-6eb4-4f73-98ce-5d3a307a5df7.png)

And last, but not least:

Fixes #404 by building Notes within a Docker container image of Ubuntu 18.04, instead of using GitHub's official one.