### PR TITLE
Add .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,108 @@
+# Copyright (C) 2016 Olivier Goffart <ogoffart@woboq.com>
+#
+# You may use this file under the terms of the 3-clause BSD license.
+# See the file LICENSE from this package for details.
+
+# This is the clang-format configuration style to be used by Qt,
+# based on the rules from https://wiki.qt.io/Qt_Coding_Style and
+# https://wiki.qt.io/Coding_Conventions
+
+---
+# Webkit style was loosely based on the Qt style
+BasedOnStyle: WebKit
+
+Standard: c++17
+
+# Column width is limited to 100 in accordance with Qt Coding Style.
+# https://wiki.qt.io/Qt_Coding_Style
+# Note that this may be changed at some point in the future.
+ColumnLimit: 100
+# How much weight do extra characters after the line length limit have.
+# PenaltyExcessCharacter: 4
+
+# Disable reflow of some specific comments
+# qdoc comments: indentation rules are different.
+# Translation comments and SPDX license identifiers are also excluded.
+CommentPragmas: "^!|^:|^ SPDX-License-Identifier:"
+
+# We want a space between the type and the star for pointer types.
+PointerBindsToType: false
+
+# We use template< without space.
+SpaceAfterTemplateKeyword: false
+
+# We want to break before the operators, but not before a '='.
+BreakBeforeBinaryOperators: NonAssignment
+
+# Braces are usually attached, but not after functions or class declarations.
+BreakBeforeBraces: Custom
+BraceWrapping:
+    AfterClass: true
+    AfterControlStatement: false
+    AfterEnum: false
+    AfterFunction: true
+    AfterNamespace: false
+    AfterObjCDeclaration: false
+    AfterStruct: true
+    AfterUnion: false
+    BeforeCatch: false
+    BeforeElse: false
+    IndentBraces: false
+
+# When constructor initializers do not fit on one line, put them each on a new line.
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+# Indent initializers by 4 spaces
+ConstructorInitializerIndentWidth: 4
+
+# Indent width for line continuations.
+ContinuationIndentWidth: 8
+
+# No indentation for namespaces.
+NamespaceIndentation: None
+
+# Allow indentation for preprocessing directives (if/ifdef/endif). https://reviews.llvm.org/rL312125
+IndentPPDirectives: AfterHash
+# We only indent with 2 spaces for preprocessor directives
+PPIndentWidth: 2
+
+# Horizontally align arguments after an open bracket.
+# The coding style does not specify the following, but this is what gives
+# results closest to the existing code.
+AlignAfterOpenBracket: true
+AlwaysBreakTemplateDeclarations: true
+
+# Ideally we should also allow less short function in a single line, but
+# clang-format does not handle that.
+AllowShortFunctionsOnASingleLine: Inline
+
+# The coding style specifies some include order categories, but also tells to
+# separate categories with an empty line. It does not specify the order within
+# the categories. Since the SortInclude feature of clang-format does not
+# re-order includes separated by empty lines, the feature is not used.
+SortIncludes: false
+
+# macros for which the opening brace stays attached.
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH, forever, Q_FOREVER, QBENCHMARK, QBENCHMARK_ONCE ]
+
+# Break constructor initializers before the colon and after the commas.
+BreakConstructorInitializers: BeforeColon
+
+# Add "// namespace <namespace>" comments on closing brace for a namespace
+# Ignored for namespaces that qualify as a short namespace,
+# see 'ShortNamespaceLines'
+FixNamespaceComments: true
+
+# Definition of how short a short namespace is, default 1
+ShortNamespaceLines: 1
+
+# When escaping newlines in a macro attach the '\' as far left as possible, e.g.
+##define a     \
+#   something; \
+#   other;     \
+#   thelastlineislong;
+AlignEscapedNewlines: Left
+
+# Avoids the addition of a space between an identifier and the
+# initializer list in list-initialization.
+SpaceBeforeCpp11BracedList: false
+

--- a/src/aboutwindow.cpp
+++ b/src/aboutwindow.cpp
@@ -6,22 +6,38 @@
 /**
  * Initializes the window components and configures the AboutWindow
  */
-AboutWindow::AboutWindow(QWidget *parent) :
-    QWidget(parent),
-    m_ui(new Ui::AboutWindow)
+AboutWindow::AboutWindow(QWidget *parent) : QWidget(parent), m_ui(new Ui::AboutWindow)
 {
     m_ui->setupUi(this);
     this->setWindowFlags(Qt::Window);
     setWindowTitle(tr("About") + " " + qApp->applicationName());
 
-    m_ui->aboutText->setText("<p>Notes was founded by <a href='https://rubymamistvalove.com'>Ruby Mamistvalove</a>, to create an elegant yet powerful cross-platform and open-source note-taking app.</p><a href='https://github.com/nuttyartist/notes'>Source code on Github</a>.<br/><br/><strong>Acknowledgments</strong><br/>This project couldn't have come this far without the help of these amazing people:<br/><br/><strong>Programmers:</strong><br/>Diep Ngoc<br/>Ali Diouri<br/>Thorbjørn Lindeijer<br/>Waqar Ahmed<br/>Alex Spataru<br/>David Planella<br/><br/><strong>Designers:</strong><br/>Kevin Doyle<br/><br/>And to the many of our beloved users who keep sending us feedback, you are an essential force in helping us improve, thank you!<br/><br/><strong>Notes makes use of the following third-party libraries:</strong><br/><br/>QMarkdownTextEdit<br/>QSimpleUpdater<br/>QAutostart<br/>QXT<br/><br/><strong>Notes makes use of the following open source fonts:</strong><br/><br/>Roboto<br/>Source Sans Pro<br/>Trykker<br/>Mate<br/>iA Writer Mono<br/>iA Writer Duo<br/>iA Writer Quattro<br/>");
+    m_ui->aboutText->setText(
+            "<p>Notes was founded by <a href='https://rubymamistvalove.com'>Ruby Mamistvalove</a>, "
+            "to create an elegant yet powerful cross-platform and open-source note-taking "
+            "app.</p><a href='https://github.com/nuttyartist/notes'>Source code on "
+            "Github</a>.<br/><br/><strong>Acknowledgments</strong><br/>This project couldn't have "
+            "come this far without the help of these amazing "
+            "people:<br/><br/><strong>Programmers:</strong><br/>Diep Ngoc<br/>Ali "
+            "Diouri<br/>Thorbjørn Lindeijer<br/>Waqar Ahmed<br/>Alex Spataru<br/>David "
+            "Planella<br/><br/><strong>Designers:</strong><br/>Kevin Doyle<br/><br/>And to the "
+            "many of our beloved users who keep sending us feedback, you are an essential force in "
+            "helping us improve, thank you!<br/><br/><strong>Notes makes use of the following "
+            "third-party "
+            "libraries:</strong><br/><br/>QMarkdownTextEdit<br/>QSimpleUpdater<br/>QAutostart<br/"
+            ">QXT<br/><br/><strong>Notes makes use of the following open source "
+            "fonts:</strong><br/><br/>Roboto<br/>Source Sans Pro<br/>Trykker<br/>Mate<br/>iA "
+            "Writer Mono<br/>iA Writer Duo<br/>iA Writer Quattro<br/>");
     m_ui->aboutText->setTextColor(QColor(26, 26, 26));
 
 #ifdef __APPLE__
-    QFont fontToUse = QFont(QStringLiteral("SF Pro Text")).exactMatch() ? QStringLiteral("SF Pro Text") : QStringLiteral("Roboto");
+    QFont fontToUse = QFont(QStringLiteral("SF Pro Text")).exactMatch()
+            ? QStringLiteral("SF Pro Text")
+            : QStringLiteral("Roboto");
     m_ui->aboutText->setFont(fontToUse);
 #elif _WIN32
-    QFont fontToUse = QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI") : QStringLiteral("Roboto");
+    QFont fontToUse = QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI")
+                                                                     : QStringLiteral("Roboto");
     m_ui->aboutText->setFont(fontToUse);
 #else
     m_ui->aboutText->setFont(QFont(QStringLiteral("Roboto")));
@@ -37,9 +53,9 @@ AboutWindow::~AboutWindow()
 void AboutWindow::setTheme(QColor backgroundColor, QColor textColor)
 {
     QString ss = "QTextBrowser { "
-        "background-color: %1;"
-        "color: %2;"
-        "}";
+                 "background-color: %1;"
+                 "color: %2;"
+                 "}";
 
     ss = ss.arg(backgroundColor.name(), textColor.name());
     m_ui->aboutText->setStyleSheet(ss);

--- a/src/aboutwindow.h
+++ b/src/aboutwindow.h
@@ -12,19 +12,17 @@ class AboutWindow : public QWidget
     Q_OBJECT
 
 public:
-    explicit AboutWindow (QWidget *parent = 0);
+    explicit AboutWindow(QWidget *parent = 0);
     ~AboutWindow();
     void setTheme(QColor backgroundColor, QColor textColor);
 
 public slots:
-
 
 signals:
 
 private slots:
 
 protected:
-
 private:
     Ui::AboutWindow *m_ui;
 };

--- a/src/allnotebuttontreedelegateeditor.cpp
+++ b/src/allnotebuttontreedelegateeditor.cpp
@@ -5,38 +5,41 @@
 #include "nodetreemodel.h"
 #include "nodetreeview.h"
 
-AllNoteButtonTreeDelegateEditor::AllNoteButtonTreeDelegateEditor(QTreeView *view, const QStyleOptionViewItem &option,
+AllNoteButtonTreeDelegateEditor::AllNoteButtonTreeDelegateEditor(QTreeView *view,
+                                                                 const QStyleOptionViewItem &option,
                                                                  const QModelIndex &m_index,
-                                                                 QWidget *parent) :
-    QWidget(parent),
-    m_option(option),
-    m_index(m_index),
-    #ifdef __APPLE__
-    m_displayFont(QFont(QStringLiteral("SF Pro Text")).exactMatch() ? QStringLiteral("SF Pro Text") : QStringLiteral("Roboto")),
-    #elif _WIN32
-    m_displayFont(QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI") : QStringLiteral("Roboto")),
-    #else
-    m_displayFont(QStringLiteral("Roboto")),
-    #endif
-    #ifdef __APPLE__
-	m_titleFont(m_displayFont, 13, QFont::DemiBold),
-    #else
-	m_titleFont(m_displayFont, 10, QFont::DemiBold),
-    #endif
-    m_titleColor(26, 26, 26),
-    m_titleSelectedColor(255, 255, 255),
-    m_activeColor(68, 138, 201),
-    m_hoverColor(207, 207, 207),
-    m_view(view)
+                                                                 QWidget *parent)
+    : QWidget(parent),
+      m_option(option),
+      m_index(m_index),
+#ifdef __APPLE__
+      m_displayFont(QFont(QStringLiteral("SF Pro Text")).exactMatch()
+                            ? QStringLiteral("SF Pro Text")
+                            : QStringLiteral("Roboto")),
+#elif _WIN32
+      m_displayFont(QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI")
+                                                                   : QStringLiteral("Roboto")),
+#else
+      m_displayFont(QStringLiteral("Roboto")),
+#endif
+#ifdef __APPLE__
+      m_titleFont(m_displayFont, 13, QFont::DemiBold),
+#else
+      m_titleFont(m_displayFont, 10, QFont::DemiBold),
+#endif
+      m_titleColor(26, 26, 26),
+      m_titleSelectedColor(255, 255, 255),
+      m_activeColor(68, 138, 201),
+      m_hoverColor(207, 207, 207),
+      m_view(view)
 {
     setContentsMargins(0, 0, 0, 0);
 }
 
-
 void AllNoteButtonTreeDelegateEditor::paintEvent(QPaintEvent *event)
 {
     QPainter painter(this);
-	auto iconRect = QRect(rect().x() + 5, rect().y() + (rect().height() - 20) / 2, 18, 20);
+    auto iconRect = QRect(rect().x() + 5, rect().y() + (rect().height() - 20) / 2, 18, 20);
     auto iconPath = m_index.data(NodeItem::Roles::Icon).toString();
     auto displayName = m_index.data(NodeItem::Roles::DisplayText).toString();
     QRect nameRect(rect());
@@ -62,6 +65,7 @@ void AllNoteButtonTreeDelegateEditor::paintEvent(QPaintEvent *event)
         painter.setPen(m_titleColor);
     }
     painter.setFont(m_titleFont);
-    painter.drawText(childCountRect, Qt::AlignHCenter | Qt::AlignVCenter, QString::number(childCount));
+    painter.drawText(childCountRect, Qt::AlignHCenter | Qt::AlignVCenter,
+                     QString::number(childCount));
     QWidget::paintEvent(event);
 }

--- a/src/allnotebuttontreedelegateeditor.h
+++ b/src/allnotebuttontreedelegateeditor.h
@@ -12,10 +12,8 @@ class AllNoteButtonTreeDelegateEditor : public QWidget
 {
     Q_OBJECT
 public:
-    explicit AllNoteButtonTreeDelegateEditor(QTreeView *view,
-                                       const QStyleOptionViewItem &option,
-                                      const QModelIndex &index,
-                                      QWidget *parent = nullptr);
+    explicit AllNoteButtonTreeDelegateEditor(QTreeView *view, const QStyleOptionViewItem &option,
+                                             const QModelIndex &index, QWidget *parent = nullptr);
 
 private:
     QStyleOptionViewItem m_option;

--- a/src/customapplicationstyle.cpp
+++ b/src/customapplicationstyle.cpp
@@ -2,18 +2,18 @@
 #include <QPainter>
 #include <QStyleOption>
 
-void CustomApplicationStyle::drawPrimitive(PrimitiveElement element, const QStyleOption *option, QPainter *painter, const QWidget *widget) const
+void CustomApplicationStyle::drawPrimitive(PrimitiveElement element, const QStyleOption *option,
+                                           QPainter *painter, const QWidget *widget) const
 {
-    if(element == QStyle::PE_IndicatorItemViewItemDrop)
-    {
+    if (element == QStyle::PE_IndicatorItemViewItemDrop) {
         painter->setRenderHint(QPainter::Antialiasing, true);
 
         QColor c;
-//        if (m_theme == Theme::Dark) {
-//            c = QColor(15, 45, 90);
-//        } else {
-            c = QColor(207, 207, 207);
-//        }
+        //        if (m_theme == Theme::Dark) {
+        //            c = QColor(15, 45, 90);
+        //        } else {
+        c = QColor(207, 207, 207);
+        //        }
         QPen pen(c);
         pen.setWidth(2);
         c.setAlpha(50);
@@ -21,7 +21,7 @@ void CustomApplicationStyle::drawPrimitive(PrimitiveElement element, const QStyl
 
         painter->setPen(pen);
         painter->setBrush(brush);
-        if(option->rect.height() == 0) {
+        if (option->rect.height() == 0) {
             painter->drawLine(option->rect.topLeft(), option->rect.topRight());
         } else {
             c.setAlpha(200);
@@ -38,5 +38,4 @@ void CustomApplicationStyle::setTheme(Theme newTheme)
     m_theme = newTheme;
 }
 
-CustomApplicationStyle::CustomApplicationStyle() : m_theme(Theme::Light)
-{}
+CustomApplicationStyle::CustomApplicationStyle() : m_theme(Theme::Light) { }

--- a/src/customapplicationstyle.h
+++ b/src/customapplicationstyle.h
@@ -9,7 +9,8 @@ class CustomApplicationStyle : public QProxyStyle
 public:
     CustomApplicationStyle();
 
-    void drawPrimitive(PrimitiveElement element, const QStyleOption *option, QPainter *painter, const QWidget *widget) const;
+    void drawPrimitive(PrimitiveElement element, const QStyleOption *option, QPainter *painter,
+                       const QWidget *widget) const;
     void setTheme(Theme newTheme);
 
 private:

--- a/src/customdocument.cpp
+++ b/src/customdocument.cpp
@@ -1,11 +1,7 @@
 #include "customDocument.h"
 #include <QDebug>
 
-CustomDocument::CustomDocument(QWidget *parent)
-    : QTextEdit(parent)
-{
-
-}
+CustomDocument::CustomDocument(QWidget *parent) : QTextEdit(parent) { }
 
 /*!
  * \brief CustomDocument::setDocumentPadding

--- a/src/dbmanager.h
+++ b/src/dbmanager.h
@@ -10,12 +10,14 @@
 #include <QSet>
 #include <QVector>
 
-struct NodeTagTreeData {
+struct NodeTagTreeData
+{
     QVector<NodeData> nodeTreeData;
     QVector<TagData> tagTreeData;
 };
 
-struct ListViewInfo {
+struct ListViewInfo
+{
     bool isInSearch;
     bool isInTag;
     QSet<int> currentTagList;
@@ -34,14 +36,14 @@ public:
     explicit DBManager(QObject *parent = Q_NULLPTR);
     Q_INVOKABLE NodePath getNodeAbsolutePath(int nodeId);
     Q_INVOKABLE NodeData getNode(int nodeId);
-    Q_INVOKABLE void moveFolderToTrash(const NodeData& node);
+    Q_INVOKABLE void moveFolderToTrash(const NodeData &node);
     Q_INVOKABLE FolderListType getFolderList();
 
 private:
-    void open(const QString& path, bool doCreate = false);
+    void open(const QString &path, bool doCreate = false);
     void createTables();
 
-    bool isNodeExist(const NodeData& node);
+    bool isNodeExist(const NodeData &node);
     QString m_dbpath;
     QSqlDatabase m_db;
 
@@ -51,7 +53,7 @@ private:
     bool updateNoteContent(const NodeData &note);
     QList<NodeData> readOldNBK(const QString &fileName);
     int nextAvailablePosition(int parentId, NodeData::Type nodeType);
-    int addNodePreComputed(const NodeData& node);
+    int addNodePreComputed(const NodeData &node);
     void recalculateChildNotesCount();
     void recalculateChildNotesCountFolder(int folderId);
     void recalculateChildNotesCountTag(int tagId);
@@ -62,48 +64,48 @@ private:
     void decreaseChildNotesCountFolder(int folderId);
 
 signals:
-    void notesListReceived(const QVector<NodeData>& noteList, const ListViewInfo& inf);
-    void nodesTagTreeReceived(const NodeTagTreeData& treeData);
+    void notesListReceived(const QVector<NodeData> &noteList, const ListViewInfo &inf);
+    void nodesTagTreeReceived(const NodeTagTreeData &treeData);
 
-    void tagAdded(const TagData& tag);
+    void tagAdded(const TagData &tag);
     void tagRemoved(int tagId);
-    void tagRenamed(int tagId, const QString& newName);
-    void tagColorChanged(int tagId, const QString& tagColor);
-    void showErrorMessage(const QString& title, const QString& content);
+    void tagRenamed(int tagId, const QString &newName);
+    void tagColorChanged(int tagId, const QString &tagColor);
+    void showErrorMessage(const QString &title, const QString &content);
     void childNotesCountUpdatedTag(int tagId, int childCount);
-    void childNotesCountUpdatedFolder(int folderId, const QString& path, int childCount);
+    void childNotesCountUpdatedFolder(int folderId, const QString &path, int childCount);
 
 public slots:
     void onNodeTagTreeRequested();
-    void onNotesListInFolderRequested(int parentID, bool isRecursive,
-                                      bool newNote = false, int scrollToId = SpecialNodeID::InvalidNodeId);
-    void onNotesListInTagsRequested(const QSet<int>& tagIds,
-                                    bool newNote = false, int scrollToId = SpecialNodeID::InvalidNodeId);
+    void onNotesListInFolderRequested(int parentID, bool isRecursive, bool newNote = false,
+                                      int scrollToId = SpecialNodeID::InvalidNodeId);
+    void onNotesListInTagsRequested(const QSet<int> &tagIds, bool newNote = false,
+                                    int scrollToId = SpecialNodeID::InvalidNodeId);
     void onOpenDBManagerRequested(const QString &path, bool doCreate);
-    void onCreateUpdateRequestedNoteContent(const NodeData& note);
-    void onImportNotesRequested(const QString& fileName);
-    void onRestoreNotesRequested(const QString& fileName);
-    void onExportNotesRequested(const QString& fileName);
+    void onCreateUpdateRequestedNoteContent(const NodeData &note);
+    void onImportNotesRequested(const QString &fileName);
+    void onRestoreNotesRequested(const QString &fileName);
+    void onExportNotesRequested(const QString &fileName);
     void onMigrateNotesFromV0_9_0Requested(QVector<NodeData> &noteList);
-    void onMigrateTrashFrom0_9_0Requested(QVector<NodeData>& noteList);
-    void onMigrateNotesFrom1_5_0Requested(const QString& fileName);
-    void onChangeDatabasePathRequested(const QString& newPath);
+    void onMigrateTrashFrom0_9_0Requested(QVector<NodeData> &noteList);
+    void onMigrateNotesFrom1_5_0Requested(const QString &fileName);
+    void onChangeDatabasePathRequested(const QString &newPath);
 
-    int addNode(const NodeData& node);
+    int addNode(const NodeData &node);
 
-    int addTag(const TagData& tag);
+    int addTag(const TagData &tag);
     void addNoteToTag(int noteId, int tagId);
     void removeNoteFromTag(int noteId, int tagId);
     int nextAvailableNodeId();
     int nextAvailableTagId();
-    void renameNode(int id, const QString& newName);
-    void renameTag(int id, const QString& newName);
-    void changeTagColor(int id, const QString& newColor);
-    void removeNote(const NodeData& note);
+    void renameNode(int id, const QString &newName);
+    void renameTag(int id, const QString &newName);
+    void changeTagColor(int id, const QString &newColor);
+    void removeNote(const NodeData &note);
     void removeTag(int tagId);
-    void moveNode(int nodeId, const NodeData& target);
-    void searchForNotes(const QString& keyword, const ListViewInfo& inf);
-    void clearSearch(const ListViewInfo& inf);
+    void moveNode(int nodeId, const NodeData &target);
+    void searchForNotes(const QString &keyword, const ListViewInfo &inf);
+    void clearSearch(const ListViewInfo &inf);
     void updateRelPosNode(int nodeId, int relPos);
     void updateRelPosTag(int tagId, int relPos);
     void updateRelPosPinnedNote(int nodeId, int relPos);

--- a/src/defaultnotefolderdelegateeditor.cpp
+++ b/src/defaultnotefolderdelegateeditor.cpp
@@ -4,33 +4,36 @@
 #include <QTreeView>
 #include "nodetreemodel.h"
 
-DefaultNoteFolderDelegateEditor::DefaultNoteFolderDelegateEditor(QTreeView *view, const QStyleOptionViewItem &option,
-                                                     const QModelIndex &m_index,
-                                                     QWidget *parent) :
-    QWidget(parent),
-    m_option(option),
-    m_index(m_index),
-    #ifdef __APPLE__
-    m_displayFont(QFont(QStringLiteral("SF Pro Text")).exactMatch() ? QStringLiteral("SF Pro Text") : QStringLiteral("Roboto")),
-    #elif _WIN32
-    m_displayFont(QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI") : QStringLiteral("Roboto")),
-    #else
-    m_displayFont(QStringLiteral("Roboto")),
-    #endif
-    #ifdef __APPLE__
-	m_titleFont(m_displayFont, 13, QFont::DemiBold),
-    #else
-	m_titleFont(m_displayFont, 10, QFont::DemiBold),
-    #endif
-    m_titleColor(26, 26, 26),
-    m_titleSelectedColor(255, 255, 255),
-    m_activeColor(68, 138, 201),
-    m_hoverColor(207, 207, 207),
-    m_view(view)
+DefaultNoteFolderDelegateEditor::DefaultNoteFolderDelegateEditor(QTreeView *view,
+                                                                 const QStyleOptionViewItem &option,
+                                                                 const QModelIndex &m_index,
+                                                                 QWidget *parent)
+    : QWidget(parent),
+      m_option(option),
+      m_index(m_index),
+#ifdef __APPLE__
+      m_displayFont(QFont(QStringLiteral("SF Pro Text")).exactMatch()
+                            ? QStringLiteral("SF Pro Text")
+                            : QStringLiteral("Roboto")),
+#elif _WIN32
+      m_displayFont(QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI")
+                                                                   : QStringLiteral("Roboto")),
+#else
+      m_displayFont(QStringLiteral("Roboto")),
+#endif
+#ifdef __APPLE__
+      m_titleFont(m_displayFont, 13, QFont::DemiBold),
+#else
+      m_titleFont(m_displayFont, 10, QFont::DemiBold),
+#endif
+      m_titleColor(26, 26, 26),
+      m_titleSelectedColor(255, 255, 255),
+      m_activeColor(68, 138, 201),
+      m_hoverColor(207, 207, 207),
+      m_view(view)
 {
     setContentsMargins(0, 0, 0, 0);
 }
-
 
 void DefaultNoteFolderDelegateEditor::paintEvent(QPaintEvent *event)
 {
@@ -63,6 +66,7 @@ void DefaultNoteFolderDelegateEditor::paintEvent(QPaintEvent *event)
         painter.setPen(m_titleColor);
     }
     painter.setFont(m_titleFont);
-    painter.drawText(childCountRect, Qt::AlignHCenter | Qt::AlignVCenter, QString::number(childCount));
+    painter.drawText(childCountRect, Qt::AlignHCenter | Qt::AlignVCenter,
+                     QString::number(childCount));
     QWidget::paintEvent(event);
 }

--- a/src/defaultnotefolderdelegateeditor.h
+++ b/src/defaultnotefolderdelegateeditor.h
@@ -12,10 +12,8 @@ class DefaultNoteFolderDelegateEditor : public QWidget
 {
     Q_OBJECT
 public:
-    explicit DefaultNoteFolderDelegateEditor(QTreeView *view,
-                                       const QStyleOptionViewItem &option,
-                                      const QModelIndex &index,
-                                      QWidget *parent = nullptr);
+    explicit DefaultNoteFolderDelegateEditor(QTreeView *view, const QStyleOptionViewItem &option,
+                                             const QModelIndex &index, QWidget *parent = nullptr);
 
 private:
     QStyleOptionViewItem m_option;

--- a/src/editorsettingsbutton.cpp
+++ b/src/editorsettingsbutton.cpp
@@ -3,8 +3,7 @@
 #include <QPainter>
 
 EditorSettingsButton::EditorSettingsButton(QWidget *parent)
-: QPushButton(parent),
-  m_currentFontName(QStringLiteral("Roboto"))
+    : QPushButton(parent), m_currentFontName(QStringLiteral("Roboto"))
 {
 }
 
@@ -35,11 +34,12 @@ void EditorSettingsButton::paintEvent(QPaintEvent *p)
     currentY += 6;
     painter.setFont(QFont(m_currentFontName, 36, QFont::Bold));
 #endif
-    painter.drawText(rowPosX, currentY, rowWidth, rowHeight, Qt::AlignHCenter, QStringLiteral("Aa"));
+    painter.drawText(rowPosX, currentY, rowWidth, rowHeight, Qt::AlignHCenter,
+                     QStringLiteral("Aa"));
 
     QString arrowImagePath;
     switch (m_currentTheme) {
-        case Theme::Dark:
+    case Theme::Dark:
         arrowImagePath = QStringLiteral(":images/arrow-right-dark.png");
         break;
     default:
@@ -48,13 +48,15 @@ void EditorSettingsButton::paintEvent(QPaintEvent *p)
     }
 
 #ifdef __APPLE__
-    painter.drawImage(rowPosX+115, currentY+30, QImage(arrowImagePath));
+    painter.drawImage(rowPosX + 115, currentY + 30, QImage(arrowImagePath));
     painter.setFont(QFont(QStringLiteral("Roboto"), 9, QFont::Normal));
-    painter.drawText(rowPosX+52, currentY+42, rowWidth, rowHeight, Qt::AlignHCenter, QStringLiteral("Next"));
+    painter.drawText(rowPosX + 52, currentY + 42, rowWidth, rowHeight, Qt::AlignHCenter,
+                     QStringLiteral("Next"));
 #else
-    painter.drawImage(rowPosX+109, currentY+24, QImage(arrowImagePath));
+    painter.drawImage(rowPosX + 109, currentY + 24, QImage(arrowImagePath));
     painter.setFont(QFont(QStringLiteral("Roboto"), 5, QFont::Normal));
-    painter.drawText(rowPosX+46, currentY+36, rowWidth, rowHeight, Qt::AlignHCenter, QStringLiteral("Next"));
+    painter.drawText(rowPosX + 46, currentY + 36, rowWidth, rowHeight, Qt::AlignHCenter,
+                     QStringLiteral("Next"));
 #endif
 
 #ifdef __APPLE__
@@ -64,7 +66,8 @@ void EditorSettingsButton::paintEvent(QPaintEvent *p)
     currentY += 54;
     painter.setFont(QFont(m_currentFontName, 10, QFont::Normal));
 #endif
-    painter.drawText(rowPosX, currentY, rowWidth, rowHeight, Qt::AlignHCenter, m_currentFontTypeface);
+    painter.drawText(rowPosX, currentY, rowWidth, rowHeight, Qt::AlignHCenter,
+                     m_currentFontTypeface);
     currentY += 16;
 
 #ifdef __APPLE__
@@ -73,7 +76,6 @@ void EditorSettingsButton::paintEvent(QPaintEvent *p)
     painter.setFont(QFont(m_currentFontName, 9, QFont::Normal));
 #endif
     painter.drawText(rowPosX, currentY, rowWidth, rowHeight, Qt::AlignHCenter, m_currentFontName);
-
 }
 
 /*!
@@ -83,7 +85,8 @@ void EditorSettingsButton::paintEvent(QPaintEvent *p)
  * \param fontTypeface
  * \param fontColor
  */
-void EditorSettingsButton::changeFont(const QString &fontName, const QString &fontTypeface, QColor fontColor)
+void EditorSettingsButton::changeFont(const QString &fontName, const QString &fontTypeface,
+                                      QColor fontColor)
 {
     m_currentFontName = fontName;
     m_currentFontTypeface = fontTypeface;
@@ -101,4 +104,3 @@ void EditorSettingsButton::setTheme(Theme theme)
 {
     m_currentTheme = theme;
 }
-

--- a/src/elidedlabel.cpp
+++ b/src/elidedlabel.cpp
@@ -3,16 +3,15 @@
 #include <QResizeEvent>
 #include <QTimer>
 
-ElidedLabel::ElidedLabel(QWidget *parent, Qt::WindowFlags f) :
-    QLabel(parent, f)
+ElidedLabel::ElidedLabel(QWidget *parent, Qt::WindowFlags f) : QLabel(parent, f)
 {
     defaultType = Qt::ElideRight;
     eliding = false;
     original = "";
 }
 
-ElidedLabel::ElidedLabel(const QString &text, QWidget *parent, Qt::WindowFlags f) :
-    QLabel(text, parent, f)
+ElidedLabel::ElidedLabel(const QString &text, QWidget *parent, Qt::WindowFlags f)
+    : QLabel(text, parent, f)
 {
     defaultType = Qt::ElideRight;
     eliding = false;

--- a/src/elidedlabel.h
+++ b/src/elidedlabel.h
@@ -7,8 +7,9 @@ class ElidedLabel : public QLabel
 {
     Q_OBJECT
 public:
-    explicit ElidedLabel(QWidget *parent=nullptr, Qt::WindowFlags f=Qt::WindowFlags());
-    explicit ElidedLabel(const QString &text, QWidget *parent=nullptr, Qt::WindowFlags f=Qt::WindowFlags());
+    explicit ElidedLabel(QWidget *parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
+    explicit ElidedLabel(const QString &text, QWidget *parent = nullptr,
+                         Qt::WindowFlags f = Qt::WindowFlags());
     void setType(const Qt::TextElideMode type);
 
 public slots:

--- a/src/foldertreedelegateeditor.cpp
+++ b/src/foldertreedelegateeditor.cpp
@@ -12,28 +12,30 @@
 
 FolderTreeDelegateEditor::FolderTreeDelegateEditor(QTreeView *view,
                                                    const QStyleOptionViewItem &option,
-                                                   const QModelIndex &index,
-                                                   QWidget *parent) :
-    QWidget(parent),
-    m_option(option),
-    m_index(index),
-    #ifdef __APPLE__
-    m_displayFont(QFont(QStringLiteral("SF Pro Text")).exactMatch() ? QStringLiteral("SF Pro Text") : QStringLiteral("Roboto")),
-    #elif _WIN32
-    m_displayFont(QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI") : QStringLiteral("Roboto")),
-    #else
-    m_displayFont(QStringLiteral("Roboto")),
-    #endif
-    #ifdef __APPLE__
-    m_titleFont(m_displayFont, 13, QFont::DemiBold),
-    #else
-    m_titleFont(m_displayFont, 10, QFont::DemiBold),
-    #endif
-    m_titleColor(26, 26, 26),
-    m_titleSelectedColor(255, 255, 255),
-    m_activeColor(68, 138, 201),
-    m_hoverColor(207, 207, 207),
-    m_view(view)
+                                                   const QModelIndex &index, QWidget *parent)
+    : QWidget(parent),
+      m_option(option),
+      m_index(index),
+#ifdef __APPLE__
+      m_displayFont(QFont(QStringLiteral("SF Pro Text")).exactMatch()
+                            ? QStringLiteral("SF Pro Text")
+                            : QStringLiteral("Roboto")),
+#elif _WIN32
+      m_displayFont(QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI")
+                                                                   : QStringLiteral("Roboto")),
+#else
+      m_displayFont(QStringLiteral("Roboto")),
+#endif
+#ifdef __APPLE__
+      m_titleFont(m_displayFont, 13, QFont::DemiBold),
+#else
+      m_titleFont(m_displayFont, 10, QFont::DemiBold),
+#endif
+      m_titleColor(26, 26, 26),
+      m_titleSelectedColor(255, 255, 255),
+      m_activeColor(68, 138, 201),
+      m_hoverColor(207, 207, 207),
+      m_view(view)
 {
     setContentsMargins(0, 0, 0, 0);
     auto layout = new QHBoxLayout(this);
@@ -41,8 +43,8 @@ FolderTreeDelegateEditor::FolderTreeDelegateEditor(QTreeView *view,
     layout->setSpacing(5);
     setLayout(layout);
     m_expandIcon = new QLabel(this);
-    m_expandIcon->setMinimumSize({15, 15});
-    m_expandIcon->setMaximumSize({15, 15});
+    m_expandIcon->setMinimumSize({ 15, 15 });
+    m_expandIcon->setMaximumSize({ 15, 15 });
     m_expanded.load(QStringLiteral(":/images/tree-node-expanded.png"));
     m_notExpanded.load(QStringLiteral(":/images/tree-node-normal.png"));
     m_expandIcon->setScaledContents(true);
@@ -56,38 +58,36 @@ FolderTreeDelegateEditor::FolderTreeDelegateEditor(QTreeView *view,
     m_label->setSizePolicy(labelPolicy);
     m_label->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
     connect(m_label, &LabelEditType::editingStarted, this, [this] {
-        auto tree_view = dynamic_cast<NodeTreeView*>(m_view);
+        auto tree_view = dynamic_cast<NodeTreeView *>(m_view);
         tree_view->setIsEditing(true);
     });
-    connect(m_label, &LabelEditType::editingFinished, this, [this] (const QString& label) {
-        auto tree_view = dynamic_cast<NodeTreeView*>(m_view);
+    connect(m_label, &LabelEditType::editingFinished, this, [this](const QString &label) {
+        auto tree_view = dynamic_cast<NodeTreeView *>(m_view);
         tree_view->onRenameFolderFinished(label);
         tree_view->setIsEditing(false);
     });
-    connect(dynamic_cast<NodeTreeView*>(m_view), &NodeTreeView::renameFolderRequested,
-            m_label, &LabelEditType::openEditor);
+    connect(dynamic_cast<NodeTreeView *>(m_view), &NodeTreeView::renameFolderRequested, m_label,
+            &LabelEditType::openEditor);
     layout->addWidget(m_label);
     m_contextButton = new PushButtonType(parent);
-    m_contextButton->setMaximumSize({33, 25});
-    m_contextButton->setMinimumSize({33, 25});
+    m_contextButton->setMaximumSize({ 33, 25 });
+    m_contextButton->setMinimumSize({ 33, 25 });
     m_contextButton->setCursor(QCursor(Qt::PointingHandCursor));
     m_contextButton->setFocusPolicy(Qt::TabFocus);
     m_contextButton->setIconSize(QSize(16, 16));
     m_contextButton->setStyleSheet(QStringLiteral(R"(QPushButton { )"
-                                            R"(    border: none; )"
-                                            R"(    padding: 0px; )"
-                                            R"(})"));
-    connect(m_contextButton, &QPushButton::clicked, m_view, [this] (bool) {
-        auto tree_view = dynamic_cast<NodeTreeView*>(m_view);
-//        tree_view->setCurrentIndexC(m_index);
-        tree_view->onCustomContextMenu(
-                    tree_view->visualRect(m_index).topLeft() + m_contextButton->geometry().bottomLeft());
+                                                  R"(    border: none; )"
+                                                  R"(    padding: 0px; )"
+                                                  R"(})"));
+    connect(m_contextButton, &QPushButton::clicked, m_view, [this](bool) {
+        auto tree_view = dynamic_cast<NodeTreeView *>(m_view);
+        //        tree_view->setCurrentIndexC(m_index);
+        tree_view->onCustomContextMenu(tree_view->visualRect(m_index).topLeft()
+                                       + m_contextButton->geometry().bottomLeft());
     });
     layout->addWidget(m_contextButton, 0, Qt::AlignRight);
     layout->addSpacing(5);
-    connect(m_view, &QTreeView::expanded, this, [this] (const QModelIndex &) {
-        this->update();
-    });
+    connect(m_view, &QTreeView::expanded, this, [this](const QModelIndex &) { this->update(); });
 }
 
 void FolderTreeDelegateEditor::updateDelegate()
@@ -98,23 +98,23 @@ void FolderTreeDelegateEditor::updateDelegate()
 
     if (m_view->selectionModel()->isSelected(m_index)) {
         m_label->setStyleSheet(QStringLiteral("QLabel{color: rgb(%1, %2, %3);}")
-                               .arg(QString::number(m_titleSelectedColor.red()),
-                                    QString::number(m_titleSelectedColor.green()),
-                                    QString::number(m_titleSelectedColor.blue())));
+                                       .arg(QString::number(m_titleSelectedColor.red()),
+                                            QString::number(m_titleSelectedColor.green()),
+                                            QString::number(m_titleSelectedColor.blue())));
         m_contextButton->setNormalIcon(QIcon(QString::fromUtf8(":/images/3dots_Highlighted.png")));
         m_contextButton->setHoveredIcon(QIcon(QString::fromUtf8(":/images/3dots_Highlighted.png")));
         m_contextButton->setPressedIcon(QIcon(QString::fromUtf8(":/images/3dots_Highlighted.png")));
     } else {
         m_label->setStyleSheet(QStringLiteral("QLabel{color: rgb(%1, %2, %3);}")
-                               .arg(QString::number(m_titleColor.red()),
-                                    QString::number(m_titleColor.green()),
-                                    QString::number(m_titleColor.blue())));
+                                       .arg(QString::number(m_titleColor.red()),
+                                            QString::number(m_titleColor.green()),
+                                            QString::number(m_titleColor.blue())));
         m_contextButton->setNormalIcon(QIcon(QString::fromUtf8(":/images/3dots_Regular.png")));
         m_contextButton->setHoveredIcon(QIcon(QString::fromUtf8(":/images/3dots_Hovered.png")));
         m_contextButton->setPressedIcon(QIcon(QString::fromUtf8(":/images/3dots_Pressed.png")));
     }
     m_label->setText(displayName);
-    auto theme = dynamic_cast<NodeTreeView*>(m_view)->theme();
+    auto theme = dynamic_cast<NodeTreeView *>(m_view)->theme();
     if (theme == Theme::Dark) {
         m_expanded.load(QStringLiteral(":/images/tree-node-expanded-dark.png"));
         m_notExpanded.load(QStringLiteral(":/images/tree-node-normal-dark.png"));
@@ -123,7 +123,7 @@ void FolderTreeDelegateEditor::updateDelegate()
         m_notExpanded.load(QStringLiteral(":/images/tree-node-normal.png"));
     }
     if (m_index.data(NodeItem::Roles::IsExpandable).toBool()) {
-        if(m_view->isExpanded(m_index)) {
+        if (m_view->isExpanded(m_index)) {
             m_expandIcon->setPixmap(m_expanded);
         } else {
             m_expandIcon->setPixmap(m_notExpanded);

--- a/src/foldertreedelegateeditor.h
+++ b/src/foldertreedelegateeditor.h
@@ -15,10 +15,8 @@ class FolderTreeDelegateEditor : public QWidget
 {
     Q_OBJECT
 public:
-    explicit FolderTreeDelegateEditor(QTreeView* view,
-                                      const QStyleOptionViewItem &option,
-                                      const QModelIndex &index,
-                                      QWidget *parent = nullptr);
+    explicit FolderTreeDelegateEditor(QTreeView *view, const QStyleOptionViewItem &option,
+                                      const QModelIndex &index, QWidget *parent = nullptr);
 
 private:
     QStyleOptionViewItem m_option;
@@ -29,12 +27,12 @@ private:
     QColor m_titleSelectedColor;
     QColor m_activeColor;
     QColor m_hoverColor;
-    QTreeView* m_view;
-    LabelEditType* m_label;
+    QTreeView *m_view;
+    LabelEditType *m_label;
     QPixmap m_expanded;
     QPixmap m_notExpanded;
-    QLabel* m_expandIcon;
-    PushButtonType* m_contextButton;
+    QLabel *m_expandIcon;
+    PushButtonType *m_contextButton;
     void updateDelegate();
 
     // QWidget interface

--- a/src/framelesswindow.cpp
+++ b/src/framelesswindow.cpp
@@ -3,17 +3,18 @@
 #include <QPoint>
 #include <QSize>
 #ifdef Q_OS_WIN
-#if defined(__MINGW32__) || defined(__GNUC__)
-#else
-#include <windows.h>
-#include <WinUser.h>
-#include <windowsx.h>
-#include <dwmapi.h>
-#include <objidl.h> // Fixes error C2504: 'IUnknown' : base class undefined
-#include <gdiplus.h>
-#include <gdipluscolor.h>
-#pragma comment (lib,"Dwmapi.lib") // Adds missing library, fixes error LNK2019: unresolved external symbol __imp__DwmExtendFrameIntoClientArea
-#pragma comment (lib,"user32.lib")
+#  if defined(__MINGW32__) || defined(__GNUC__)
+#  else
+#    include <windows.h>
+#    include <WinUser.h>
+#    include <windowsx.h>
+#    include <dwmapi.h>
+#    include <objidl.h> // Fixes error C2504: 'IUnknown' : base class undefined
+#    include <gdiplus.h>
+#    include <gdipluscolor.h>
+#    pragma comment(lib, "Dwmapi.lib") // Adds missing library, fixes error LNK2019: unresolved
+                                       // external symbol __imp__DwmExtendFrameIntoClientArea
+#    pragma comment(lib, "user32.lib")
 
 CFramelessWindow::CFramelessWindow(QWidget *parent)
     : QMainWindow(parent),
@@ -22,10 +23,10 @@ CFramelessWindow::CFramelessWindow(QWidget *parent)
       m_bJustMaximized(false),
       m_bResizeable(true)
 {
-//    setWindowFlag(Qt::Window,true);
-//    setWindowFlag(Qt::FramelessWindowHint, true);
-//    setWindowFlag(Qt::WindowSystemMenuHint, true);
-//    setWindowFlag() is not avaliable before Qt v5.9, so we should use setWindowFlags instead
+    //    setWindowFlag(Qt::Window,true);
+    //    setWindowFlag(Qt::FramelessWindowHint, true);
+    //    setWindowFlag(Qt::WindowSystemMenuHint, true);
+    //    setWindowFlag() is not avaliable before Qt v5.9, so we should use setWindowFlags instead
 
     setWindowFlags(windowFlags() | Qt::Window | Qt::FramelessWindowHint | Qt::WindowSystemMenuHint);
 
@@ -36,20 +37,20 @@ void CFramelessWindow::setResizeable(bool resizeable)
 {
     bool visible = isVisible();
     m_bResizeable = resizeable;
-    if (m_bResizeable){
+    if (m_bResizeable) {
         setWindowFlags(windowFlags() | Qt::WindowMaximizeButtonHint);
-//        setWindowFlag(Qt::WindowMaximizeButtonHint);
+        //        setWindowFlag(Qt::WindowMaximizeButtonHint);
 
         //此行代码可以带回Aero效果，同时也带回了标题栏和边框,在nativeEvent()会再次去掉标题栏
         //
-        //this line will get titlebar/thick frame/Aero back, which is exactly what we want
-        //we will get rid of titlebar and thick frame again in nativeEvent() later
+        // this line will get titlebar/thick frame/Aero back, which is exactly what we want
+        // we will get rid of titlebar and thick frame again in nativeEvent() later
         HWND hwnd = (HWND)this->winId();
         DWORD style = ::GetWindowLong(hwnd, GWL_STYLE);
         ::SetWindowLong(hwnd, GWL_STYLE, style | WS_MAXIMIZEBOX | WS_THICKFRAME | WS_CAPTION);
-    }else{
+    } else {
         setWindowFlags(windowFlags() & ~Qt::WindowMaximizeButtonHint);
-//        setWindowFlag(Qt::WindowMaximizeButtonHint,false);
+        //        setWindowFlag(Qt::WindowMaximizeButtonHint,false);
 
         HWND hwnd = (HWND)this->winId();
         DWORD style = ::GetWindowLong(hwnd, GWL_STYLE);
@@ -58,7 +59,7 @@ void CFramelessWindow::setResizeable(bool resizeable)
 
     //保留一个像素的边框宽度，否则系统不会绘制边框阴影
     //
-    //we better left 1 piexl width of border untouch, so OS can draw nice shadow around it
+    // we better left 1 piexl width of border untouch, so OS can draw nice shadow around it
     const MARGINS shadow = { 1, 1, 1, 1 };
     DwmExtendFrameIntoClientArea(HWND(winId()), &shadow);
 
@@ -67,59 +68,60 @@ void CFramelessWindow::setResizeable(bool resizeable)
 
 void CFramelessWindow::setResizeableAreaWidth(int width)
 {
-    if (1 > width) width = 1;
+    if (1 > width)
+        width = 1;
     m_borderWidth = width;
 }
 
-void CFramelessWindow::setTitleBar(QWidget* titlebar)
+void CFramelessWindow::setTitleBar(QWidget *titlebar)
 {
     m_titlebar = titlebar;
-    if (!titlebar) return;
-    connect(titlebar, SIGNAL(destroyed(QObject*)), this, SLOT(onTitleBarDestroyed()));
+    if (!titlebar)
+        return;
+    connect(titlebar, SIGNAL(destroyed(QObject *)), this, SLOT(onTitleBarDestroyed()));
 }
 
 void CFramelessWindow::onTitleBarDestroyed()
 {
-    if (m_titlebar == QObject::sender())
-    {
+    if (m_titlebar == QObject::sender()) {
         m_titlebar = Q_NULLPTR;
     }
 }
 
-void CFramelessWindow::addIgnoreWidget(QWidget* widget)
+void CFramelessWindow::addIgnoreWidget(QWidget *widget)
 {
-    if (!widget) return;
-    if (m_whiteList.contains(widget)) return;
+    if (!widget)
+        return;
+    if (m_whiteList.contains(widget))
+        return;
     m_whiteList.append(widget);
 }
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#    if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 bool CFramelessWindow::nativeEvent(const QByteArray &eventType, void *message, qintptr *result)
-#else
+#    else
 bool CFramelessWindow::nativeEvent(const QByteArray &eventType, void *message, long *result)
-#endif
+#    endif
 {
-    //Workaround for known bug -> check Qt forum : https://forum.qt.io/topic/93141/qtablewidget-itemselectionchanged/13
-    #if (QT_VERSION == QT_VERSION_CHECK(5, 11, 1))
-    MSG* msg = *reinterpret_cast<MSG**>(message);
-    #else
-    MSG* msg = reinterpret_cast<MSG*>(message);
-    #endif
-    
-    switch (msg->message)
-    {
-    case WM_NCCALCSIZE:
-    {
-        NCCALCSIZE_PARAMS& params = *reinterpret_cast<NCCALCSIZE_PARAMS*>(msg->lParam);
+// Workaround for known bug -> check Qt forum :
+// https://forum.qt.io/topic/93141/qtablewidget-itemselectionchanged/13
+#    if (QT_VERSION == QT_VERSION_CHECK(5, 11, 1))
+    MSG *msg = *reinterpret_cast<MSG **>(message);
+#    else
+    MSG *msg = reinterpret_cast<MSG *>(message);
+#    endif
+
+    switch (msg->message) {
+    case WM_NCCALCSIZE: {
+        NCCALCSIZE_PARAMS &params = *reinterpret_cast<NCCALCSIZE_PARAMS *>(msg->lParam);
         if (params.rgrc[0].top != 0)
             params.rgrc[0].top -= 1;
 
-        //this kills the window frame and title bar we added with WS_THICKFRAME and WS_CAPTION
+        // this kills the window frame and title bar we added with WS_THICKFRAME and WS_CAPTION
         *result = WVR_REDRAW;
         return true;
     }
-    case WM_NCHITTEST:
-    {
+    case WM_NCHITTEST: {
         *result = 0;
 
         const LONG border_width = m_borderWidth;
@@ -129,113 +131,99 @@ bool CFramelessWindow::nativeEvent(const QByteArray &eventType, void *message, l
         long x = GET_X_LPARAM(msg->lParam);
         long y = GET_Y_LPARAM(msg->lParam);
 
-        if(m_bResizeable)
-        {
+        if (m_bResizeable) {
 
             bool resizeWidth = minimumWidth() != maximumWidth();
             bool resizeHeight = minimumHeight() != maximumHeight();
 
-            if(resizeWidth)
-            {
-                //left border
-                if (x >= winrect.left && x < winrect.left + border_width)
-                {
+            if (resizeWidth) {
+                // left border
+                if (x >= winrect.left && x < winrect.left + border_width) {
                     *result = HTLEFT;
                 }
-                //right border
-                if (x < winrect.right && x >= winrect.right - border_width)
-                {
+                // right border
+                if (x < winrect.right && x >= winrect.right - border_width) {
                     *result = HTRIGHT;
                 }
             }
-            if(resizeHeight)
-            {
-                //bottom border
-                if (y < winrect.bottom && y >= winrect.bottom - border_width)
-                {
+            if (resizeHeight) {
+                // bottom border
+                if (y < winrect.bottom && y >= winrect.bottom - border_width) {
                     *result = HTBOTTOM;
                 }
-                //top border
-                if (y >= winrect.top && y < winrect.top + border_width)
-                {
+                // top border
+                if (y >= winrect.top && y < winrect.top + border_width) {
                     *result = HTTOP;
                 }
             }
-            if(resizeWidth && resizeHeight)
-            {
-                //bottom left corner
-                if (x >= winrect.left && x < winrect.left + border_width &&
-                        y < winrect.bottom && y >= winrect.bottom - border_width)
-                {
+            if (resizeWidth && resizeHeight) {
+                // bottom left corner
+                if (x >= winrect.left && x < winrect.left + border_width && y < winrect.bottom
+                    && y >= winrect.bottom - border_width) {
                     *result = HTBOTTOMLEFT;
                 }
-                //bottom right corner
-                if (x < winrect.right && x >= winrect.right - border_width &&
-                        y < winrect.bottom && y >= winrect.bottom - border_width)
-                {
+                // bottom right corner
+                if (x < winrect.right && x >= winrect.right - border_width && y < winrect.bottom
+                    && y >= winrect.bottom - border_width) {
                     *result = HTBOTTOMRIGHT;
                 }
-                //top left corner
-                if (x >= winrect.left && x < winrect.left + border_width &&
-                        y >= winrect.top && y < winrect.top + border_width)
-                {
+                // top left corner
+                if (x >= winrect.left && x < winrect.left + border_width && y >= winrect.top
+                    && y < winrect.top + border_width) {
                     *result = HTTOPLEFT;
                 }
-                //top right corner
-                if (x < winrect.right && x >= winrect.right - border_width &&
-                        y >= winrect.top && y < winrect.top + border_width)
-                {
+                // top right corner
+                if (x < winrect.right && x >= winrect.right - border_width && y >= winrect.top
+                    && y < winrect.top + border_width) {
                     *result = HTTOPRIGHT;
                 }
             }
         }
-        if (0!=*result) return true;
+        if (0 != *result)
+            return true;
 
         //*result still equals 0, that means the cursor locate OUTSIDE the frame area
-        //but it may locate in titlebar area
-        if (!m_titlebar) return false;
+        // but it may locate in titlebar area
+        if (!m_titlebar)
+            return false;
 
-        //support highdpi
+        // support highdpi
         double dpr = this->devicePixelRatioF();
-        QPoint pos = m_titlebar->mapFromGlobal(QPoint(x/dpr,y/dpr));
+        QPoint pos = m_titlebar->mapFromGlobal(QPoint(x / dpr, y / dpr));
 
-        if (!m_titlebar->rect().contains(pos)) return false;
-        QWidget* child = m_titlebar->childAt(pos);
-        if (!child)
-        {
+        if (!m_titlebar->rect().contains(pos))
+            return false;
+        QWidget *child = m_titlebar->childAt(pos);
+        if (!child) {
             *result = HTCAPTION;
             return true;
-        }else{
-            if (m_whiteList.contains(child))
-            {
+        } else {
+            if (m_whiteList.contains(child)) {
                 *result = HTCAPTION;
                 return true;
             }
         }
         return false;
-    } //end case WM_NCHITTEST
-    case WM_GETMINMAXINFO:
-    {
+    } // end case WM_NCHITTEST
+    case WM_GETMINMAXINFO: {
         if (::IsZoomed(msg->hwnd)) {
             RECT frame = { 0, 0, 0, 0 };
             AdjustWindowRectEx(&frame, WS_OVERLAPPEDWINDOW, FALSE, 0);
 
-            //record frame area data
+            // record frame area data
             double dpr = this->devicePixelRatioF();
 
-            m_frames.setLeft(abs(frame.left)/dpr+0.5);
-            m_frames.setTop(abs(frame.bottom)/dpr+0.5);
-            m_frames.setRight(abs(frame.right)/dpr+0.5);
-            m_frames.setBottom(abs(frame.bottom)/dpr+0.5);
+            m_frames.setLeft(abs(frame.left) / dpr + 0.5);
+            m_frames.setTop(abs(frame.bottom) / dpr + 0.5);
+            m_frames.setRight(abs(frame.right) / dpr + 0.5);
+            m_frames.setBottom(abs(frame.bottom) / dpr + 0.5);
 
-            QMainWindow::setContentsMargins(m_frames.left()+m_margins.left(), \
-                                            m_frames.top()+m_margins.top(), \
-                                            m_frames.right()+m_margins.right(), \
-                                            m_frames.bottom()+m_margins.bottom());
+            QMainWindow::setContentsMargins(
+                    m_frames.left() + m_margins.left(), m_frames.top() + m_margins.top(),
+                    m_frames.right() + m_margins.right(), m_frames.bottom() + m_margins.bottom());
             m_bJustMaximized = true;
-        }else {
-            if (m_bJustMaximized)
-            {
+        } else {
+            if (m_bJustMaximized) {
                 QMainWindow::setContentsMargins(m_margins);
                 m_frames = QMargins();
                 m_bJustMaximized = false;
@@ -250,15 +238,13 @@ bool CFramelessWindow::nativeEvent(const QByteArray &eventType, void *message, l
 
 void CFramelessWindow::setContentsMargins(const QMargins &margins)
 {
-    QMainWindow::setContentsMargins(margins+m_frames);
+    QMainWindow::setContentsMargins(margins + m_frames);
     m_margins = margins;
 }
 void CFramelessWindow::setContentsMargins(int left, int top, int right, int bottom)
 {
-    QMainWindow::setContentsMargins(left+m_frames.left(),\
-                                    top+m_frames.top(), \
-                                    right+m_frames.right(), \
-                                    bottom+m_frames.bottom());
+    QMainWindow::setContentsMargins(left + m_frames.left(), top + m_frames.top(),
+                                    right + m_frames.right(), bottom + m_frames.bottom());
     m_margins.setLeft(left);
     m_margins.setTop(top);
     m_margins.setRight(right);
@@ -277,9 +263,9 @@ void CFramelessWindow::getContentsMargins(int *left, int *top, int *right, int *
     *top = margins.top();
     *right = margins.right();
     *bottom = margins.bottom();
-    if (!(left&&top&&right&&bottom)) return;
-    if (isMaximized())
-    {
+    if (!(left && top && right && bottom))
+        return;
+    if (isMaximized()) {
         *left -= m_frames.left();
         *top -= m_frames.top();
         *right -= m_frames.right();
@@ -299,12 +285,11 @@ QRect CFramelessWindow::contentsRect() const
 }
 void CFramelessWindow::showFullScreen()
 {
-    if (isMaximized())
-    {
+    if (isMaximized()) {
         QMainWindow::setContentsMargins(m_margins);
         m_frames = QMargins();
     }
     QMainWindow::showFullScreen();
 }
-#endif
-#endif //Q_OS_WIN
+#  endif
+#endif // Q_OS_WIN

--- a/src/framelesswindow.h
+++ b/src/framelesswindow.h
@@ -4,52 +4,54 @@
 #include <QObject>
 #include <QMainWindow>
 
-//A nice frameless window for both Windows and OS X
-//Author: Bringer-of-Light
-//Github: https://github.com/Bringer-of-Light/Qt-Nice-Frameless-Window
-// Usage: use "CFramelessWindow" as base class instead of "QMainWindow", and enjoy
+// A nice frameless window for both Windows and OS X
+// Author: Bringer-of-Light
+// Github: https://github.com/Bringer-of-Light/Qt-Nice-Frameless-Window
+//  Usage: use "CFramelessWindow" as base class instead of "QMainWindow", and enjoy
 #ifdef Q_OS_WIN
-#if defined(__MINGW32__) || defined(__GNUC__)
-#else
-#include <QWidget>
-#include <QList>
-#include <QMargins>
-#include <QRect>
+#  if defined(__MINGW32__) || defined(__GNUC__)
+#  else
+#    include <QWidget>
+#    include <QList>
+#    include <QMargins>
+#    include <QRect>
 class CFramelessWindow : public QMainWindow
 {
     Q_OBJECT
 public:
     explicit CFramelessWindow(QWidget *parent = 0);
-public:
 
+public:
     //设置是否可以通过鼠标调整窗口大小
-    //if resizeable is set to false, then the window can not be resized by mouse
-    //but still can be resized programtically
-    void setResizeable(bool resizeable=true);
-    bool isResizeable(){return m_bResizeable;}
+    // if resizeable is set to false, then the window can not be resized by mouse
+    // but still can be resized programtically
+    void setResizeable(bool resizeable = true);
+    bool isResizeable() { return m_bResizeable; }
 
     //设置可调整大小区域的宽度，在此区域内，可以使用鼠标调整窗口大小
-    //set border width, inside this aera, window can be resized by mouse
+    // set border width, inside this aera, window can be resized by mouse
     void setResizeableAreaWidth(int width = 5);
+
 protected:
     //设置一个标题栏widget，此widget会被当做标题栏对待
-    //set a widget which will be treat as SYSTEM titlebar
-    void setTitleBar(QWidget* titlebar);
+    // set a widget which will be treat as SYSTEM titlebar
+    void setTitleBar(QWidget *titlebar);
 
     //在标题栏控件内，也可以有子控件如标签控件“label1”，此label1遮盖了标题栏，导致不能通过label1拖动窗口
     //要解决此问题，使用addIgnoreWidget(label1)
-    //generally, we can add widget say "label1" on titlebar, and it will cover the titlebar under it
-    //as a result, we can not drag and move the MainWindow with this "label1" again
-    //we can fix this by add "label1" to a ignorelist, just call addIgnoreWidget(label1)
-    void addIgnoreWidget(QWidget* widget);
+    // generally, we can add widget say "label1" on titlebar, and it will cover the titlebar under
+    // it as a result, we can not drag and move the MainWindow with this "label1" again we can fix
+    // this by add "label1" to a ignorelist, just call addIgnoreWidget(label1)
+    void addIgnoreWidget(QWidget *widget);
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-	bool nativeEvent(const QByteArray &eventType, void *message, qintptr *result);
-#else
-	bool nativeEvent(const QByteArray &eventType, void *message, long *result);
-#endif
+#    if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    bool nativeEvent(const QByteArray &eventType, void *message, qintptr *result);
+#    else
+    bool nativeEvent(const QByteArray &eventType, void *message, long *result);
+#    endif
 private slots:
     void onTitleBarDestroyed();
+
 public:
     void setContentsMargins(const QMargins &margins);
     void setContentsMargins(int left, int top, int right, int bottom);
@@ -58,9 +60,10 @@ public:
     void getContentsMargins(int *left, int *top, int *right, int *bottom) const;
 public slots:
     void showFullScreen();
+
 private:
-    QWidget* m_titlebar;
-    QList<QWidget*> m_whiteList;
+    QWidget *m_titlebar;
+    QList<QWidget *> m_whiteList;
     int m_borderWidth;
 
     QMargins m_margins;
@@ -69,52 +72,56 @@ private:
 
     bool m_bResizeable;
 };
-#endif
+#  endif
 #elif defined Q_OS_MAC
-#include <QMouseEvent>
-#include <QResizeEvent>
-#include <QPoint>
+#  include <QMouseEvent>
+#  include <QResizeEvent>
+#  include <QPoint>
 class CFramelessWindow : public QMainWindow
 {
     Q_OBJECT
 public:
     explicit CFramelessWindow(QWidget *parent = 0);
+
 private:
     void initUI();
+
 public:
     //设置可拖动区域的高度，在此区域内，可以通过鼠标拖动窗口, 0表示整个窗口都可拖动
-    //In draggable area, window can be moved by mouse, (height = 0) means that the whole window is draggable
+    // In draggable area, window can be moved by mouse, (height = 0) means that the whole window is
+    // draggable
     void setDraggableAreaHeight(int height = 0);
 
     //只有OS X10.10及以后系统，才支持OS X原生样式包括：三个系统按钮、窗口圆角、窗口阴影
     //类初始化完成后，可以通过此函数查看是否已经启用了原生样式。如果未启动，需要自定义关闭按钮、最小化按钮、最大化按钮
-    //Native style（three system button/ round corner/ drop shadow） works only on OS X 10.10 or later
-    //after init, we should check whether NativeStyle is OK with this function
-    //if NOT ok, we should implement close button/ min button/ max button ourself
-    bool isNativeStyleOK() {return m_bNativeSystemBtn;}
+    // Native style（three system button/ round corner/ drop shadow） works only on OS X 10.10 or
+    // later after init, we should check whether NativeStyle is OK with this function if NOT ok, we
+    // should implement close button/ min button/ max button ourself
+    bool isNativeStyleOK() { return m_bNativeSystemBtn; }
 
-    //如果设置setCloseBtnQuit(false)，那么点击关闭按钮后，程序不会退出，而是会隐藏,只有在OS X 10.10 及以后系统中有效
-    //if setCloseBtnQuit(false), then when close button is clicked, the application will hide itself instead of quit
-    //be carefull, after you set this to false, you can NOT change it to true again
-    //this function should be called inside of the constructor function of derived classes, and can NOT be called more than once
-    //only works for OS X 10.10 or later
+    //如果设置setCloseBtnQuit(false)，那么点击关闭按钮后，程序不会退出，而是会隐藏,只有在OS X 10.10
+    //及以后系统中有效 if setCloseBtnQuit(false), then when close button is clicked, the application
+    // will hide itself instead of quit be carefull, after you set this to false, you can NOT change
+    // it to true again this function should be called inside of the constructor function of derived
+    // classes, and can NOT be called more than once only works for OS X 10.10 or later
     void setCloseBtnQuit(bool bQuit = true);
 
     //启用或禁用关闭按钮，只有在isNativeStyleOK()返回true的情况下才有效
-    //enable or disable Close button, only worked if isNativeStyleOK() returns true
+    // enable or disable Close button, only worked if isNativeStyleOK() returns true
     void setCloseBtnEnabled(bool bEnable = true);
 
     //启用或禁用最小化按钮，只有在isNativeStyleOK()返回true的情况下才有效
-    //enable or disable Miniaturize button, only worked if isNativeStyleOK() returns true
+    // enable or disable Miniaturize button, only worked if isNativeStyleOK() returns true
     void setMinBtnEnabled(bool bEnable = true);
 
     //启用或禁用zoom（最大化）按钮，只有在isNativeStyleOK()返回true的情况下才有效
-    //enable or disable Zoom button(fullscreen button), only worked if isNativeStyleOK() returns true
+    // enable or disable Zoom button(fullscreen button), only worked if isNativeStyleOK() returns
+    // true
     void setZoomBtnEnabled(bool bEnable = true);
 
-    bool isCloseBtnEnabled() {return m_bIsCloseBtnEnabled;}
-    bool isMinBtnEnabled() {return m_bIsMinBtnEnabled;}
-    bool isZoomBtnEnabled() {return m_bIsZoomBtnEnabled;}
+    bool isCloseBtnEnabled() { return m_bIsCloseBtnEnabled; }
+    bool isMinBtnEnabled() { return m_bIsMinBtnEnabled; }
+    bool isZoomBtnEnabled() { return m_bIsZoomBtnEnabled; }
 
     void maximizeWindowMac();
     void setWindowAlwaysOnTopMac(bool isAlwaysOnTop);
@@ -122,42 +129,46 @@ public:
 
 signals:
     void toggleFullScreen(bool isFullScreen);
+
 protected:
     void mousePressEvent(QMouseEvent *event);
     void mouseReleaseEvent(QMouseEvent *event);
     void mouseMoveEvent(QMouseEvent *event);
+
 private:
     int m_draggableHeight;
-    bool    m_bWinMoving;
-    bool    m_bMousePressed;
-    QPoint  m_MousePos;
-    QPoint  m_WindowPos;
+    bool m_bWinMoving;
+    bool m_bMousePressed;
+    QPoint m_MousePos;
+    QPoint m_WindowPos;
     bool m_bCloseBtnQuit;
     bool m_bNativeSystemBtn;
     bool m_bIsCloseBtnEnabled, m_bIsMinBtnEnabled, m_bIsZoomBtnEnabled;
 
     //===============================================
-    //TODO
+    // TODO
     //下面的代码是试验性质的
-    //tentative code
+    // tentative code
 
     //窗口从全屏状态恢复正常大小时，标题栏又会出现，原因未知。
     //默认情况下，系统的最大化按钮(zoom button)是进入全屏，为了避免标题栏重新出现的问题，
     //以上代码已经重新定义了系统zoom button的行为，是其功能变为最大化而不是全屏
     //以下代码尝试，每次窗口从全屏状态恢复正常大小时，都再次进行设置，以消除标题栏
-    //after the window restore from fullscreen mode, the titlebar will show again, it looks like a BUG
-    //on OS X 10.10 and later, click the system green button (zoom button) will make the app become fullscreen
-    //so we have override it's action to "maximized" in the CFramelessWindow Constructor function
-    //but we may try something else such as delete the titlebar again and again...
+    // after the window restore from fullscreen mode, the titlebar will show again, it looks like a
+    // BUG on OS X 10.10 and later, click the system green button (zoom button) will make the app
+    // become fullscreen so we have override it's action to "maximized" in the CFramelessWindow
+    // Constructor function but we may try something else such as delete the titlebar again and
+    // again...
 private:
     bool m_bTitleBarVisible;
 
     void setTitlebarVisible(bool bTitlebarVisible = false);
-    bool isTitlebarVisible() {return m_bTitleBarVisible;}
+    bool isTitlebarVisible() { return m_bTitleBarVisible; }
 private slots:
     void onRestoreFromFullScreen();
 signals:
     void restoreFromFullScreen();
+
 protected:
     void resizeEvent(QResizeEvent *event);
 };

--- a/src/labeledittype.h
+++ b/src/labeledittype.h
@@ -13,16 +13,15 @@ public:
 public slots:
     void openEditor();
 
-
 private slots:
     void onFinishedEdit();
 
 signals:
     void editingStarted();
-    void editingFinished(const QString& text);
+    void editingFinished(const QString &text);
 
 private:
-    QLineEdit* m_editor;
+    QLineEdit *m_editor;
 };
 
 #endif // LABELEDITTYPE_H

--- a/src/listviewlogic.cpp
+++ b/src/listviewlogic.cpp
@@ -10,12 +10,13 @@
 #include "tagpool.h"
 #include <QTimer>
 
-static bool isInvalidCurrentNotesId(const QSet<int>& currentNotesId) {
+static bool isInvalidCurrentNotesId(const QSet<int> &currentNotesId)
+{
     if (currentNotesId.isEmpty()) {
         return true;
     }
     bool isInvalid = true;
-    for (const auto& id : qAsConst(currentNotesId)) {
+    for (const auto &id : qAsConst(currentNotesId)) {
         if (id != SpecialNodeID::InvalidNodeId) {
             isInvalid = false;
         }
@@ -23,114 +24,115 @@ static bool isInvalidCurrentNotesId(const QSet<int>& currentNotesId) {
     return isInvalid;
 }
 
-
-ListViewLogic::ListViewLogic(NoteListView* noteView,
-                             NoteListModel* noteModel, QLineEdit *searchEdit, QToolButton *clearButton,
-                             TagPool *tagPool,
-                             DBManager* dbManager,
-                             QObject* parent) : QObject(parent),
-    m_listView{noteView},
-    m_listModel{noteModel},
-    m_searchEdit{searchEdit},
-    m_clearButton{clearButton},
-    m_dbManager{dbManager},
-    m_tagPool{tagPool},
-    m_needLoadSavedState{0},
-    m_lastSelectedNotes{}
+ListViewLogic::ListViewLogic(NoteListView *noteView, NoteListModel *noteModel,
+                             QLineEdit *searchEdit, QToolButton *clearButton, TagPool *tagPool,
+                             DBManager *dbManager, QObject *parent)
+    : QObject(parent),
+      m_listView{ noteView },
+      m_listModel{ noteModel },
+      m_searchEdit{ searchEdit },
+      m_clearButton{ clearButton },
+      m_dbManager{ dbManager },
+      m_tagPool{ tagPool },
+      m_needLoadSavedState{ 0 },
+      m_lastSelectedNotes{}
 {
     m_listDelegate = new NoteListDelegate(m_listView, tagPool, m_listView);
     m_listView->setItemDelegate(m_listDelegate);
     m_listView->setDbManager(m_dbManager);
     connect(m_dbManager, &DBManager::notesListReceived, this, &ListViewLogic::loadNoteListModel);
     // note model rows moved
-    connect(m_listModel, &NoteListModel::rowsAboutToBeMovedC, m_listView, &NoteListView::rowsAboutToBeMoved);
+    connect(m_listModel, &NoteListModel::rowsAboutToBeMovedC, m_listView,
+            &NoteListView::rowsAboutToBeMoved);
     connect(m_listModel, &NoteListModel::rowsMovedC, m_listView, &NoteListView::rowsMoved);
     // note pressed
-    connect(m_listView, &NoteListView::notePressed, this, [this] (const QModelIndexList& indexes) {
-        onNotePressed(indexes);
-    });
+    connect(m_listView, &NoteListView::notePressed, this,
+            [this](const QModelIndexList &indexes) { onNotePressed(indexes); });
     connect(m_listView, &NoteListView::addTagRequested, this, &ListViewLogic::onAddTagRequest);
-    connect(m_listView, &NoteListView::removeTagRequested, this, &ListViewLogic::onRemoveTagRequest);
+    connect(m_listView, &NoteListView::removeTagRequested, this,
+            &ListViewLogic::onRemoveTagRequest);
 
-    connect(this, &ListViewLogic::requestAddTagDb, dbManager, &DBManager::addNoteToTag, Qt::QueuedConnection);
-    connect(this, &ListViewLogic::requestRemoveTagDb, dbManager, &DBManager::removeNoteFromTag, Qt::QueuedConnection);
-    connect(this, &ListViewLogic::requestRemoveNoteDb, dbManager, &DBManager::removeNote, Qt::QueuedConnection);
-    connect(this, &ListViewLogic::requestMoveNoteDb, dbManager, &DBManager::moveNode, Qt::QueuedConnection);
-    connect(this, &ListViewLogic::requestSearchInDb, dbManager, &DBManager::searchForNotes, Qt::QueuedConnection);
-    connect(this, &ListViewLogic::requestClearSearchDb, dbManager, &DBManager::clearSearch, Qt::QueuedConnection);
-    connect(m_listModel, &NoteListModel::requestUpdatePinnedRelPos,
-            dbManager, &DBManager::updateRelPosPinnedNote, Qt::QueuedConnection);
-    connect(m_listModel, &NoteListModel::requestUpdatePinnedRelPosAN,
-            dbManager, &DBManager::updateRelPosPinnedNoteAN, Qt::QueuedConnection);
-    connect(m_listModel, &NoteListModel::requestUpdatePinned,
-            dbManager, &DBManager::setNoteIsPinned, Qt::QueuedConnection);
+    connect(this, &ListViewLogic::requestAddTagDb, dbManager, &DBManager::addNoteToTag,
+            Qt::QueuedConnection);
+    connect(this, &ListViewLogic::requestRemoveTagDb, dbManager, &DBManager::removeNoteFromTag,
+            Qt::QueuedConnection);
+    connect(this, &ListViewLogic::requestRemoveNoteDb, dbManager, &DBManager::removeNote,
+            Qt::QueuedConnection);
+    connect(this, &ListViewLogic::requestMoveNoteDb, dbManager, &DBManager::moveNode,
+            Qt::QueuedConnection);
+    connect(this, &ListViewLogic::requestSearchInDb, dbManager, &DBManager::searchForNotes,
+            Qt::QueuedConnection);
+    connect(this, &ListViewLogic::requestClearSearchDb, dbManager, &DBManager::clearSearch,
+            Qt::QueuedConnection);
+    connect(m_listModel, &NoteListModel::requestUpdatePinnedRelPos, dbManager,
+            &DBManager::updateRelPosPinnedNote, Qt::QueuedConnection);
+    connect(m_listModel, &NoteListModel::requestUpdatePinnedRelPosAN, dbManager,
+            &DBManager::updateRelPosPinnedNoteAN, Qt::QueuedConnection);
+    connect(m_listModel, &NoteListModel::requestUpdatePinned, dbManager,
+            &DBManager::setNoteIsPinned, Qt::QueuedConnection);
 
-    connect(m_listView, &NoteListView::deleteNoteRequested, this, &ListViewLogic::deleteNoteRequestedI);
-    connect(m_listView, &NoteListView::restoreNoteRequested, this, &ListViewLogic::restoreNotesRequestedI);
+    connect(m_listView, &NoteListView::deleteNoteRequested, this,
+            &ListViewLogic::deleteNoteRequestedI);
+    connect(m_listView, &NoteListView::restoreNoteRequested, this,
+            &ListViewLogic::restoreNotesRequestedI);
 
-    connect(tagPool, &TagPool::dataUpdated, this, [this] (int) {
+    connect(tagPool, &TagPool::dataUpdated, this, [this](int) {
         if (m_listModel->rowCount() > 0) {
-            emit m_listModel->dataChanged(m_listModel->index(0,0),
-                                          m_listModel->index(m_listModel->rowCount() - 1,0));
+            emit m_listModel->dataChanged(m_listModel->index(0, 0),
+                                          m_listModel->index(m_listModel->rowCount() - 1, 0));
             emit m_listModel->rowCountChanged();
         }
     });
-    connect(m_listModel, &QAbstractItemModel::rowsInserted,
-            this, &ListViewLogic::updateListViewLabel);
-    connect(m_listModel, &QAbstractItemModel::rowsRemoved,
-            this, &ListViewLogic::updateListViewLabel);
-    connect(m_listView, &NoteListView::newNoteRequested,
-            this, &ListViewLogic::requestNewNote);
-    connect(m_listView, &NoteListView::moveNoteRequested,
-            this, &ListViewLogic::moveNoteRequested);
-    connect(m_listModel, &NoteListModel::rowCountChanged,
-            this, &ListViewLogic::onRowCountChanged);
-    connect(m_listView, &NoteListView::doubleClicked,
-            this, &ListViewLogic::onNoteDoubleClicked);
-    connect(m_listView, &NoteListView::setPinnedNoteRequested,
-            this, &ListViewLogic::onSetPinnedNoteRequested);
-    connect(m_listView, &NoteListView::pinnedCollapseChanged,
-            this, &ListViewLogic::onRowCountChanged);
-    connect(m_listModel, &NoteListModel::requestOpenNoteEditor,
-            this, [this](const QModelIndexList& indexes) {
-        for (const auto& index : indexes) {
-            if (index.isValid()) {
-                m_listView->openPersistentEditorC(index);
-            }
-        }
-    });
-    connect(m_listModel, &NoteListModel::requestCloseNoteEditor,
-            this, [this](const QModelIndexList& indexes) {
-        for (const auto& index : indexes) {
-            if (index.isValid()) {
-                m_listView->closePersistentEditorC(index);
-            }
-        }
-    });
-    connect(m_listDelegate, &NoteListDelegate::animationFinished,
-            m_listView, &NoteListView::onAnimationFinished);
-    connect(m_listModel, &NoteListModel::requestRemoveNotes,
-            m_listView, &NoteListView::onRemoveRowRequested);
-    connect(this, &ListViewLogic::requestNotesListInFolder,
-            m_dbManager, &DBManager::onNotesListInFolderRequested, Qt::QueuedConnection);
-    connect(this, &ListViewLogic::requestNotesListInTags,
-            m_dbManager, &DBManager::onNotesListInTagsRequested, Qt::QueuedConnection);
-    connect(m_listModel, &NoteListModel::rowsInsertedC,
-            m_listView, &NoteListView::onRowsInserted);
-    connect(m_listModel, &NoteListModel::selectNotes,
-            this, &ListViewLogic::selectNotes);
-    connect(m_listView, &NoteListView::noteListViewClicked,
-            this, &ListViewLogic::onListViewClicked);
+    connect(m_listModel, &QAbstractItemModel::rowsInserted, this,
+            &ListViewLogic::updateListViewLabel);
+    connect(m_listModel, &QAbstractItemModel::rowsRemoved, this,
+            &ListViewLogic::updateListViewLabel);
+    connect(m_listView, &NoteListView::newNoteRequested, this, &ListViewLogic::requestNewNote);
+    connect(m_listView, &NoteListView::moveNoteRequested, this, &ListViewLogic::moveNoteRequested);
+    connect(m_listModel, &NoteListModel::rowCountChanged, this, &ListViewLogic::onRowCountChanged);
+    connect(m_listView, &NoteListView::doubleClicked, this, &ListViewLogic::onNoteDoubleClicked);
+    connect(m_listView, &NoteListView::setPinnedNoteRequested, this,
+            &ListViewLogic::onSetPinnedNoteRequested);
+    connect(m_listView, &NoteListView::pinnedCollapseChanged, this,
+            &ListViewLogic::onRowCountChanged);
+    connect(m_listModel, &NoteListModel::requestOpenNoteEditor, this,
+            [this](const QModelIndexList &indexes) {
+                for (const auto &index : indexes) {
+                    if (index.isValid()) {
+                        m_listView->openPersistentEditorC(index);
+                    }
+                }
+            });
+    connect(m_listModel, &NoteListModel::requestCloseNoteEditor, this,
+            [this](const QModelIndexList &indexes) {
+                for (const auto &index : indexes) {
+                    if (index.isValid()) {
+                        m_listView->closePersistentEditorC(index);
+                    }
+                }
+            });
+    connect(m_listDelegate, &NoteListDelegate::animationFinished, m_listView,
+            &NoteListView::onAnimationFinished);
+    connect(m_listModel, &NoteListModel::requestRemoveNotes, m_listView,
+            &NoteListView::onRemoveRowRequested);
+    connect(this, &ListViewLogic::requestNotesListInFolder, m_dbManager,
+            &DBManager::onNotesListInFolderRequested, Qt::QueuedConnection);
+    connect(this, &ListViewLogic::requestNotesListInTags, m_dbManager,
+            &DBManager::onNotesListInTagsRequested, Qt::QueuedConnection);
+    connect(m_listModel, &NoteListModel::rowsInsertedC, m_listView, &NoteListView::onRowsInserted);
+    connect(m_listModel, &NoteListModel::selectNotes, this, &ListViewLogic::selectNotes);
+    connect(m_listView, &NoteListView::noteListViewClicked, this,
+            &ListViewLogic::onListViewClicked);
 }
 
 void ListViewLogic::selectNote(const QModelIndex &noteIndex)
 {
-    if (noteIndex.isValid()){
-        const auto& note = m_listModel->getNote(noteIndex);
+    if (noteIndex.isValid()) {
+        const auto &note = m_listModel->getNote(noteIndex);
         m_listView->selectionModel()->select(noteIndex, QItemSelectionModel::ClearAndSelect);
         m_listView->setCurrentIndexC(noteIndex);
         m_listView->scrollTo(noteIndex);
-        emit showNotesInEditor({note});
+        emit showNotesInEditor({ note });
     } else {
         qDebug() << __FUNCTION__ << "noteIndex is not valid";
     }
@@ -139,7 +141,7 @@ void ListViewLogic::selectNote(const QModelIndex &noteIndex)
 void ListViewLogic::moveNoteToTop(const NodeData &note)
 {
     QModelIndex noteIndex = m_listModel->getNoteIndex(note.id());
-    if (noteIndex.isValid()){
+    if (noteIndex.isValid()) {
         m_listView->scrollToTop();
 
         // move the current selected note to the top
@@ -165,14 +167,12 @@ void ListViewLogic::setNoteData(const NodeData &note)
     if (noteIndex.isValid()) {
         QMap<int, QVariant> dataValue;
         auto wasTemp = noteIndex.data(NoteListModel::NoteIsTemp).toBool();
-        dataValue[NoteListModel::NoteContent] =  QVariant::fromValue(note.content());
-        dataValue[NoteListModel::NoteFullTitle] =  QVariant::fromValue(note.fullTitle());
+        dataValue[NoteListModel::NoteContent] = QVariant::fromValue(note.content());
+        dataValue[NoteListModel::NoteFullTitle] = QVariant::fromValue(note.fullTitle());
         dataValue[NoteListModel::NoteLastModificationDateTime] =
                 QVariant::fromValue(note.lastModificationdateTime());
-        dataValue[NoteListModel::NoteIsTemp] =
-                QVariant::fromValue(note.isTempNote());
-        dataValue[NoteListModel::NoteScrollbarPos] =
-                QVariant::fromValue(note.scrollBarPosition());
+        dataValue[NoteListModel::NoteIsTemp] = QVariant::fromValue(note.isTempNote());
+        dataValue[NoteListModel::NoteScrollbarPos] = QVariant::fromValue(note.scrollBarPosition());
         m_listModel->setItemData(noteIndex, dataValue);
         if (wasTemp) {
             auto tagIds = noteIndex.data(NoteListModel::NoteTagsList).value<QSet<int>>();
@@ -191,13 +191,13 @@ void ListViewLogic::onNoteEditClosed(const NodeData &note, bool selectNext)
         QModelIndex noteIndex = m_listModel->getNoteIndex(note.id());
         if (noteIndex.isValid()) {
             auto r = noteIndex.row();
-            m_listModel->removeNotes({noteIndex});
+            m_listModel->removeNotes({ noteIndex });
             if (selectNext) {
                 QModelIndex nextIndex = m_listView->model()->index(r + 1, 0);
                 if (!nextIndex.isValid()) {
                     nextIndex = m_listView->model()->index(r - 1, 0);
                     if (!nextIndex.isValid()) {
-                        nextIndex = m_listModel->index(0,0);
+                        nextIndex = m_listModel->index(0, 0);
                     }
                 }
                 selectNote(nextIndex);
@@ -209,16 +209,16 @@ void ListViewLogic::onNoteEditClosed(const NodeData &note, bool selectNext)
 void ListViewLogic::deleteNoteRequested(const NodeData &note)
 {
     auto index = m_listModel->getNoteIndex(note.id());
-    deleteNoteRequestedI({index});
+    deleteNoteRequestedI({ index });
 }
 
 void ListViewLogic::selectNoteUp()
 {
     auto currentIndex = m_listView->currentIndex();
-    if(currentIndex.isValid()) {
+    if (currentIndex.isValid()) {
         int currentRow = currentIndex.row();
         QModelIndex aboveIndex = m_listView->model()->index(currentRow - 1, 0);
-        if(aboveIndex.isValid()) {
+        if (aboveIndex.isValid()) {
             selectNote(aboveIndex);
             m_listView->setCurrentRowActive(false);
         }
@@ -235,15 +235,15 @@ void ListViewLogic::selectNoteUp()
 void ListViewLogic::selectNoteDown()
 {
     auto currentIndex = m_listView->currentIndex();
-    if(currentIndex.isValid()) {
+    if (currentIndex.isValid()) {
         int currentRow = currentIndex.row();
         QModelIndex belowIndex = m_listView->model()->index(currentRow + 1, 0);
-        if(belowIndex.isValid()){
+        if (belowIndex.isValid()) {
             selectNote(belowIndex);
             m_listView->setCurrentRowActive(false);
         }
 
-        //if the searchEdit is not empty, set the focus to it
+        // if the searchEdit is not empty, set the focus to it
         if (!m_searchEdit->text().isEmpty()) {
             m_searchEdit->setFocus();
         } else {
@@ -273,7 +273,7 @@ void ListViewLogic::onSearchEditTextChanged(const QString &keyword)
         if (!m_listViewInfo.isInSearch) {
             auto indexes = m_listView->selectedIndex();
             m_listViewInfo.currentNotesId.clear();
-            for (const auto& index : qAsConst(indexes)) {
+            for (const auto &index : qAsConst(indexes)) {
                 if (index.isValid()) {
                     m_listViewInfo.currentNotesId.insert(index.data(NoteListModel::NoteID).toInt());
                 }
@@ -292,7 +292,7 @@ void ListViewLogic::clearSearch(bool createNewNote, int scrollToId)
     emit requestClearSearchUI();
 }
 
-void ListViewLogic::loadNoteListModel(const QVector<NodeData>& noteList, const ListViewInfo& inf)
+void ListViewLogic::loadNoteListModel(const QVector<NodeData> &noteList, const ListViewInfo &inf)
 {
     auto currentNotesId = m_listViewInfo.currentNotesId;
     m_listViewInfo = inf;
@@ -326,12 +326,12 @@ void ListViewLogic::loadNoteListModel(const QVector<NodeData>& noteList, const L
 
     if (!m_listViewInfo.isInSearch && !isInvalidCurrentNotesId(currentNotesId)) {
         if (m_listViewInfo.scrollToId != SpecialNodeID::InvalidNodeId) {
-            currentNotesId = {m_listViewInfo.scrollToId};
+            currentNotesId = { m_listViewInfo.scrollToId };
             m_listViewInfo.scrollToId = SpecialNodeID::InvalidNodeId;
         }
         if (!currentNotesId.isEmpty()) {
             QModelIndexList indexes;
-            for (const auto& id : qAsConst(currentNotesId)) {
+            for (const auto &id : qAsConst(currentNotesId)) {
                 if (id != SpecialNodeID::InvalidNodeId) {
                     indexes.append(m_listModel->getNoteIndex(id));
                 }
@@ -346,7 +346,7 @@ void ListViewLogic::loadNoteListModel(const QVector<NodeData>& noteList, const L
         m_needLoadSavedState -= 1;
         if (!m_lastSelectedNotes.isEmpty()) {
             QModelIndexList indexes;
-            for (const auto& id : qAsConst(m_lastSelectedNotes)) {
+            for (const auto &id : qAsConst(m_lastSelectedNotes)) {
                 if (id != SpecialNodeID::InvalidNodeId) {
                     indexes.append(m_listModel->getNoteIndex(id));
                 }
@@ -389,21 +389,18 @@ void ListViewLogic::onNoteMovedOut(int nodeId, int targetId)
 {
     auto index = m_listModel->getNoteIndex(nodeId);
     if (index.isValid()) {
-        if ((!m_listViewInfo.isInTag
-             && m_listViewInfo.parentFolderId != SpecialNodeID::RootFolder
+        if ((!m_listViewInfo.isInTag && m_listViewInfo.parentFolderId != SpecialNodeID::RootFolder
              && m_listViewInfo.parentFolderId != targetId)
-                || targetId == SpecialNodeID::TrashFolder) {
+            || targetId == SpecialNodeID::TrashFolder) {
             selectNoteDown();
-            m_listModel->removeNotes({index});
+            m_listModel->removeNotes({ index });
             if (m_listModel->rowCount() == 0) {
                 emit closeNoteEditor();
             }
         } else {
             NodeData note;
             QMetaObject::invokeMethod(m_dbManager, "getNode", Qt::BlockingQueuedConnection,
-                                      Q_RETURN_ARG(NodeData, note),
-                                      Q_ARG(int, nodeId)
-                                      );
+                                      Q_RETURN_ARG(NodeData, note), Q_ARG(int, nodeId));
             if (note.id() != SpecialNodeID::InvalidNodeId) {
                 m_listView->closePersistentEditorC(index);
                 m_listModel->setNoteData(index, note);
@@ -419,7 +416,7 @@ void ListViewLogic::setLastSelectedNote()
 {
     auto indexes = m_listView->selectedIndex();
     QSet<int> ids;
-    for (const auto& index : qAsConst(indexes)) {
+    for (const auto &index : qAsConst(indexes)) {
         if (index.isValid()) {
             ids.insert(index.data(NoteListModel::NoteID).toInt());
         }
@@ -432,7 +429,8 @@ void ListViewLogic::loadLastSelectedNoteRequested()
     requestLoadSavedState(2);
 }
 
-void ListViewLogic::onNotesListInFolderRequested(int parentID, bool isRecursive, bool newNote, int scrollToId)
+void ListViewLogic::onNotesListInFolderRequested(int parentID, bool isRecursive, bool newNote,
+                                                 int scrollToId)
 {
     if (m_listViewInfo.isInSearch && !m_searchEdit->text().isEmpty()) {
         m_listViewInfo.parentFolderId = parentID;
@@ -448,7 +446,8 @@ void ListViewLogic::onNotesListInFolderRequested(int parentID, bool isRecursive,
     }
 }
 
-void ListViewLogic::onNotesListInTagsRequested(const QSet<int> &tagIds, bool newNote, int scrollToId)
+void ListViewLogic::onNotesListInTagsRequested(const QSet<int> &tagIds, bool newNote,
+                                               int scrollToId)
 {
     if (m_listViewInfo.isInSearch && !m_searchEdit->text().isEmpty()) {
         m_listViewInfo.parentFolderId = SpecialNodeID::InvalidNodeId;
@@ -472,8 +471,9 @@ void ListViewLogic::selectNotes(const QModelIndexList &indexes)
         if (index.isValid()) {
             lastIdx = index;
             m_listView->selectionModel()->select(index, QItemSelectionModel::Select);
-            //m_listView->setCurrentIndex(index);
-            //m_listView->selectionModel()->setCurrentIndex(index, QItemSelectionModel::SelectCurrent);
+            // m_listView->setCurrentIndex(index);
+            // m_listView->selectionModel()->setCurrentIndex(index,
+            // QItemSelectionModel::SelectCurrent);
         }
     }
     onNotePressed(indexes);
@@ -512,7 +512,7 @@ void ListViewLogic::onNotePressed(const QModelIndexList &indexes)
 {
     QVector<NodeData> notes;
     QModelIndex lastIndex;
-    for (const auto& index : indexes) {
+    for (const auto &index : indexes) {
         if (index.isValid()) {
             const auto &note = m_listModel->getNote(index);
             notes.append(note);
@@ -530,14 +530,12 @@ void ListViewLogic::deleteNoteRequestedI(const QModelIndexList &indexes)
         bool isInTrash = false;
         QVector<NodeData> needDelete;
         QModelIndexList needDeleteI;
-        for (const auto& index : qAsConst(indexes)) {
+        for (const auto &index : qAsConst(indexes)) {
             if (index.isValid()) {
                 auto id = index.data(NoteListModel::NoteID).toInt();
                 NodeData note;
                 QMetaObject::invokeMethod(m_dbManager, "getNode", Qt::BlockingQueuedConnection,
-                                          Q_RETURN_ARG(NodeData, note),
-                                          Q_ARG(int, id)
-                                          );
+                                          Q_RETURN_ARG(NodeData, note), Q_ARG(int, id));
                 if (note.parentId() == SpecialNodeID::TrashFolder) {
                     isInTrash = true;
                 }
@@ -546,8 +544,10 @@ void ListViewLogic::deleteNoteRequestedI(const QModelIndexList &indexes)
             }
         }
         if (isInTrash) {
-            auto btn = QMessageBox::question(nullptr, "Are you sure you want to delete this note permanently",
-                                             "Are you sure you want to delete this note permanently? It will not be recoverable.");
+            auto btn = QMessageBox::question(
+                    nullptr, "Are you sure you want to delete this note permanently",
+                    "Are you sure you want to delete this note permanently? It will not be "
+                    "recoverable.");
             if (btn == QMessageBox::Yes) {
                 selectNoteDown();
                 bool needClose = false;
@@ -558,7 +558,7 @@ void ListViewLogic::deleteNoteRequestedI(const QModelIndexList &indexes)
                 if (needClose) {
                     emit closeNoteEditor();
                 }
-                for (const auto& note : qAsConst(needDelete)) {
+                for (const auto &note : qAsConst(needDelete)) {
                     emit requestRemoveNoteDb(note);
                 }
             }
@@ -572,7 +572,7 @@ void ListViewLogic::deleteNoteRequestedI(const QModelIndexList &indexes)
             if (needClose) {
                 emit closeNoteEditor();
             }
-            for (const auto& note : qAsConst(needDelete)) {
+            for (const auto &note : qAsConst(needDelete)) {
                 emit requestRemoveNoteDb(note);
             }
         }
@@ -583,14 +583,12 @@ void ListViewLogic::restoreNotesRequestedI(const QModelIndexList &indexes)
 {
     QModelIndexList needRestoredI;
     QSet<int> needRestored;
-    for (const auto& index : qAsConst(indexes)) {
+    for (const auto &index : qAsConst(indexes)) {
         if (index.isValid()) {
             auto id = index.data(NoteListModel::NoteID).toInt();
             NodeData note;
             QMetaObject::invokeMethod(m_dbManager, "getNode", Qt::BlockingQueuedConnection,
-                                      Q_RETURN_ARG(NodeData, note),
-                                      Q_ARG(int, id)
-                                      );
+                                      Q_RETURN_ARG(NodeData, note), Q_ARG(int, id));
             if (note.parentId() == SpecialNodeID::TrashFolder) {
                 needRestoredI.append(index);
                 needRestored.insert(note.id());
@@ -610,9 +608,8 @@ void ListViewLogic::restoreNotesRequestedI(const QModelIndexList &indexes)
     NodeData defaultNotesFolder;
     QMetaObject::invokeMethod(m_dbManager, "getNode", Qt::BlockingQueuedConnection,
                               Q_RETURN_ARG(NodeData, defaultNotesFolder),
-                              Q_ARG(int, SpecialNodeID::DefaultNotesFolder)
-                              );
-    for (const auto& id: qAsConst(needRestored)) {
+                              Q_ARG(int, SpecialNodeID::DefaultNotesFolder));
+    for (const auto &id : qAsConst(needRestored)) {
         emit requestMoveNoteDb(id, defaultNotesFolder);
     }
 }
@@ -622,14 +619,14 @@ void ListViewLogic::updateListViewLabel()
     QString l1, l2;
     if ((!m_listViewInfo.isInTag) && m_listViewInfo.parentFolderId == SpecialNodeID::RootFolder) {
         l1 = "All Notes";
-    } else if ((!m_listViewInfo.isInTag) && m_listViewInfo.parentFolderId == SpecialNodeID::TrashFolder) {
+    } else if ((!m_listViewInfo.isInTag)
+               && m_listViewInfo.parentFolderId == SpecialNodeID::TrashFolder) {
         l1 = "Trash";
     } else if (!m_listViewInfo.isInTag) {
         NodeData parentFolder;
         QMetaObject::invokeMethod(m_dbManager, "getNode", Qt::BlockingQueuedConnection,
                                   Q_RETURN_ARG(NodeData, parentFolder),
-                                  Q_ARG(int, m_listViewInfo.parentFolderId)
-                                  );
+                                  Q_ARG(int, m_listViewInfo.parentFolderId));
         l1 = parentFolder.fullTitle();
     } else {
         if (m_listViewInfo.currentTagList.size() == 0) {
@@ -676,7 +673,7 @@ void ListViewLogic::onNoteDoubleClicked(const QModelIndex &index)
     clearSearch(false, id);
 }
 
-void ListViewLogic::onSetPinnedNoteRequested(const QModelIndexList& indexes,  bool isPinned)
+void ListViewLogic::onSetPinnedNoteRequested(const QModelIndexList &indexes, bool isPinned)
 {
     m_listModel->setNotesIsPinned(indexes, isPinned);
 }
@@ -702,12 +699,12 @@ void ListViewLogic::onListViewClicked()
 
 void ListViewLogic::selectFirstNote()
 {
-    if (m_listModel->rowCount() > 0){
-        QModelIndex index = m_listModel->index(0,0);
+    if (m_listModel->rowCount() > 0) {
+        QModelIndex index = m_listModel->index(0, 0);
         if (index.isValid()) {
             m_listView->setCurrentIndexC(index);
-            const auto& firstNote = m_listModel->getNote(index);
-            emit showNotesInEditor({firstNote});
+            const auto &firstNote = m_listModel->getNote(index);
+            emit showNotesInEditor({ firstNote });
         }
     } else {
         emit closeNoteEditor();
@@ -741,11 +738,15 @@ void ListViewLogic::selectAllNotes()
 {
     if (m_listModel->rowCount() > 50) {
 #ifdef Q_OS_MAC
-        auto btn = QMessageBox::question(nullptr, "Are you sure you want to select more than 50 notes?",
-                                         "Selecting more than 50 notes to show in the editor might cause the app to hang.  Do you want to continue?");
+        auto btn = QMessageBox::question(nullptr,
+                                         "Are you sure you want to select more than 50 notes?",
+                                         "Selecting more than 50 notes to show in the editor might "
+                                         "cause the app to hang.  Do you want to continue?");
 #else
-        auto btn = QMessageBox::question(nullptr, "Are you sure you want to select more than 50 notes?",
-                                         "Selecting more than 50 notes to show in the editor might cause the app to hang. Do you want to continue?");
+        auto btn = QMessageBox::question(nullptr,
+                                         "Are you sure you want to select more than 50 notes?",
+                                         "Selecting more than 50 notes to show in the editor might "
+                                         "cause the app to hang. Do you want to continue?");
 #endif
         if (btn != QMessageBox::Yes) {
             return;
@@ -760,7 +761,8 @@ void ListViewLogic::selectAllNotes()
     //        if (index.isValid()) {
     //            indexes.append(index);
     //            m_listView->setCurrentIndex(index);
-    //            m_listView->selectionModel()->setCurrentIndex(index, QItemSelectionModel::SelectCurrent);
+    //            m_listView->selectionModel()->setCurrentIndex(index,
+    //            QItemSelectionModel::SelectCurrent);
     //        }
     //    }
     onNotePressed(m_listView->selectedIndex());

--- a/src/listviewlogic.h
+++ b/src/listviewlogic.h
@@ -20,12 +20,8 @@ class ListViewLogic : public QObject
 {
     Q_OBJECT
 public:
-    explicit ListViewLogic(NoteListView* noteView,
-                           NoteListModel* noteModel,
-                           QLineEdit* searchEdit,
-                           QToolButton* clearButton,
-                           TagPool* tagPool,
-                           DBManager* dbManager,
+    explicit ListViewLogic(NoteListView *noteView, NoteListModel *noteModel, QLineEdit *searchEdit,
+                           QToolButton *clearButton, TagPool *tagPool, DBManager *dbManager,
                            QObject *parent = nullptr);
     void selectNote(const QModelIndex &noteIndex);
 
@@ -33,14 +29,14 @@ public:
     void selectFirstNote();
     void setTheme(Theme theme);
     bool isAnimationRunning();
-    void setLastSavedState(const QSet<int>& lastSelectedNotes, int needLoadSavedState = 2);
+    void setLastSavedState(const QSet<int> &lastSelectedNotes, int needLoadSavedState = 2);
     void requestLoadSavedState(int needLoadSavedState);
     void selectAllNotes();
 public slots:
-    void moveNoteToTop(const NodeData& note);
-    void setNoteData(const NodeData& note);
-    void onNoteEditClosed(const NodeData& note, bool selectNext);
-    void deleteNoteRequested(const NodeData& note);
+    void moveNoteToTop(const NodeData &note);
+    void setNoteData(const NodeData &note);
+    void onNoteEditClosed(const NodeData &note, bool selectNext);
+    void deleteNoteRequested(const NodeData &note);
     void selectNoteUp();
     void selectNoteDown();
     void onSearchEditTextChanged(const QString &keyword);
@@ -53,45 +49,45 @@ public slots:
     void onNotesListInTagsRequested(const QSet<int> &tagIds, bool newNote, int scrollToId);
     void selectNotes(const QModelIndexList &indexes);
 signals:
-    void showNotesInEditor(const QVector<NodeData>& notesData);
+    void showNotesInEditor(const QVector<NodeData> &notesData);
     void requestAddTagDb(int noteId, int tagId);
     void requestRemoveTagDb(int noteId, int tagId);
-    void requestRemoveNoteDb(const NodeData& noteData);
-    void requestMoveNoteDb(int noteId, const NodeData& targetFolder);
+    void requestRemoveNoteDb(const NodeData &noteData);
+    void requestMoveNoteDb(int noteId, const NodeData &targetFolder);
     void requestHightlightSearch();
     void closeNoteEditor();
-    void noteTagListChanged(int noteId, const QSet<int>& tagIds);
-    void requestSearchInDb(const QString& keyword, const ListViewInfo& inf);
-    void requestClearSearchDb(const ListViewInfo& inf);
+    void noteTagListChanged(int noteId, const QSet<int> &tagIds);
+    void requestSearchInDb(const QString &keyword, const ListViewInfo &inf);
+    void requestClearSearchDb(const ListViewInfo &inf);
     void requestClearSearchUI();
     void requestNewNote();
     void moveNoteRequested(int id, int target);
-    void listViewLabelChanged(const QString& label1, const QString& label2);
+    void listViewLabelChanged(const QString &label1, const QString &label2);
     void setNewNoteButtonVisible(bool visible);
     void requestNotesListInFolder(int parentID, bool isRecursive, bool newNote, int scrollToId);
     void requestNotesListInTags(const QSet<int> &tagIds, bool newNote, int scrollToId);
 
 private slots:
-    void loadNoteListModel(const QVector<NodeData>& noteList, const ListViewInfo& inf);
-    void onAddTagRequest(const QModelIndex& index, int tagId);
-    void onRemoveTagRequest(const QModelIndex& index, int tagId);
+    void loadNoteListModel(const QVector<NodeData> &noteList, const ListViewInfo &inf);
+    void onAddTagRequest(const QModelIndex &index, int tagId);
+    void onRemoveTagRequest(const QModelIndex &index, int tagId);
     void onNotePressed(const QModelIndexList &indexes);
-    void deleteNoteRequestedI(const QModelIndexList& indexes);
-    void restoreNotesRequestedI(const QModelIndexList& indexes);
+    void deleteNoteRequestedI(const QModelIndexList &indexes);
+    void restoreNotesRequestedI(const QModelIndexList &indexes);
     void updateListViewLabel();
     void onRowCountChanged();
-    void onNoteDoubleClicked(const QModelIndex& index);
+    void onNoteDoubleClicked(const QModelIndex &index);
     void onSetPinnedNoteRequested(const QModelIndexList &indexes, bool isPinned);
     void onListViewClicked();
 
 private:
-    NoteListView* m_listView;
-    NoteListModel* m_listModel;
-    QLineEdit* m_searchEdit;
-    QToolButton* m_clearButton;
-    DBManager* m_dbManager;
-    NoteListDelegate* m_listDelegate;
-    TagPool* m_tagPool;
+    NoteListView *m_listView;
+    NoteListModel *m_listModel;
+    QLineEdit *m_searchEdit;
+    QToolButton *m_clearButton;
+    DBManager *m_dbManager;
+    NoteListDelegate *m_listDelegate;
+    TagPool *m_tagPool;
     ListViewInfo m_listViewInfo;
     QVector<QModelIndex> m_editorIndexes;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,8 +1,8 @@
 /*********************************************************************************************
-* Mozila License
-* Just a meantime project to see the ability of qt, the framework that my OS might be based on
-* And for those linux users that beleive in the power of notes
-*********************************************************************************************/
+ * Mozila License
+ * Just a meantime project to see the ability of qt, the framework that my OS might be based on
+ * And for those linux users that beleive in the power of notes
+ *********************************************************************************************/
 
 #include "mainwindow.h"
 #include "singleinstance.h"
@@ -11,80 +11,78 @@
 
 int main(int argc, char *argv[])
 {
-    QApplication app (argc, argv);
+    QApplication app(argc, argv);
     // Set application information
-    app.setApplicationName ("Notes");
-    app.setApplicationVersion (APP_VERSION);
+    app.setApplicationName("Notes");
+    app.setApplicationVersion(APP_VERSION);
 
     // Load fonts from resources
     // Roboto
-    QFontDatabase::addApplicationFont (":/fonts/roboto-hinted/Roboto-Bold.ttf");
-    QFontDatabase::addApplicationFont (":/fonts/roboto-hinted/Roboto-Medium.ttf");
-    QFontDatabase::addApplicationFont (":/fonts/roboto-hinted/Roboto-Regular.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/roboto-hinted/Roboto-Bold.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/roboto-hinted/Roboto-Medium.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/roboto-hinted/Roboto-Regular.ttf");
 
     // Source Sans Pro
-    QFontDatabase::addApplicationFont (":/fonts/sourcesanspro/SourceSansPro-Black.ttf");
-    QFontDatabase::addApplicationFont (":/fonts/sourcesanspro/SourceSansPro-BlackItalic.ttf");
-    QFontDatabase::addApplicationFont (":/fonts/sourcesanspro/SourceSansPro-Bold.ttf");
-    QFontDatabase::addApplicationFont (":/fonts/sourcesanspro/SourceSansPro-BoldItalic.ttf");
-    QFontDatabase::addApplicationFont (":/fonts/sourcesanspro/SourceSansPro-ExtraLight.ttf");
-    QFontDatabase::addApplicationFont (":/fonts/sourcesanspro/SourceSansPro-ExtraLightItalic.ttf");
-    QFontDatabase::addApplicationFont (":/fonts/sourcesanspro/SourceSansPro-Italic.ttf");
-    QFontDatabase::addApplicationFont (":/fonts/sourcesanspro/SourceSansPro-Light.ttf");
-    QFontDatabase::addApplicationFont (":/fonts/sourcesanspro/SourceSansPro-LightItalic.ttf");
-    QFontDatabase::addApplicationFont (":/fonts/sourcesanspro/SourceSansPro-Regular.ttf");
-    QFontDatabase::addApplicationFont (":/fonts/sourcesanspro/SourceSansPro-SemiBold.ttf");
-    QFontDatabase::addApplicationFont (":/fonts/sourcesanspro/SourceSansPro-SemiBoldItalic.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/sourcesanspro/SourceSansPro-Black.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/sourcesanspro/SourceSansPro-BlackItalic.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/sourcesanspro/SourceSansPro-Bold.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/sourcesanspro/SourceSansPro-BoldItalic.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/sourcesanspro/SourceSansPro-ExtraLight.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/sourcesanspro/SourceSansPro-ExtraLightItalic.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/sourcesanspro/SourceSansPro-Italic.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/sourcesanspro/SourceSansPro-Light.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/sourcesanspro/SourceSansPro-LightItalic.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/sourcesanspro/SourceSansPro-Regular.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/sourcesanspro/SourceSansPro-SemiBold.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/sourcesanspro/SourceSansPro-SemiBoldItalic.ttf");
 
     // Trykker
-    QFontDatabase::addApplicationFont (":/fonts/trykker/Trykker-Regular.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/trykker/Trykker-Regular.ttf");
 
     // Mate
-    QFontDatabase::addApplicationFont (":/fonts/mate/Mate-Regular.ttf");
-    QFontDatabase::addApplicationFont (":/fonts/mate/Mate-Italic.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/mate/Mate-Regular.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/mate/Mate-Italic.ttf");
 
     // PT Serif
-    QFontDatabase::addApplicationFont (":/fonts/ptserif/PTSerif-Regular.ttf");
-    QFontDatabase::addApplicationFont (":/fonts/ptserif/PTSerif-Italic.ttf");
-    QFontDatabase::addApplicationFont (":/fonts/ptserif/PTSerif-Bold.ttf");
-    QFontDatabase::addApplicationFont (":/fonts/ptserif/PTSerif-BoldItalic.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/ptserif/PTSerif-Regular.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/ptserif/PTSerif-Italic.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/ptserif/PTSerif-Bold.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/ptserif/PTSerif-BoldItalic.ttf");
 
     // iA Mono
-    QFontDatabase::addApplicationFont (":/fonts/iamono/iAWriterMonoS-Regular.ttf");
-    QFontDatabase::addApplicationFont (":/fonts/iamono/iAWriterMonoS-Italic.ttf");
-    QFontDatabase::addApplicationFont (":/fonts/iamono/iAWriterMonoS-Bold.ttf");
-    QFontDatabase::addApplicationFont (":/fonts/iamono/iAWriterMonoS-BoldItalic.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/iamono/iAWriterMonoS-Regular.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/iamono/iAWriterMonoS-Italic.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/iamono/iAWriterMonoS-Bold.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/iamono/iAWriterMonoS-BoldItalic.ttf");
 
     // iA Duo
-    QFontDatabase::addApplicationFont (":/fonts/iaduo/iAWriterDuoS-Regular.ttf");
-    QFontDatabase::addApplicationFont (":/fonts/iaduo/iAWriterDuoS-Italic.ttf");
-    QFontDatabase::addApplicationFont (":/fonts/iaduo/iAWriterDuoS-Bold.ttf");
-    QFontDatabase::addApplicationFont (":/fonts/iaduo/iAWriterDuoS-BoldItalic.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/iaduo/iAWriterDuoS-Regular.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/iaduo/iAWriterDuoS-Italic.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/iaduo/iAWriterDuoS-Bold.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/iaduo/iAWriterDuoS-BoldItalic.ttf");
 
     // iA Quattro
-    QFontDatabase::addApplicationFont (":/fonts/iaquattro/iAWriterQuattroS-Regular.ttf");
-    QFontDatabase::addApplicationFont (":/fonts/iaquattro/iAWriterQuattroS-Italic.ttf");
-    QFontDatabase::addApplicationFont (":/fonts/iaquattro/iAWriterQuattroS-Bold.ttf");
-    QFontDatabase::addApplicationFont (":/fonts/iaquattro/iAWriterQuattroS-BoldItalic.ttf");
-
+    QFontDatabase::addApplicationFont(":/fonts/iaquattro/iAWriterQuattroS-Regular.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/iaquattro/iAWriterQuattroS-Italic.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/iaquattro/iAWriterQuattroS-Bold.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/iaquattro/iAWriterQuattroS-BoldItalic.ttf");
 
     // Prevent many instances of the app to be launched
     QString name = "com.awsomeness.notes";
     SingleInstance instance;
-    if (instance.hasPrevious (name)){
+    if (instance.hasPrevious(name)) {
         return EXIT_SUCCESS;
     }
 
-    instance.listen (name);
+    instance.listen(name);
 
     // Create and Show the app
     MainWindow w;
     w.show();
 
     // Bring the Notes window to the front
-    QObject::connect(&instance, &SingleInstance::newInstance, &w, [&](){
-        (&w)->setMainWindowVisibility(true);
-    });
+    QObject::connect(&instance, &SingleInstance::newInstance, &w,
+                     [&]() { (&w)->setMainWindowVisibility(true); });
 
     return app.exec();
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1,8 +1,8 @@
 /**************************************************************************************
-* We believe in the power of notes to help us record ideas and thoughts.
-* We want people to have an easy, beautiful and simple way of doing that.
-* And so we have Notes.
-***************************************************************************************/
+ * We believe in the power of notes to help us record ideas and thoughts.
+ * We want people to have an easy, beautiful and simple way of doing that.
+ * And so we have Notes.
+ ***************************************************************************************/
 
 #include "mainwindow.h"
 #include "ui_mainwindow.h"
@@ -35,79 +35,86 @@
  * \brief MainWindow::MainWindow
  * \param parent
  */
-MainWindow::MainWindow(QWidget *parent) :
-    MainWindowBase (parent),
-    ui (new Ui::MainWindow),
-    m_settingsDatabase(Q_NULLPTR),
-    m_clearButton(Q_NULLPTR),
-    m_greenMaximizeButton(Q_NULLPTR),
-    m_redCloseButton(Q_NULLPTR),
-    m_yellowMinimizeButton(Q_NULLPTR),
-    m_trafficLightLayout(Q_NULLPTR),
-    m_newNoteButton(Q_NULLPTR),
-    m_trashButton(Q_NULLPTR),
-    m_dotsButton(Q_NULLPTR),
-    m_styleEditorButton(Q_NULLPTR),
-    m_textEdit(Q_NULLPTR),
-    m_searchEdit(Q_NULLPTR),
-    m_editorDateLabel(Q_NULLPTR),
-    m_splitter(Q_NULLPTR),
-    m_trayIcon(new QSystemTrayIcon(this)),
-    m_restoreAction(new QAction(tr("&Hide Notes"), this)),
-    m_quitAction(new QAction(tr("&Quit"), this)),
-    m_trayIconMenu(new QMenu(this)),
-    m_listView(Q_NULLPTR),
-    m_listModel(Q_NULLPTR),
-    m_listViewLogic(Q_NULLPTR),
-    m_treeView(Q_NULLPTR),
-    m_treeModel(new NodeTreeModel(this)),
-    m_treeViewLogic(Q_NULLPTR),
-    m_tagPool(Q_NULLPTR),
-    m_dbManager(Q_NULLPTR),
-    m_dbThread(Q_NULLPTR),
-    m_styleEditorWindow(this),
-    m_aboutWindow(this),
-    m_trashCounter(0),
-    m_layoutMargin(10),
-    m_shadowWidth(10),
-    m_noteListWidth(200),
-    m_nodeTreeWidth(0),
-    m_smallEditorWidth(420),
-    m_largeEditorWidth(1250),
-    m_canMoveWindow(false),
-    m_canStretchWindow(false),
-    m_isTemp(false),
-    m_isListViewScrollBarHidden(true),
-    m_isOperationRunning(false),
-    m_dontShowUpdateWindow(false),
-    m_alwaysStayOnTop(false),
-    m_useNativeWindowFrame(false),
-    m_listOfSerifFonts({QStringLiteral("Trykker"), QStringLiteral("PT Serif"), QStringLiteral("Mate")}),
-    m_listOfSansSerifFonts({QStringLiteral("Source Sans Pro"), QStringLiteral("Roboto")}),
-    m_listOfMonoFonts({QStringLiteral("iA Writer Mono S"), QStringLiteral("iA Writer Duo S"), QStringLiteral("iA Writer Quattro S")}),
-    m_chosenSerifFontIndex(0),
-    m_chosenSansSerifFontIndex(0),
-    m_chosenMonoFontIndex(0),
-    m_isNoteListCollapsed(false),
-    m_isTreeCollapsed(false),
-    m_currentCharsLimitPerFont({ 64    // Mono    TODO: is this the proper way to initialize?
-                               , 80    // Serif
-                               , 80}), // SansSerif
-    m_currentFontTypeface(FontTypeface::SansSerif),
-    #ifdef __APPLE__
-    m_displayFont(QFont(QStringLiteral("SF Pro Text")).exactMatch() ? QStringLiteral("SF Pro Text") : QStringLiteral("Roboto")),
-    #elif _WIN32
-    m_displayFont(QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI") : QStringLiteral("Roboto")),
-    #else
-    m_displayFont(QStringLiteral("Roboto")),
-    #endif
-    m_currentEditorBackgroundColor(247, 247, 247),
-    m_currentRightFrameColor(247, 247, 247),
-    m_currentTheme(Theme::Light),
-    m_currentEditorTextColor(26, 26, 26),
-    m_currentThemeBackgroundColor(247, 247, 247),
-    m_areNonEditorWidgetsVisible(true),
-    m_isFrameRightTopWidgetsVisible(true)
+MainWindow::MainWindow(QWidget *parent)
+    : MainWindowBase(parent),
+      ui(new Ui::MainWindow),
+      m_settingsDatabase(Q_NULLPTR),
+      m_clearButton(Q_NULLPTR),
+      m_greenMaximizeButton(Q_NULLPTR),
+      m_redCloseButton(Q_NULLPTR),
+      m_yellowMinimizeButton(Q_NULLPTR),
+      m_trafficLightLayout(Q_NULLPTR),
+      m_newNoteButton(Q_NULLPTR),
+      m_trashButton(Q_NULLPTR),
+      m_dotsButton(Q_NULLPTR),
+      m_styleEditorButton(Q_NULLPTR),
+      m_textEdit(Q_NULLPTR),
+      m_searchEdit(Q_NULLPTR),
+      m_editorDateLabel(Q_NULLPTR),
+      m_splitter(Q_NULLPTR),
+      m_trayIcon(new QSystemTrayIcon(this)),
+      m_restoreAction(new QAction(tr("&Hide Notes"), this)),
+      m_quitAction(new QAction(tr("&Quit"), this)),
+      m_trayIconMenu(new QMenu(this)),
+      m_listView(Q_NULLPTR),
+      m_listModel(Q_NULLPTR),
+      m_listViewLogic(Q_NULLPTR),
+      m_treeView(Q_NULLPTR),
+      m_treeModel(new NodeTreeModel(this)),
+      m_treeViewLogic(Q_NULLPTR),
+      m_tagPool(Q_NULLPTR),
+      m_dbManager(Q_NULLPTR),
+      m_dbThread(Q_NULLPTR),
+      m_styleEditorWindow(this),
+      m_aboutWindow(this),
+      m_trashCounter(0),
+      m_layoutMargin(10),
+      m_shadowWidth(10),
+      m_noteListWidth(200),
+      m_nodeTreeWidth(0),
+      m_smallEditorWidth(420),
+      m_largeEditorWidth(1250),
+      m_canMoveWindow(false),
+      m_canStretchWindow(false),
+      m_isTemp(false),
+      m_isListViewScrollBarHidden(true),
+      m_isOperationRunning(false),
+      m_dontShowUpdateWindow(false),
+      m_alwaysStayOnTop(false),
+      m_useNativeWindowFrame(false),
+      m_listOfSerifFonts(
+              { QStringLiteral("Trykker"), QStringLiteral("PT Serif"), QStringLiteral("Mate") }),
+      m_listOfSansSerifFonts({ QStringLiteral("Source Sans Pro"), QStringLiteral("Roboto") }),
+      m_listOfMonoFonts({ QStringLiteral("iA Writer Mono S"), QStringLiteral("iA Writer Duo S"),
+                          QStringLiteral("iA Writer Quattro S") }),
+      m_chosenSerifFontIndex(0),
+      m_chosenSansSerifFontIndex(0),
+      m_chosenMonoFontIndex(0),
+      m_isNoteListCollapsed(false),
+      m_isTreeCollapsed(false),
+      m_currentCharsLimitPerFont({ 64 // Mono    TODO: is this the proper way to initialize?
+                                   ,
+                                   80 // Serif
+                                   ,
+                                   80 }), // SansSerif
+      m_currentFontTypeface(FontTypeface::SansSerif),
+#ifdef __APPLE__
+      m_displayFont(QFont(QStringLiteral("SF Pro Text")).exactMatch()
+                            ? QStringLiteral("SF Pro Text")
+                            : QStringLiteral("Roboto")),
+#elif _WIN32
+      m_displayFont(QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI")
+                                                                   : QStringLiteral("Roboto")),
+#else
+      m_displayFont(QStringLiteral("Roboto")),
+#endif
+      m_currentEditorBackgroundColor(247, 247, 247),
+      m_currentRightFrameColor(247, 247, 247),
+      m_currentTheme(Theme::Light),
+      m_currentEditorTextColor(26, 26, 26),
+      m_currentThemeBackgroundColor(247, 247, 247),
+      m_areNonEditorWidgetsVisible(true),
+      m_isFrameRightTopWidgetsVisible(true)
 {
     ui->setupUi(this);
     setupMainWindow();
@@ -127,7 +134,7 @@ MainWindow::MainWindow(QWidget *parent) :
     setupSignalsSlots();
     autoCheckForUpdates();
 
-    QTimer::singleShot(200,this, SLOT(InitData()));
+    QTimer::singleShot(200, this, SLOT(InitData()));
 }
 
 /*!
@@ -142,8 +149,9 @@ void MainWindow::InitData()
     QString oldTrashDBPath(dir.path() + QStringLiteral("/Trash.ini"));
 
     bool isV0_9_0 = (QFile::exists(oldNoteDBPath) || QFile::exists(oldTrashDBPath));
-    if (isV0_9_0){
-        QProgressDialog* pd = new QProgressDialog(tr("Migrating database, please wait."), QString(), 0, 0, this);
+    if (isV0_9_0) {
+        QProgressDialog *pd =
+                new QProgressDialog(tr("Migrating database, please wait."), QString(), 0, 0, this);
         pd->setCancelButton(Q_NULLPTR);
         pd->setWindowFlags(Qt::Window | Qt::FramelessWindowHint);
         pd->setMinimumDuration(0);
@@ -151,8 +159,8 @@ void MainWindow::InitData()
 
         setButtonsAndFieldsEnabled(false);
 
-        QFutureWatcher<void>* watcher = new QFutureWatcher<void>(this);
-        connect(watcher, &QFutureWatcher<void>::finished, this, [&, pd](){
+        QFutureWatcher<void> *watcher = new QFutureWatcher<void>(this);
+        connect(watcher, &QFutureWatcher<void>::finished, this, [&, pd]() {
             pd->deleteLater();
             setButtonsAndFieldsEnabled(true);
         });
@@ -179,24 +187,25 @@ void MainWindow::InitData()
  */
 void MainWindow::setMainWindowVisibility(bool state)
 {
-    if(state){
+    if (state) {
         show();
         qApp->processEvents();
         qApp->setActiveWindow(this);
         qApp->processEvents();
         m_restoreAction->setText(tr("&Hide Notes"));
-    }else{
+    } else {
         m_restoreAction->setText(tr("&Show Notes"));
         hide();
     }
 }
 
-void MainWindow::saveLastSelectedFolderTags(bool isFolder, const QString& folderPath, const QSet<int> &tagId)
+void MainWindow::saveLastSelectedFolderTags(bool isFolder, const QString &folderPath,
+                                            const QSet<int> &tagId)
 {
     m_settingsDatabase->setValue("isSelectingFolder", isFolder);
     m_settingsDatabase->setValue("currentSelectFolder", folderPath);
     QStringList sl;
-    for (const auto& id: tagId) {
+    for (const auto &id : tagId) {
         sl.append(QString::number(id));
     }
     m_settingsDatabase->setValue("currentSelectTagsId", sl);
@@ -207,10 +216,10 @@ void MainWindow::saveExpandedFolder(const QStringList &folderPaths)
     m_settingsDatabase->setValue("currentExpandedFolder", folderPaths);
 }
 
-void MainWindow::saveLastSelectedNote(const QSet<int>& notesId)
+void MainWindow::saveLastSelectedNote(const QSet<int> &notesId)
 {
     QStringList sl;
-    for (const auto& id: notesId) {
+    for (const auto &id : notesId) {
         sl.append(QString::number(id));
     }
     m_settingsDatabase->setValue("currentSelectNotesId", sl);
@@ -220,7 +229,7 @@ void MainWindow::saveLastSelectedNote(const QSet<int>& notesId)
  * \brief MainWindow::paintEvent
  * \param event
  */
-void MainWindow::paintEvent(QPaintEvent* event)
+void MainWindow::paintEvent(QPaintEvent *event)
 {
 #if !defined(__APPLE__) && !defined(Q_OS_LINUX) && !defined(Q_OS_FREEBSD)
     if (!m_useNativeWindowFrame) {
@@ -230,15 +239,15 @@ void MainWindow::paintEvent(QPaintEvent* event)
         painter.setRenderHint(QPainter::Antialiasing);
         painter.setPen(Qt::NoPen);
 
-        dropShadow(painter, ShadowType::Linear, ShadowSide::Left  );
-        dropShadow(painter, ShadowType::Linear, ShadowSide::Top   );
-        dropShadow(painter, ShadowType::Linear, ShadowSide::Right );
+        dropShadow(painter, ShadowType::Linear, ShadowSide::Left);
+        dropShadow(painter, ShadowType::Linear, ShadowSide::Top);
+        dropShadow(painter, ShadowType::Linear, ShadowSide::Right);
         dropShadow(painter, ShadowType::Linear, ShadowSide::Bottom);
 
-        dropShadow(painter, ShadowType::Radial, ShadowSide::TopLeft    );
-        dropShadow(painter, ShadowType::Radial, ShadowSide::TopRight   );
+        dropShadow(painter, ShadowType::Radial, ShadowSide::TopLeft);
+        dropShadow(painter, ShadowType::Radial, ShadowSide::TopRight);
         dropShadow(painter, ShadowType::Radial, ShadowSide::BottomRight);
-        dropShadow(painter, ShadowType::Radial, ShadowSide::BottomLeft );
+        dropShadow(painter, ShadowType::Radial, ShadowSide::BottomLeft);
 
         painter.restore();
     }
@@ -251,10 +260,10 @@ void MainWindow::paintEvent(QPaintEvent* event)
  * \brief MainWindow::resizeEvent
  * \param event
  */
-void MainWindow::resizeEvent(QResizeEvent* event)
+void MainWindow::resizeEvent(QResizeEvent *event)
 {
-    if(m_splitter != Q_NULLPTR){
-        //restore note list width
+    if (m_splitter != Q_NULLPTR) {
+        // restore note list width
         updateFrame();
     }
 
@@ -292,8 +301,8 @@ void MainWindow::setupMainWindow()
     m_yellowMinimizeButton = new QPushButton(this);
 #ifndef __APPLE__
     //    If we want to align window buttons with searchEdit and notesList
-    //    QSpacerItem *horizontialSpacer = new QSpacerItem(3, 0, QSizePolicy::Minimum, QSizePolicy::Minimum);
-    //    m_trafficLightLayout.addSpacerItem(horizontialSpacer);
+    //    QSpacerItem *horizontialSpacer = new QSpacerItem(3, 0, QSizePolicy::Minimum,
+    //    QSizePolicy::Minimum); m_trafficLightLayout.addSpacerItem(horizontialSpacer);
     m_trafficLightLayout.addWidget(m_redCloseButton);
     m_trafficLightLayout.addWidget(m_yellowMinimizeButton);
     m_trafficLightLayout.addWidget(m_greenMaximizeButton);
@@ -308,7 +317,7 @@ void MainWindow::setupMainWindow()
 #ifdef _WIN32
     m_trafficLightLayout.setSpacing(0);
     m_trafficLightLayout.setContentsMargins(QMargins(0, 0, 0, 0));
-    m_trafficLightLayout.setGeometry(QRect(2,2,90,16));
+    m_trafficLightLayout.setGeometry(QRect(2, 2, 90, 16));
 #endif
 
     m_newNoteButton = ui->newNoteButton;
@@ -323,7 +332,7 @@ void MainWindow::setupMainWindow()
 #if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
     //    QMargins margins(m_layoutMargin, m_layoutMargin, m_layoutMargin, m_layoutMargin);
     //    setMargins(margins);
-    setMargins(QMargins(0,0,0,0));
+    setMargins(QMargins(0, 0, 0, 0));
 #elif _WIN32
     ui->verticalSpacer->changeSize(0, 7, QSizePolicy::Fixed, QSizePolicy::Fixed);
     ui->verticalSpacer_upEditorDateLabel->changeSize(0, 27, QSizePolicy::Fixed, QSizePolicy::Fixed);
@@ -359,8 +368,8 @@ void MainWindow::setupMainWindow()
     m_styleEditorButton->setStyleSheet(ss);
     m_styleEditorButton->installEventFilter(this);
 
-    ui->toggleTreeViewButton->setMaximumSize({33, 25});
-    ui->toggleTreeViewButton->setMinimumSize({33, 25});
+    ui->toggleTreeViewButton->setMaximumSize({ 33, 25 });
+    ui->toggleTreeViewButton->setMinimumSize({ 33, 25 });
     ui->toggleTreeViewButton->setCursor(QCursor(Qt::PointingHandCursor));
     ui->toggleTreeViewButton->setFocusPolicy(Qt::TabFocus);
     ui->toggleTreeViewButton->setIconSize(QSize(16, 16));
@@ -368,19 +377,20 @@ void MainWindow::setupMainWindow()
                                                            R"(    border: none; )"
                                                            R"(    padding: 0px; )"
                                                            R"(})"));
-    ui->toggleTreeViewButton->setHoveredIcon(
-                QIcon(QString::fromUtf8(":/images/drawer_icon.png")));
-    ui->toggleTreeViewButton->setNormalIcon(
-                QIcon(QString::fromUtf8(":/images/drawer_icon.png")));
-    ui->toggleTreeViewButton->setPressedIcon(
-                QIcon(QString::fromUtf8(":/images/drawer_icon.png")));
-    ui->listviewLabel2->setMinimumSize({40, 25});
-    ui->listviewLabel2->setMaximumSize({40, 25});
+    ui->toggleTreeViewButton->setHoveredIcon(QIcon(QString::fromUtf8(":/images/drawer_icon.png")));
+    ui->toggleTreeViewButton->setNormalIcon(QIcon(QString::fromUtf8(":/images/drawer_icon.png")));
+    ui->toggleTreeViewButton->setPressedIcon(QIcon(QString::fromUtf8(":/images/drawer_icon.png")));
+    ui->listviewLabel2->setMinimumSize({ 40, 25 });
+    ui->listviewLabel2->setMaximumSize({ 40, 25 });
 
 #ifdef __APPLE__
-    QString m_displayFont(QFont(QStringLiteral("SF Pro Text")).exactMatch() ? QStringLiteral("SF Pro Text") : QStringLiteral("Roboto"));
+    QString m_displayFont(QFont(QStringLiteral("SF Pro Text")).exactMatch()
+                                  ? QStringLiteral("SF Pro Text")
+                                  : QStringLiteral("Roboto"));
 #elif _WIN32
-    QString m_displayFont(QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI") : QStringLiteral("Roboto"));
+    QString m_displayFont(QFont(QStringLiteral("Segoe UI")).exactMatch()
+                                  ? QStringLiteral("Segoe UI")
+                                  : QStringLiteral("Roboto"));
 #else
     QString m_displayFont(QStringLiteral("Roboto"));
 #endif
@@ -393,8 +403,8 @@ void MainWindow::setupMainWindow()
     ui->listviewLabel2->setFont(m_titleFont);
     ui->listviewLabel1->setStyleSheet("QLabel { color :  rgb(0, 0, 0); }");
     ui->listviewLabel2->setStyleSheet("QLabel { color :  rgb(132, 132, 132); }");
-	m_splitterStyle = new SplitterStyle();
-	m_splitter->setStyle(m_splitterStyle);
+    m_splitterStyle = new SplitterStyle();
+    m_splitter->setStyle(m_splitterStyle);
     m_splitter->setHandleWidth(0);
     setNoteListLoading();
 #ifdef __APPLE__
@@ -450,30 +460,40 @@ void MainWindow::setupKeyboardShortcuts()
     new QShortcut(QKeySequence(Qt::Key_Up), this, SLOT(selectNoteUp()));
     new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_Enter), this, SLOT(setFocusOnText()));
     new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_Return), this, SLOT(setFocusOnText()));
-    //new QShortcut(QKeySequence(Qt::Key_Enter), this, SLOT(setFocusOnText()));
-    //new QShortcut(QKeySequence(Qt::Key_Return), this, SLOT(setFocusOnText()));
+    // new QShortcut(QKeySequence(Qt::Key_Enter), this, SLOT(setFocusOnText()));
+    // new QShortcut(QKeySequence(Qt::Key_Return), this, SLOT(setFocusOnText()));
     new QShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_F), this, SLOT(fullscreenWindow()));
     new QShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_L), this, SLOT(maximizeWindow()));
     new QShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_M), this, SLOT(minimizeWindow()));
     new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_Q), this, SLOT(QuitApplication()));
     new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_K), this, SLOT(toggleStayOnTop()));
     new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_J), this, SLOT(toggleNoteList()));
-    new QShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_S), this, SLOT(onStyleEditorButtonClicked()));
+    new QShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_S), this,
+                  SLOT(onStyleEditorButtonClicked()));
     new QShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_J), this, SLOT(toggleNodeTree()));
     new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_A), this, SLOT(selectAllNotesInList()));
     new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_QuoteLeft), this, SLOT(makeCode()));
     new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_B), this, SLOT(makeBold()));
     new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_I), this, SLOT(makeItalic()));
     new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_S), this, SLOT(makeStrikethrough()));
-    new QShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_Minus), this, SLOT(decreaseHeading()));
-    new QShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_Equal), this, SLOT(increaseHeading()));
-    connect(new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_0), this),  &QShortcut::activated, this, [=](){setHeading(0);});
-    connect(new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_1), this),  &QShortcut::activated, this, [=](){setHeading(1);});
-    connect(new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_2), this),  &QShortcut::activated, this, [=](){setHeading(2);});
-    connect(new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_3), this),  &QShortcut::activated, this, [=](){setHeading(3);});
-    connect(new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_4), this),  &QShortcut::activated, this, [=](){setHeading(4);});
-    connect(new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_5), this),  &QShortcut::activated, this, [=](){setHeading(5);});
-    connect(new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_6), this),  &QShortcut::activated, this, [=](){setHeading(6);});
+    new QShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_Minus), this,
+                  SLOT(decreaseHeading()));
+    new QShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_Equal), this,
+                  SLOT(increaseHeading()));
+    connect(new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_0), this), &QShortcut::activated, this,
+            [=]() { setHeading(0); });
+    connect(new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_1), this), &QShortcut::activated, this,
+            [=]() { setHeading(1); });
+    connect(new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_2), this), &QShortcut::activated, this,
+            [=]() { setHeading(2); });
+    connect(new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_3), this), &QShortcut::activated, this,
+            [=]() { setHeading(3); });
+    connect(new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_4), this), &QShortcut::activated, this,
+            [=]() { setHeading(4); });
+    connect(new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_5), this), &QShortcut::activated, this,
+            [=]() { setHeading(5); });
+    connect(new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_6), this), &QShortcut::activated, this,
+            [=]() { setHeading(6); });
     new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_Backslash), this, SLOT(resetBlockFormat()));
 
     QxtGlobalShortcut *shortcut = new QxtGlobalShortcut(this);
@@ -487,12 +507,10 @@ void MainWindow::setupKeyboardShortcuts()
         // from taking 'N' from shortcut
         m_textEdit->setDisabled(true);
         m_searchEdit->setDisabled(true);
-        setMainWindowVisibility(isHidden()
-                                || windowState() == Qt::WindowMinimized
+        setMainWindowVisibility(isHidden() || windowState() == Qt::WindowMinimized
                                 || qApp->applicationState() == Qt::ApplicationInactive);
-        if(isHidden()
-                || windowState() == Qt::WindowMinimized
-                || qApp->applicationState() == Qt::ApplicationInactive)
+        if (isHidden() || windowState() == Qt::WindowMinimized
+            || qApp->applicationState() == Qt::ApplicationInactive)
 #ifdef __APPLE__
             this->raise();
 #else
@@ -561,7 +579,8 @@ void MainWindow::setupRightFrame()
     QString ss = QStringLiteral("QFrame{ "
                                 "  background-color: %1; "
                                 "  border: none;"
-                                "}").arg(m_currentRightFrameColor.name());
+                                "}")
+                         .arg(m_currentRightFrameColor.name());
     ui->frameRight->setStyleSheet(ss);
 }
 
@@ -603,145 +622,155 @@ void MainWindow::setupTitleBarButtons()
  */
 void MainWindow::setupSignalsSlots()
 {
-    connect(&m_updater, &UpdaterWindow::dontShowUpdateWindowChanged, this, [=](bool state){m_dontShowUpdateWindow = state;});
+    connect(&m_updater, &UpdaterWindow::dontShowUpdateWindowChanged, this,
+            [=](bool state) { m_dontShowUpdateWindow = state; });
     // Style Editor Window
-    connect(&m_styleEditorWindow, &StyleEditorWindow::changeFontType, this, [=](FontTypeface fontType){changeEditorFontTypeFromStyleButtons(fontType);});
-    connect(&m_styleEditorWindow, &StyleEditorWindow::changeFontSize, this, [=](FontSizeAction fontSizeAction){changeEditorFontSizeFromStyleButtons(fontSizeAction);});
-    connect(&m_styleEditorWindow, &StyleEditorWindow::changeEditorTextWidth, this, [=](EditorTextWidth editorTextWidth){changeEditorTextWidthFromStyleButtons(editorTextWidth);});
-    connect(&m_styleEditorWindow, &StyleEditorWindow::resetEditorToDefaultSettings, this, [=](){resetEditorToDefaultSettings();});
-    connect(&m_styleEditorWindow, &StyleEditorWindow::changeTheme, this, [=](Theme theme){setTheme(theme);});
+    connect(&m_styleEditorWindow, &StyleEditorWindow::changeFontType, this,
+            [=](FontTypeface fontType) { changeEditorFontTypeFromStyleButtons(fontType); });
+    connect(&m_styleEditorWindow, &StyleEditorWindow::changeFontSize, this,
+            [=](FontSizeAction fontSizeAction) {
+                changeEditorFontSizeFromStyleButtons(fontSizeAction);
+            });
+    connect(&m_styleEditorWindow, &StyleEditorWindow::changeEditorTextWidth, this,
+            [=](EditorTextWidth editorTextWidth) {
+                changeEditorTextWidthFromStyleButtons(editorTextWidth);
+            });
+    connect(&m_styleEditorWindow, &StyleEditorWindow::resetEditorToDefaultSettings, this,
+            [=]() { resetEditorToDefaultSettings(); });
+    connect(&m_styleEditorWindow, &StyleEditorWindow::changeTheme, this,
+            [=](Theme theme) { setTheme(theme); });
     // actions
     // connect(rightToLeftActionion, &QAction::triggered, this, );
-    //connect(checkForUpdatesAction, &QAction::triggered, this, );
+    // connect(checkForUpdatesAction, &QAction::triggered, this, );
     // green button
-    connect(m_greenMaximizeButton, &QPushButton::pressed, this, &MainWindow::onGreenMaximizeButtonPressed);
-    connect(m_greenMaximizeButton, &QPushButton::clicked, this, &MainWindow::onGreenMaximizeButtonClicked);
+    connect(m_greenMaximizeButton, &QPushButton::pressed, this,
+            &MainWindow::onGreenMaximizeButtonPressed);
+    connect(m_greenMaximizeButton, &QPushButton::clicked, this,
+            &MainWindow::onGreenMaximizeButtonClicked);
     // red button
     connect(m_redCloseButton, &QPushButton::pressed, this, &MainWindow::onRedCloseButtonPressed);
     connect(m_redCloseButton, &QPushButton::clicked, this, &MainWindow::onRedCloseButtonClicked);
     // yellow button
-    connect(m_yellowMinimizeButton, &QPushButton::pressed, this, &MainWindow::onYellowMinimizeButtonPressed);
-    connect(m_yellowMinimizeButton, &QPushButton::clicked, this, &MainWindow::onYellowMinimizeButtonClicked);
+    connect(m_yellowMinimizeButton, &QPushButton::pressed, this,
+            &MainWindow::onYellowMinimizeButtonPressed);
+    connect(m_yellowMinimizeButton, &QPushButton::clicked, this,
+            &MainWindow::onYellowMinimizeButtonClicked);
     // new note button
     connect(m_newNoteButton, &QPushButton::pressed, this, &MainWindow::onNewNoteButtonPressed);
     connect(m_newNoteButton, &QPushButton::clicked, this, &MainWindow::onNewNoteButtonClicked);
     // delete note button
     connect(m_trashButton, &QPushButton::pressed, this, &MainWindow::onTrashButtonPressed);
     connect(m_trashButton, &QPushButton::clicked, this, &MainWindow::onTrashButtonClicked);
-    connect(m_listModel, &NoteListModel::rowsRemoved, this, [this](){m_trashButton->setEnabled(true);});
+    connect(m_listModel, &NoteListModel::rowsRemoved, this,
+            [this]() { m_trashButton->setEnabled(true); });
     // 3 dots button
     connect(m_dotsButton, &QPushButton::pressed, this, &MainWindow::onDotsButtonPressed);
     connect(m_dotsButton, &QPushButton::clicked, this, &MainWindow::onDotsButtonClicked);
     // Style Editor Button
-    connect(m_styleEditorButton, &QPushButton::pressed, this, &MainWindow::onStyleEditorButtonPressed);
-    connect(m_styleEditorButton, &QPushButton::clicked, this, &MainWindow::onStyleEditorButtonClicked);
+    connect(m_styleEditorButton, &QPushButton::pressed, this,
+            &MainWindow::onStyleEditorButtonPressed);
+    connect(m_styleEditorButton, &QPushButton::clicked, this,
+            &MainWindow::onStyleEditorButtonClicked);
     // textEdit scrollbar triggered
-    connect(m_textEdit->verticalScrollBar(), &QAbstractSlider::actionTriggered, this, [=](){if(m_isFrameRightTopWidgetsVisible) setVisibilityOfFrameRightNonEditor(false);});
+    connect(m_textEdit->verticalScrollBar(), &QAbstractSlider::actionTriggered, this, [=]() {
+        if (m_isFrameRightTopWidgetsVisible)
+            setVisibilityOfFrameRightNonEditor(false);
+    });
     // line edit text changed
-    connect(m_searchEdit, &QLineEdit::textChanged, m_listViewLogic, &ListViewLogic::onSearchEditTextChanged);
+    connect(m_searchEdit, &QLineEdit::textChanged, m_listViewLogic,
+            &ListViewLogic::onSearchEditTextChanged);
     // line edit enter key pressed
     connect(m_searchEdit, &QLineEdit::returnPressed, this, &MainWindow::onSearchEditReturnPressed);
     // clear button
     connect(m_clearButton, &QToolButton::clicked, this, &MainWindow::onClearButtonClicked);
     // Restore Notes Action
-    connect(m_restoreAction, &QAction::triggered, this, [this](){
-        setMainWindowVisibility(isHidden()
-                                || windowState() == Qt::WindowMinimized
+    connect(m_restoreAction, &QAction::triggered, this, [this]() {
+        setMainWindowVisibility(isHidden() || windowState() == Qt::WindowMinimized
                                 || (qApp->applicationState() == Qt::ApplicationInactive));
     });
     // Quit Action
     connect(m_quitAction, &QAction::triggered, this, &MainWindow::QuitApplication);
     // Application state changed
-    connect(qApp, &QApplication::applicationStateChanged, this,[this](){
-        m_listView->update(m_listView->currentIndex());
-    });
+    connect(qApp, &QApplication::applicationStateChanged, this,
+            [this]() { m_listView->update(m_listView->currentIndex()); });
 
     // MainWindow <-> DBManager
-    connect(this, &MainWindow::requestNodesTree,
-            m_dbManager, &DBManager::onNodeTagTreeRequested, Qt::BlockingQueuedConnection);
-    connect(this, &MainWindow::requestRestoreNotes,
-            m_dbManager, &DBManager::onRestoreNotesRequested, Qt::BlockingQueuedConnection);
-    connect(this, &MainWindow::requestImportNotes,
-            m_dbManager, &DBManager::onImportNotesRequested, Qt::BlockingQueuedConnection);
-    connect(this, &MainWindow::requestExportNotes,
-            m_dbManager, &DBManager::onExportNotesRequested, Qt::BlockingQueuedConnection);
-    connect(this, &MainWindow::requestMigrateNotesFromV0_9_0,
-            m_dbManager, &DBManager::onMigrateNotesFromV0_9_0Requested, Qt::BlockingQueuedConnection);
-    connect(this, &MainWindow::requestMigrateTrashFromV0_9_0,
-            m_dbManager, &DBManager::onMigrateTrashFrom0_9_0Requested, Qt::BlockingQueuedConnection);
+    connect(this, &MainWindow::requestNodesTree, m_dbManager, &DBManager::onNodeTagTreeRequested,
+            Qt::BlockingQueuedConnection);
+    connect(this, &MainWindow::requestRestoreNotes, m_dbManager,
+            &DBManager::onRestoreNotesRequested, Qt::BlockingQueuedConnection);
+    connect(this, &MainWindow::requestImportNotes, m_dbManager, &DBManager::onImportNotesRequested,
+            Qt::BlockingQueuedConnection);
+    connect(this, &MainWindow::requestExportNotes, m_dbManager, &DBManager::onExportNotesRequested,
+            Qt::BlockingQueuedConnection);
+    connect(this, &MainWindow::requestMigrateNotesFromV0_9_0, m_dbManager,
+            &DBManager::onMigrateNotesFromV0_9_0Requested, Qt::BlockingQueuedConnection);
+    connect(this, &MainWindow::requestMigrateTrashFromV0_9_0, m_dbManager,
+            &DBManager::onMigrateTrashFrom0_9_0Requested, Qt::BlockingQueuedConnection);
 
-    connect(m_listViewLogic, &ListViewLogic::showNotesInEditor,
-            m_noteEditorLogic, &NoteEditorLogic::showNotesInEditor);
-    connect(m_listViewLogic, &ListViewLogic::closeNoteEditor,
-            m_noteEditorLogic, &NoteEditorLogic::closeEditor);
-    connect(m_noteEditorLogic, &NoteEditorLogic::setVisibilityOfFrameRightNonEditor,
-            this, [this] (bool vl) {
-        setVisibilityOfFrameRightNonEditor(vl);
-    });
-    connect(m_noteEditorLogic, &NoteEditorLogic::moveNoteToListViewTop,
-            m_listViewLogic, &ListViewLogic::moveNoteToTop);
-    connect(m_noteEditorLogic, &NoteEditorLogic::updateNoteDataInList,
-            m_listViewLogic, &ListViewLogic::setNoteData);
-    connect(m_noteEditorLogic, &NoteEditorLogic::deleteNoteRequested,
-            m_listViewLogic, &ListViewLogic::deleteNoteRequested);
-    connect(m_listViewLogic, &ListViewLogic::noteTagListChanged,
-            m_noteEditorLogic, &NoteEditorLogic::onNoteTagListChanged);
-    connect(m_noteEditorLogic, &NoteEditorLogic::noteEditClosed,
-            m_listViewLogic, &ListViewLogic::onNoteEditClosed);
-    connect(m_listViewLogic, &ListViewLogic::requestClearSearchUI,
-            this, &MainWindow::clearSearch);
-    connect(m_treeViewLogic, &TreeViewLogic::addNoteToTag,
-            m_listViewLogic, &ListViewLogic::onAddTagRequestD);
-    connect(m_listViewLogic, &ListViewLogic::listViewLabelChanged,
-            this, [this] (const QString& l1, const QString& l2) {
-        ui->listviewLabel1->setText(l1);
-        ui->listviewLabel2->setText(l2);
-        m_splitter->setHandleWidth(0);
-    });
-    connect(ui->toggleTreeViewButton, &QPushButton::pressed,
-            this, &MainWindow::toggleNodeTree);
-    connect(m_dbManager, &DBManager::showErrorMessage,
-            this, &MainWindow::showErrorMessage, Qt::QueuedConnection);
-    connect(m_listViewLogic, &ListViewLogic::requestNewNote,
-            this, &MainWindow::onNewNoteButtonClicked);
-    connect(m_listViewLogic, &ListViewLogic::moveNoteRequested,
-            this, [this] (int id, int target) {
+    connect(m_listViewLogic, &ListViewLogic::showNotesInEditor, m_noteEditorLogic,
+            &NoteEditorLogic::showNotesInEditor);
+    connect(m_listViewLogic, &ListViewLogic::closeNoteEditor, m_noteEditorLogic,
+            &NoteEditorLogic::closeEditor);
+    connect(m_noteEditorLogic, &NoteEditorLogic::setVisibilityOfFrameRightNonEditor, this,
+            [this](bool vl) { setVisibilityOfFrameRightNonEditor(vl); });
+    connect(m_noteEditorLogic, &NoteEditorLogic::moveNoteToListViewTop, m_listViewLogic,
+            &ListViewLogic::moveNoteToTop);
+    connect(m_noteEditorLogic, &NoteEditorLogic::updateNoteDataInList, m_listViewLogic,
+            &ListViewLogic::setNoteData);
+    connect(m_noteEditorLogic, &NoteEditorLogic::deleteNoteRequested, m_listViewLogic,
+            &ListViewLogic::deleteNoteRequested);
+    connect(m_listViewLogic, &ListViewLogic::noteTagListChanged, m_noteEditorLogic,
+            &NoteEditorLogic::onNoteTagListChanged);
+    connect(m_noteEditorLogic, &NoteEditorLogic::noteEditClosed, m_listViewLogic,
+            &ListViewLogic::onNoteEditClosed);
+    connect(m_listViewLogic, &ListViewLogic::requestClearSearchUI, this, &MainWindow::clearSearch);
+    connect(m_treeViewLogic, &TreeViewLogic::addNoteToTag, m_listViewLogic,
+            &ListViewLogic::onAddTagRequestD);
+    connect(m_listViewLogic, &ListViewLogic::listViewLabelChanged, this,
+            [this](const QString &l1, const QString &l2) {
+                ui->listviewLabel1->setText(l1);
+                ui->listviewLabel2->setText(l2);
+                m_splitter->setHandleWidth(0);
+            });
+    connect(ui->toggleTreeViewButton, &QPushButton::pressed, this, &MainWindow::toggleNodeTree);
+    connect(m_dbManager, &DBManager::showErrorMessage, this, &MainWindow::showErrorMessage,
+            Qt::QueuedConnection);
+    connect(m_listViewLogic, &ListViewLogic::requestNewNote, this,
+            &MainWindow::onNewNoteButtonClicked);
+    connect(m_listViewLogic, &ListViewLogic::moveNoteRequested, this, [this](int id, int target) {
         m_treeViewLogic->onMoveNodeRequested(id, target);
         m_treeViewLogic->openFolder(target);
     });
-    connect(m_listViewLogic, &ListViewLogic::setNewNoteButtonVisible,
-            this, [this] (bool visible) {
-        ui->newNoteButton->setVisible(visible);
-    });
-    connect(m_treeViewLogic, &TreeViewLogic::noteMoved,
-            m_listViewLogic, &ListViewLogic::onNoteMovedOut);
+    connect(m_listViewLogic, &ListViewLogic::setNewNoteButtonVisible, this,
+            [this](bool visible) { ui->newNoteButton->setVisible(visible); });
+    connect(m_treeViewLogic, &TreeViewLogic::noteMoved, m_listViewLogic,
+            &ListViewLogic::onNoteMovedOut);
 
-    connect(m_listViewLogic, &ListViewLogic::requestClearSearchDb,
-            this, &MainWindow::setNoteListLoading);
-    connect(m_treeView, &NodeTreeView::loadNotesInTagsRequested,
-            this, &MainWindow::setNoteListLoading);
-    connect(m_treeView, &NodeTreeView::loadNotesInFolderRequested,
-            this, &MainWindow::setNoteListLoading);
+    connect(m_listViewLogic, &ListViewLogic::requestClearSearchDb, this,
+            &MainWindow::setNoteListLoading);
+    connect(m_treeView, &NodeTreeView::loadNotesInTagsRequested, this,
+            &MainWindow::setNoteListLoading);
+    connect(m_treeView, &NodeTreeView::loadNotesInFolderRequested, this,
+            &MainWindow::setNoteListLoading);
 #ifdef __APPLE__
     // Replace setUseNativeWindowFrame with just the part that handles pushing things up
-    connect(this, &MainWindow::toggleFullScreen, this, [=](bool isFullScreen){adjustUpperWidgets(isFullScreen);});
+    connect(this, &MainWindow::toggleFullScreen, this,
+            [=](bool isFullScreen) { adjustUpperWidgets(isFullScreen); });
 #endif
-    connect(m_treeView, &NodeTreeView::saveExpand,
-            this, &MainWindow::saveExpandedFolder);
-    connect(m_treeView, &NodeTreeView::saveSelected,
-            this, &MainWindow::saveLastSelectedFolderTags);
-    connect(m_listView, &NoteListView::saveSelectedNote,
-            this, &MainWindow::saveLastSelectedNote);
-    connect(m_treeView, &NodeTreeView::saveLastSelectedNote,
-            m_listViewLogic, &ListViewLogic::setLastSelectedNote);
-    connect(m_treeView, &NodeTreeView::requestLoadLastSelectedNote,
-            m_listViewLogic, &ListViewLogic::loadLastSelectedNoteRequested);
-    connect(m_treeView, &NodeTreeView::loadNotesInFolderRequested,
-            m_listViewLogic, &ListViewLogic::onNotesListInFolderRequested);
-    connect(m_treeView, &NodeTreeView::loadNotesInTagsRequested,
-            m_listViewLogic, &ListViewLogic::onNotesListInTagsRequested);
-    connect(this, &MainWindow::requestChangeDatabasePath,
-            m_dbManager, &DBManager::onChangeDatabasePathRequested, Qt::QueuedConnection);
+    connect(m_treeView, &NodeTreeView::saveExpand, this, &MainWindow::saveExpandedFolder);
+    connect(m_treeView, &NodeTreeView::saveSelected, this, &MainWindow::saveLastSelectedFolderTags);
+    connect(m_listView, &NoteListView::saveSelectedNote, this, &MainWindow::saveLastSelectedNote);
+    connect(m_treeView, &NodeTreeView::saveLastSelectedNote, m_listViewLogic,
+            &ListViewLogic::setLastSelectedNote);
+    connect(m_treeView, &NodeTreeView::requestLoadLastSelectedNote, m_listViewLogic,
+            &ListViewLogic::loadLastSelectedNoteRequested);
+    connect(m_treeView, &NodeTreeView::loadNotesInFolderRequested, m_listViewLogic,
+            &ListViewLogic::onNotesListInFolderRequested);
+    connect(m_treeView, &NodeTreeView::loadNotesInTagsRequested, m_listViewLogic,
+            &ListViewLogic::onNotesListInTagsRequested);
+    connect(this, &MainWindow::requestChangeDatabasePath, m_dbManager,
+            &DBManager::onChangeDatabasePathRequested, Qt::QueuedConnection);
 }
 
 /*!
@@ -758,23 +787,26 @@ void MainWindow::autoCheckForUpdates()
 
 void MainWindow::setSearchEditStyleSheet(bool isFocused = false)
 {
-    m_searchEdit->setStyleSheet(QStringLiteral("QLineEdit{ "
-                                               "  color: %3;"
-                                               "  padding-left: 21px;"
-                                               "  padding-right: 19px;"
-                                               "  border: %2;"
-                                               "  border-radius: 3px;"
-                                               "  background: %1;"
-                                               "  selection-background-color: rgb(61, 155, 218);"
-                                               "} "
-                                               "QLineEdit:focus { "
-                                               "  border: 2px solid rgb(61, 155, 218);"
-                                               "}"
-                                               "QToolButton { "
-                                               "  border: none; "
-                                               "  padding: 0px;"
-                                               "}").arg(m_currentThemeBackgroundColor.name(),
-                                                        isFocused ? "2px solid rgb(61, 155, 218)" : "1px solid rgb(205, 205, 205)", m_currentEditorTextColor.name()));
+    m_searchEdit->setStyleSheet(
+            QStringLiteral("QLineEdit{ "
+                           "  color: %3;"
+                           "  padding-left: 21px;"
+                           "  padding-right: 19px;"
+                           "  border: %2;"
+                           "  border-radius: 3px;"
+                           "  background: %1;"
+                           "  selection-background-color: rgb(61, 155, 218);"
+                           "} "
+                           "QLineEdit:focus { "
+                           "  border: 2px solid rgb(61, 155, 218);"
+                           "}"
+                           "QToolButton { "
+                           "  border: none; "
+                           "  padding: 0px;"
+                           "}")
+                    .arg(m_currentThemeBackgroundColor.name(),
+                         isFocused ? "2px solid rgb(61, 155, 218)" : "1px solid rgb(205, 205, 205)",
+                         m_currentEditorTextColor.name()));
 }
 
 /*!
@@ -805,8 +837,8 @@ void MainWindow::setupSearchEdit()
     searchButton->setCursor(Qt::ArrowCursor);
 
     // layout
-    QBoxLayout* layout = new QBoxLayout(QBoxLayout::RightToLeft, m_searchEdit);
-    layout->setContentsMargins(2,0,3,0);
+    QBoxLayout *layout = new QBoxLayout(QBoxLayout::RightToLeft, m_searchEdit);
+    layout->setContentsMargins(2, 0, 3, 0);
     layout->addWidget(m_clearButton);
     layout->addStretch();
     layout->addWidget(searchButton);
@@ -824,7 +856,7 @@ void MainWindow::setupSearchEdit()
 void MainWindow::setCurrentFontBasedOnTypeface(FontTypeface selectedFontTypeFace)
 {
     m_currentFontTypeface = selectedFontTypeFace;
-    switch(selectedFontTypeFace) {
+    switch (selectedFontTypeFace) {
     case FontTypeface::Mono:
         m_currentFontFamily = m_listOfMonoFonts.at(m_chosenMonoFontIndex);
         m_textEdit->setLineWrapColumnOrWidth(m_currentCharsLimitPerFont.mono);
@@ -845,11 +877,12 @@ void MainWindow::setCurrentFontBasedOnTypeface(FontTypeface selectedFontTypeFace
     int increaseSize = 1;
 #endif
 
-    if(m_textEdit->width() < m_smallEditorWidth) {
+    if (m_textEdit->width() < m_smallEditorWidth) {
         m_currentFontPointSize = m_editorMediumFontSize - 2;
-    } else if(m_textEdit->width() > m_smallEditorWidth && m_textEdit->width() < m_largeEditorWidth) {
+    } else if (m_textEdit->width() > m_smallEditorWidth
+               && m_textEdit->width() < m_largeEditorWidth) {
         m_currentFontPointSize = m_editorMediumFontSize;
-    } else if(m_textEdit->width() > m_largeEditorWidth) {
+    } else if (m_textEdit->width() > m_largeEditorWidth) {
         m_currentFontPointSize = m_editorMediumFontSize + increaseSize;
     }
 
@@ -882,9 +915,12 @@ void MainWindow::resetEditorSettings()
     m_textEdit->setWordWrapMode(QTextOption::WordWrap);
     m_currentTheme = Theme::Light;
 
-    m_styleEditorWindow.changeSelectedFont(FontTypeface::Mono, m_listOfMonoFonts.at(m_chosenMonoFontIndex));
-    m_styleEditorWindow.changeSelectedFont(FontTypeface::Serif, m_listOfSerifFonts.at(m_chosenSerifFontIndex));
-    m_styleEditorWindow.changeSelectedFont(FontTypeface::SansSerif, m_listOfSansSerifFonts.at(m_chosenSansSerifFontIndex));
+    m_styleEditorWindow.changeSelectedFont(FontTypeface::Mono,
+                                           m_listOfMonoFonts.at(m_chosenMonoFontIndex));
+    m_styleEditorWindow.changeSelectedFont(FontTypeface::Serif,
+                                           m_listOfSerifFonts.at(m_chosenSerifFontIndex));
+    m_styleEditorWindow.changeSelectedFont(FontTypeface::SansSerif,
+                                           m_listOfSansSerifFonts.at(m_chosenSansSerifFontIndex));
 
     setCurrentFontBasedOnTypeface(m_currentFontTypeface);
     setTheme(m_currentTheme);
@@ -896,22 +932,28 @@ void MainWindow::setupTextEditStyleSheet(int paddingLeft, int paddingRight)
     m_textEdit->setDocumentPadding(paddingLeft, 0, paddingRight, 2);
 
 #if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-    QString ss = QString("QTextEdit {background-color: %1;} "
-                         "QTextEdit{selection-background-color: rgb(63, 99, 139);}"
-                         "QTextEdit{color: %2}"
-                         "QScrollBar::handle:vertical:hover { background: rgba(40, 40, 40, 0.5); }"
-                         "QScrollBar::handle:vertical:pressed { background: rgba(40, 40, 40, 0.5); }"
-                         "QScrollBar::handle:vertical { border-radius: 4px; background: rgba(100, 100, 100, 0.5); min-height: 20px; }"
-                         "QScrollBar::vertical {border-radius: 6px; width: 10px; color: rgba(255, 255, 255,0);}"
-                         "QScrollBar {margin-right: 2px; background: transparent;}"
-                         "QScrollBar::add-line:vertical { width:0px; height: 0px; subcontrol-position: bottom; subcontrol-origin: margin; }"
-                         "QScrollBar::sub-line:vertical { width:0px; height: 0px; subcontrol-position: top; subcontrol-origin: margin; }"
-                         ).arg(m_currentEditorBackgroundColor.name(), m_currentEditorTextColor.name());
+    QString ss =
+            QString("QTextEdit {background-color: %1;} "
+                    "QTextEdit{selection-background-color: rgb(63, 99, 139);}"
+                    "QTextEdit{color: %2}"
+                    "QScrollBar::handle:vertical:hover { background: rgba(40, 40, 40, 0.5); }"
+                    "QScrollBar::handle:vertical:pressed { background: rgba(40, 40, 40, 0.5); }"
+                    "QScrollBar::handle:vertical { border-radius: 4px; background: rgba(100, 100, "
+                    "100, 0.5); min-height: 20px; }"
+                    "QScrollBar::vertical {border-radius: 6px; width: 10px; color: rgba(255, 255, "
+                    "255,0);}"
+                    "QScrollBar {margin-right: 2px; background: transparent;}"
+                    "QScrollBar::add-line:vertical { width:0px; height: 0px; subcontrol-position: "
+                    "bottom; subcontrol-origin: margin; }"
+                    "QScrollBar::sub-line:vertical { width:0px; height: 0px; subcontrol-position: "
+                    "top; subcontrol-origin: margin; }")
+                    .arg(m_currentEditorBackgroundColor.name(), m_currentEditorTextColor.name());
 #else
-    QString ss = QString("QTextEdit {background-color: %1;} "
-                         "QTextEdit{selection-background-color: rgb(63, 99, 139);}"
-                         "QTextEdit{color: %2}"
-                         ).arg(m_currentEditorBackgroundColor.name(), m_currentEditorTextColor.name());
+    QString ss =
+            QString("QTextEdit {background-color: %1;} "
+                    "QTextEdit{selection-background-color: rgb(63, 99, 139);}"
+                    "QTextEdit{color: %2}")
+                    .arg(m_currentEditorBackgroundColor.name(), m_currentEditorTextColor.name());
 #endif
 
     m_textEdit->setStyleSheet(ss);
@@ -924,29 +966,35 @@ void MainWindow::setupTextEditStyleSheet(int paddingLeft, int paddingRight)
  */
 void MainWindow::alignTextEditText()
 {
-    if(m_textEdit->lineWrapMode() == QTextEdit::WidgetWidth){
+    if (m_textEdit->lineWrapMode() == QTextEdit::WidgetWidth) {
         setupTextEditStyleSheet(m_noteEditorLogic->currentMinimumEditorPadding(),
                                 m_noteEditorLogic->currentMinimumEditorPadding());
         return;
     }
 
     QFontMetricsF fm(m_currentSelectedFont);
-    QString limitingStringSample = QString("The quick brown fox jumps over the lazy dog the quick brown fox jumps over the lazy dog the quick brown fox jumps over the lazy dog");
+    QString limitingStringSample =
+            QString("The quick brown fox jumps over the lazy dog the quick brown fox jumps over "
+                    "the lazy dog the quick brown fox jumps over the lazy dog");
     limitingStringSample.truncate(m_textEdit->lineWrapColumnOrWidth());
 #if QT_VERSION < QT_VERSION_CHECK(5, 11, 0)
     qreal textSamplePixelsWidth = fm.width(limitingStringSample);
-#else 
+#else
     qreal textSamplePixelsWidth = fm.horizontalAdvance(limitingStringSample);
 #endif
-    m_noteEditorLogic->setCurrentAdaptableEditorPadding((m_textEdit->width() - textSamplePixelsWidth) / 2 - 10);
+    m_noteEditorLogic->setCurrentAdaptableEditorPadding(
+            (m_textEdit->width() - textSamplePixelsWidth) / 2 - 10);
 
-
-    if(m_textEdit->width() - m_noteEditorLogic->currentMinimumEditorPadding()*2 > textSamplePixelsWidth &&
-            m_noteEditorLogic->currentAdaptableEditorPadding() > 0 &&
-            m_noteEditorLogic->currentAdaptableEditorPadding() > m_noteEditorLogic->currentMinimumEditorPadding()) {
-        setupTextEditStyleSheet(m_noteEditorLogic->currentAdaptableEditorPadding(), m_noteEditorLogic->currentAdaptableEditorPadding());
+    if (m_textEdit->width() - m_noteEditorLogic->currentMinimumEditorPadding() * 2
+                > textSamplePixelsWidth
+        && m_noteEditorLogic->currentAdaptableEditorPadding() > 0
+        && m_noteEditorLogic->currentAdaptableEditorPadding()
+                > m_noteEditorLogic->currentMinimumEditorPadding()) {
+        setupTextEditStyleSheet(m_noteEditorLogic->currentAdaptableEditorPadding(),
+                                m_noteEditorLogic->currentAdaptableEditorPadding());
     } else {
-        setupTextEditStyleSheet(m_noteEditorLogic->currentMinimumEditorPadding(), m_noteEditorLogic->currentMinimumEditorPadding());
+        setupTextEditStyleSheet(m_noteEditorLogic->currentMinimumEditorPadding(),
+                                m_noteEditorLogic->currentMinimumEditorPadding());
     }
 }
 
@@ -963,33 +1011,34 @@ void MainWindow::setupTextEdit()
     m_textEdit->installEventFilter(this);
     m_textEdit->verticalScrollBar()->installEventFilter(this);
     m_textEdit->setCursorWidth(2);
-    setupTextEditStyleSheet(m_noteEditorLogic->currentMinimumEditorPadding(), m_noteEditorLogic->currentMinimumEditorPadding());
+    setupTextEditStyleSheet(m_noteEditorLogic->currentMinimumEditorPadding(),
+                            m_noteEditorLogic->currentMinimumEditorPadding());
     m_textEdit->setWordWrapMode(QTextOption::WordWrap);
 
 #ifdef __APPLE__
-    if(QFont("Helvetica Neue").exactMatch()) {
+    if (QFont("Helvetica Neue").exactMatch()) {
         m_listOfSansSerifFonts.push_front("Helvetica Neue");
-    } else if(QFont("Helvetica").exactMatch()) {
+    } else if (QFont("Helvetica").exactMatch()) {
         m_listOfSansSerifFonts.push_front("Helvetica");
     }
 
-    if(QFont("SF Pro Text").exactMatch()) {
+    if (QFont("SF Pro Text").exactMatch()) {
         m_listOfSansSerifFonts.push_front("SF Pro Text");
     }
 
-    if(QFont("Avenir Next").exactMatch()) {
+    if (QFont("Avenir Next").exactMatch()) {
         m_listOfSansSerifFonts.push_front("Avenir Next");
-    } else if(QFont("Avenir").exactMatch()) {
+    } else if (QFont("Avenir").exactMatch()) {
         m_listOfSansSerifFonts.push_front("Avenir");
     }
 #elif _WIN32
-    if(QFont("Calibri").exactMatch())
+    if (QFont("Calibri").exactMatch())
         m_listOfSansSerifFonts.push_front("Calibri");
 
-    if(QFont("Arial").exactMatch())
+    if (QFont("Arial").exactMatch())
         m_listOfSansSerifFonts.push_front("Arial");
 
-    if(QFont("Segoe UI").exactMatch())
+    if (QFont("Segoe UI").exactMatch())
         m_listOfSansSerifFonts.push_front("Segoe UI");
 #endif
 
@@ -1005,25 +1054,27 @@ void MainWindow::setupTextEdit()
 void MainWindow::initializeSettingsDatabase()
 {
     // Why are we not updating the app version in Settings?
-    if(m_settingsDatabase->value(QStringLiteral("version"), "NULL") == "NULL")
+    if (m_settingsDatabase->value(QStringLiteral("version"), "NULL") == "NULL")
         m_settingsDatabase->setValue(QStringLiteral("version"), qApp->applicationVersion());
 
-    if(m_settingsDatabase->value(QStringLiteral("dontShowUpdateWindow"), "NULL") == "NULL")
-        m_settingsDatabase->setValue(QStringLiteral("dontShowUpdateWindow"), m_dontShowUpdateWindow);
+    if (m_settingsDatabase->value(QStringLiteral("dontShowUpdateWindow"), "NULL") == "NULL")
+        m_settingsDatabase->setValue(QStringLiteral("dontShowUpdateWindow"),
+                                     m_dontShowUpdateWindow);
 
-    if(m_settingsDatabase->value(QStringLiteral("windowGeometry"), "NULL") == "NULL"){
+    if (m_settingsDatabase->value(QStringLiteral("windowGeometry"), "NULL") == "NULL") {
         int initWidth = 870;
         int initHeight = 630;
         QPoint center = qApp->primaryScreen()->geometry().center();
-        QRect rect(center.x() - initWidth/2, center.y() - initHeight/2, initWidth, initHeight);
+        QRect rect(center.x() - initWidth / 2, center.y() - initHeight / 2, initWidth, initHeight);
         setGeometry(rect);
         m_settingsDatabase->setValue(QStringLiteral("windowGeometry"), saveGeometry());
     }
 
-    if(m_settingsDatabase->value(QStringLiteral("splitterSizes"), "NULL") == "NULL"){
-        m_splitter->resize(width()-2*m_layoutMargin, height()-2*m_layoutMargin);
+    if (m_settingsDatabase->value(QStringLiteral("splitterSizes"), "NULL") == "NULL") {
+        m_splitter->resize(width() - 2 * m_layoutMargin, height() - 2 * m_layoutMargin);
         QList<int> sizes = m_splitter->sizes();
-        m_noteListWidth = ui->frameMiddle->minimumWidth() != 0 ? ui->frameMiddle->minimumWidth() : m_noteListWidth;
+        m_noteListWidth = ui->frameMiddle->minimumWidth() != 0 ? ui->frameMiddle->minimumWidth()
+                                                               : m_noteListWidth;
         sizes[0] = m_noteListWidth;
         sizes[1] = m_splitter->width() - m_noteListWidth;
         m_isTreeCollapsed = sizes[0] == 0;
@@ -1039,8 +1090,9 @@ void MainWindow::initializeSettingsDatabase()
  */
 void MainWindow::setupDatabases()
 {
-    m_settingsDatabase = new QSettings(QSettings::IniFormat, QSettings::UserScope,
-                                       QStringLiteral("Awesomeness"), QStringLiteral("Settings"), this);
+    m_settingsDatabase =
+            new QSettings(QSettings::IniFormat, QSettings::UserScope, QStringLiteral("Awesomeness"),
+                          QStringLiteral("Settings"), this);
     m_settingsDatabase->setFallbacksEnabled(false);
     bool needMigrateFromV1_5_0 = false;
     if (m_settingsDatabase->value(QStringLiteral("version"), "NULL") == "NULL") {
@@ -1057,12 +1109,13 @@ void MainWindow::setupDatabases()
     QFileInfo fi(m_settingsDatabase->fileName());
     QDir dir(fi.absolutePath());
     bool folderCreated = dir.mkpath(QStringLiteral("."));
-    if(!folderCreated)
-        qFatal("ERROR: Can't create settings folder : %s", dir.absolutePath().toStdString().c_str());
+    if (!folderCreated)
+        qFatal("ERROR: Can't create settings folder : %s",
+               dir.absolutePath().toStdString().c_str());
     QString defaultDBPath = dir.path() + QDir::separator() + QStringLiteral("notes.db");
 
-    QString noteDBFilePath = m_settingsDatabase->value(
-                QStringLiteral("noteDBFilePath"), QString()).toString();
+    QString noteDBFilePath =
+            m_settingsDatabase->value(QStringLiteral("noteDBFilePath"), QString()).toString();
     if (noteDBFilePath.isEmpty()) {
         noteDBFilePath = defaultDBPath;
     }
@@ -1079,8 +1132,9 @@ void MainWindow::setupDatabases()
             m_db.setDatabaseName(noteDBFilePath);
             if (m_db.open()) {
                 QSqlQuery query(m_db);
-                bool status = query.exec("SELECT name FROM sqlite_master WHERE type='table' AND name='tag_table';");
-                if(status) {
+                bool status = query.exec(
+                        "SELECT name FROM sqlite_master WHERE type='table' AND name='tag_table';");
+                if (status) {
                     query.next();
                     if (query.value(0).toString() == "tag_table") {
                         needMigrateFromV1_5_0 = false;
@@ -1092,20 +1146,20 @@ void MainWindow::setupDatabases()
         }
         QSqlDatabase::removeDatabase(DEFAULT_DATABASE_NAME);
     }
-    if(!QFile::exists(noteDBFilePath)){
+    if (!QFile::exists(noteDBFilePath)) {
         QFile noteDBFile(noteDBFilePath);
-        if(!noteDBFile.open(QIODevice::WriteOnly))
+        if (!noteDBFile.open(QIODevice::WriteOnly))
             qFatal("ERROR : Can't create database file");
 
         noteDBFile.close();
         doCreate = true;
         needMigrateFromV1_5_0 = false;
-    } else if(needMigrateFromV1_5_0) {
+    } else if (needMigrateFromV1_5_0) {
         QFile noteDBFile(noteDBFilePath);
         noteDBFile.rename(dir.path() + QDir::separator() + QStringLiteral("oldNotes.db"));
         {
             QFile noteDBFile(noteDBFilePath);
-            if(!noteDBFile.open(QIODevice::WriteOnly))
+            if (!noteDBFile.open(QIODevice::WriteOnly))
                 qFatal("ERROR : Can't create database file");
 
             noteDBFile.close();
@@ -1120,19 +1174,18 @@ void MainWindow::setupDatabases()
     m_dbThread = new QThread;
     m_dbThread->setObjectName(QStringLiteral("dbThread"));
     m_dbManager->moveToThread(m_dbThread);
-    connect(m_dbThread, &QThread::started, this, [=](){
+    connect(m_dbThread, &QThread::started, this, [=]() {
         setTheme(m_currentTheme);
         emit requestOpenDBManager(noteDBFilePath, doCreate);
         if (needMigrateFromV1_5_0) {
-            emit requestMigrateNotesFromV1_5_0(dir.path() + QDir::separator() + QStringLiteral("oldNotes.db"));
+            emit requestMigrateNotesFromV1_5_0(dir.path() + QDir::separator()
+                                               + QStringLiteral("oldNotes.db"));
         }
     });
-    connect(this, &MainWindow::requestOpenDBManager,
-            m_dbManager, &DBManager::onOpenDBManagerRequested,
-            Qt::QueuedConnection);
-    connect(this, &MainWindow::requestMigrateNotesFromV1_5_0,
-            m_dbManager, &DBManager::onMigrateNotesFrom1_5_0Requested,
-            Qt::QueuedConnection);
+    connect(this, &MainWindow::requestOpenDBManager, m_dbManager,
+            &DBManager::onOpenDBManagerRequested, Qt::QueuedConnection);
+    connect(this, &MainWindow::requestMigrateNotesFromV1_5_0, m_dbManager,
+            &DBManager::onMigrateNotesFrom1_5_0Requested, Qt::QueuedConnection);
     connect(m_dbThread, &QThread::finished, m_dbManager, &QObject::deleteLater);
     m_dbThread->start();
 }
@@ -1147,27 +1200,14 @@ void MainWindow::setupModelView()
     m_listModel = new NoteListModel(m_listView);
     m_listView->setTagPool(m_tagPool);
     m_listView->setModel(m_listModel);
-    m_listViewLogic = new ListViewLogic(m_listView,
-                                        m_listModel,
-                                        m_searchEdit,
-                                        m_clearButton,
-                                        m_tagPool,
-                                        m_dbManager,
-                                        this);
-    m_treeView = static_cast<NodeTreeView*>(ui->treeView);
+    m_listViewLogic = new ListViewLogic(m_listView, m_listModel, m_searchEdit, m_clearButton,
+                                        m_tagPool, m_dbManager, this);
+    m_treeView = static_cast<NodeTreeView *>(ui->treeView);
     m_treeView->setModel(m_treeModel);
-    m_treeViewLogic = new TreeViewLogic(m_treeView,
-                                        m_treeModel,
-                                        m_dbManager,
-                                        this);
-    m_noteEditorLogic = new NoteEditorLogic(m_textEdit,
-                                            m_editorDateLabel,
-                                            m_searchEdit,
-                                            static_cast<TagListView*>(ui->tagListView),
-                                            m_tagPool,
-                                            m_dbManager,
-                                            this);
-
+    m_treeViewLogic = new TreeViewLogic(m_treeView, m_treeModel, m_dbManager, this);
+    m_noteEditorLogic = new NoteEditorLogic(m_textEdit, m_editorDateLabel, m_searchEdit,
+                                            static_cast<TagListView *>(ui->tagListView), m_tagPool,
+                                            m_dbManager, this);
 }
 
 /*!
@@ -1177,44 +1217,52 @@ void MainWindow::setupModelView()
  */
 void MainWindow::restoreStates()
 {
-    setUseNativeWindowFrame(m_settingsDatabase->value(QStringLiteral("useNativeWindowFrame"), false).toBool());
+    setUseNativeWindowFrame(
+            m_settingsDatabase->value(QStringLiteral("useNativeWindowFrame"), false).toBool());
 
-    if(m_settingsDatabase->value(QStringLiteral("windowGeometry"), "NULL") != "NULL")
-        this->restoreGeometry(m_settingsDatabase->value(QStringLiteral("windowGeometry")).toByteArray());
+    if (m_settingsDatabase->value(QStringLiteral("windowGeometry"), "NULL") != "NULL")
+        this->restoreGeometry(
+                m_settingsDatabase->value(QStringLiteral("windowGeometry")).toByteArray());
 
-    if(m_settingsDatabase->value(QStringLiteral("editorSettingsWindowGeometry"), "NULL") != "NULL")
-        m_styleEditorWindow.restoreGeometry(m_settingsDatabase->value(QStringLiteral("editorSettingsWindowGeometry")).toByteArray());
+    if (m_settingsDatabase->value(QStringLiteral("editorSettingsWindowGeometry"), "NULL") != "NULL")
+        m_styleEditorWindow.restoreGeometry(
+                m_settingsDatabase->value(QStringLiteral("editorSettingsWindowGeometry"))
+                        .toByteArray());
 
 #if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-    /// Set margin to zero if the window is maximized
-    //    if (isMaximized()) {
-    //        setMargins(QMargins(0,0,0,0));
-    //    }
+        /// Set margin to zero if the window is maximized
+        //    if (isMaximized()) {
+        //        setMargins(QMargins(0,0,0,0));
+        //    }
 #endif
 
-    if(m_settingsDatabase->value(QStringLiteral("dontShowUpdateWindow"), "NULL") != "NULL")
-        m_dontShowUpdateWindow = m_settingsDatabase->value(QStringLiteral("dontShowUpdateWindow")).toBool();
+    if (m_settingsDatabase->value(QStringLiteral("dontShowUpdateWindow"), "NULL") != "NULL")
+        m_dontShowUpdateWindow =
+                m_settingsDatabase->value(QStringLiteral("dontShowUpdateWindow")).toBool();
 
     m_splitter->setCollapsible(0, true);
     m_splitter->resize(width() - m_layoutMargin, height() - m_layoutMargin);
-    if(m_settingsDatabase->value(QStringLiteral("splitterSizes"), "NULL") != "NULL")
-        m_splitter->restoreState(m_settingsDatabase->value(QStringLiteral("splitterSizes")).toByteArray());
+    if (m_settingsDatabase->value(QStringLiteral("splitterSizes"), "NULL") != "NULL")
+        m_splitter->restoreState(
+                m_settingsDatabase->value(QStringLiteral("splitterSizes")).toByteArray());
     m_noteListWidth = m_splitter->sizes().at(1);
     m_splitter->setCollapsible(0, false);
 
-    QString selectedFontTypefaceFromDatabase = m_settingsDatabase->value(QStringLiteral("selectedFontTypeface"), "NULL").toString();
-    if(selectedFontTypefaceFromDatabase != "NULL") {
-        if(selectedFontTypefaceFromDatabase == "Mono") {
+    QString selectedFontTypefaceFromDatabase =
+            m_settingsDatabase->value(QStringLiteral("selectedFontTypeface"), "NULL").toString();
+    if (selectedFontTypefaceFromDatabase != "NULL") {
+        if (selectedFontTypefaceFromDatabase == "Mono") {
             m_currentFontTypeface = FontTypeface::Mono;
-        } else if(selectedFontTypefaceFromDatabase == "Serif") {
+        } else if (selectedFontTypefaceFromDatabase == "Serif") {
             m_currentFontTypeface = FontTypeface::Serif;
-        } else if(selectedFontTypefaceFromDatabase == "SansSerif") {
+        } else if (selectedFontTypefaceFromDatabase == "SansSerif") {
             m_currentFontTypeface = FontTypeface::SansSerif;
         }
     }
 
-    if(m_settingsDatabase->value(QStringLiteral("editorMediumFontSize"), "NULL") != "NULL") {
-        m_editorMediumFontSize = m_settingsDatabase->value(QStringLiteral("editorMediumFontSize")).toInt();
+    if (m_settingsDatabase->value(QStringLiteral("editorMediumFontSize"), "NULL") != "NULL") {
+        m_editorMediumFontSize =
+                m_settingsDatabase->value(QStringLiteral("editorMediumFontSize")).toInt();
     } else {
 #ifdef __APPLE__
         m_editorMediumFontSize = 17;
@@ -1225,9 +1273,9 @@ void MainWindow::restoreStates()
     m_currentFontPointSize = m_editorMediumFontSize;
 
     bool isTextFullWidth = false;
-    if(m_settingsDatabase->value(QStringLiteral("isTextFullWidth"), "NULL") != "NULL") {
+    if (m_settingsDatabase->value(QStringLiteral("isTextFullWidth"), "NULL") != "NULL") {
         isTextFullWidth = m_settingsDatabase->value(QStringLiteral("isTextFullWidth")).toBool();
-        if(isTextFullWidth) {
+        if (isTextFullWidth) {
             m_textEdit->setLineWrapMode(QTextEdit::WidgetWidth);
         } else {
             m_textEdit->setLineWrapMode(QTextEdit::FixedColumnWidth);
@@ -1236,69 +1284,83 @@ void MainWindow::restoreStates()
         m_textEdit->setLineWrapMode(QTextEdit::FixedColumnWidth);
     }
 
-    if(m_settingsDatabase->value(QStringLiteral("charsLimitPerFontMono"), "NULL") != "NULL")
-        m_currentCharsLimitPerFont.mono = m_settingsDatabase->value(QStringLiteral("charsLimitPerFontMono")).toInt();
-    if(m_settingsDatabase->value(QStringLiteral("charsLimitPerFontSerif"), "NULL") != "NULL")
-        m_currentCharsLimitPerFont.serif = m_settingsDatabase->value(QStringLiteral("charsLimitPerFontSerif")).toInt();
-    if(m_settingsDatabase->value(QStringLiteral("charsLimitPerFontSansSerif"), "NULL") != "NULL")
-        m_currentCharsLimitPerFont.sansSerif = m_settingsDatabase->value(QStringLiteral("charsLimitPerFontSansSerif")).toInt();
+    if (m_settingsDatabase->value(QStringLiteral("charsLimitPerFontMono"), "NULL") != "NULL")
+        m_currentCharsLimitPerFont.mono =
+                m_settingsDatabase->value(QStringLiteral("charsLimitPerFontMono")).toInt();
+    if (m_settingsDatabase->value(QStringLiteral("charsLimitPerFontSerif"), "NULL") != "NULL")
+        m_currentCharsLimitPerFont.serif =
+                m_settingsDatabase->value(QStringLiteral("charsLimitPerFontSerif")).toInt();
+    if (m_settingsDatabase->value(QStringLiteral("charsLimitPerFontSansSerif"), "NULL") != "NULL")
+        m_currentCharsLimitPerFont.sansSerif =
+                m_settingsDatabase->value(QStringLiteral("charsLimitPerFontSansSerif")).toInt();
 
-    if(m_settingsDatabase->value(QStringLiteral("chosenMonoFont"), "NULL") != "NULL") {
+    if (m_settingsDatabase->value(QStringLiteral("chosenMonoFont"), "NULL") != "NULL") {
         QString fontName = m_settingsDatabase->value(QStringLiteral("chosenMonoFont")).toString();
         int fontIndex = m_listOfMonoFonts.indexOf(fontName);
-        if(fontIndex != -1) {
+        if (fontIndex != -1) {
             m_chosenMonoFontIndex = fontIndex;
         }
     }
-    if(m_settingsDatabase->value(QStringLiteral("chosenSerifFont"), "NULL") != "NULL") {
+    if (m_settingsDatabase->value(QStringLiteral("chosenSerifFont"), "NULL") != "NULL") {
         QString fontName = m_settingsDatabase->value(QStringLiteral("chosenSerifFont")).toString();
         int fontIndex = m_listOfSerifFonts.indexOf(fontName);
-        if(fontIndex != -1) {
+        if (fontIndex != -1) {
             m_chosenSerifFontIndex = fontIndex;
         }
     }
-    if(m_settingsDatabase->value(QStringLiteral("chosenSansSerifFont"), "NULL") != "NULL") {
-        QString fontName = m_settingsDatabase->value(QStringLiteral("chosenSansSerifFont")).toString();
+    if (m_settingsDatabase->value(QStringLiteral("chosenSansSerifFont"), "NULL") != "NULL") {
+        QString fontName =
+                m_settingsDatabase->value(QStringLiteral("chosenSansSerifFont")).toString();
         int fontIndex = m_listOfSansSerifFonts.indexOf(fontName);
-        if(fontIndex != -1) {
+        if (fontIndex != -1) {
             m_chosenSansSerifFontIndex = fontIndex;
         }
     }
 
-    if(m_settingsDatabase->value(QStringLiteral("theme"), "NULL") != "NULL") {
+    if (m_settingsDatabase->value(QStringLiteral("theme"), "NULL") != "NULL") {
         QString chosenTheme = m_settingsDatabase->value(QStringLiteral("theme")).toString();
         if (chosenTheme == "Light") {
             m_currentTheme = Theme::Light;
-        } else if(chosenTheme == "Dark") {
+        } else if (chosenTheme == "Dark") {
             m_currentTheme = Theme::Dark;
-        } else if(chosenTheme == "Sepia") {
+        } else if (chosenTheme == "Sepia") {
             m_currentTheme = Theme::Sepia;
         }
     }
 
-    m_styleEditorWindow.changeSelectedFont(FontTypeface::Mono, m_listOfMonoFonts.at(m_chosenMonoFontIndex));
-    m_styleEditorWindow.changeSelectedFont(FontTypeface::Serif, m_listOfSerifFonts.at(m_chosenSerifFontIndex));
-    m_styleEditorWindow.changeSelectedFont(FontTypeface::SansSerif, m_listOfSansSerifFonts.at(m_chosenSansSerifFontIndex));
+    m_styleEditorWindow.changeSelectedFont(FontTypeface::Mono,
+                                           m_listOfMonoFonts.at(m_chosenMonoFontIndex));
+    m_styleEditorWindow.changeSelectedFont(FontTypeface::Serif,
+                                           m_listOfSerifFonts.at(m_chosenSerifFontIndex));
+    m_styleEditorWindow.changeSelectedFont(FontTypeface::SansSerif,
+                                           m_listOfSansSerifFonts.at(m_chosenSansSerifFontIndex));
 
     setCurrentFontBasedOnTypeface(m_currentFontTypeface);
     setTheme(m_currentTheme);
-    m_styleEditorWindow.restoreSelectedOptions(isTextFullWidth, m_currentFontTypeface, m_currentTheme);
+    m_styleEditorWindow.restoreSelectedOptions(isTextFullWidth, m_currentFontTypeface,
+                                               m_currentTheme);
 
-    auto expandedFolder = m_settingsDatabase->value(QStringLiteral("currentExpandedFolder"), QStringList{}).toStringList();
-    auto isSelectingFolder = m_settingsDatabase->value(QStringLiteral("isSelectingFolder"), true).toBool();
-    auto currentSelectFolder = m_settingsDatabase->value(QStringLiteral("currentSelectFolder"), QString{}).toString();
-    auto currentSelectTagsId = m_settingsDatabase->value(QStringLiteral("currentSelectTagsId"), QStringList{}).toStringList();
+    auto expandedFolder =
+            m_settingsDatabase->value(QStringLiteral("currentExpandedFolder"), QStringList{})
+                    .toStringList();
+    auto isSelectingFolder =
+            m_settingsDatabase->value(QStringLiteral("isSelectingFolder"), true).toBool();
+    auto currentSelectFolder =
+            m_settingsDatabase->value(QStringLiteral("currentSelectFolder"), QString{}).toString();
+    auto currentSelectTagsId =
+            m_settingsDatabase->value(QStringLiteral("currentSelectTagsId"), QStringList{})
+                    .toStringList();
     QSet<int> tags;
-    for (const auto& tagId : qAsConst(currentSelectTagsId)) {
+    for (const auto &tagId : qAsConst(currentSelectTagsId)) {
         tags.insert(tagId.toInt());
     }
-    m_treeViewLogic->setLastSavedState(isSelectingFolder,
-                                       currentSelectFolder,
-                                       tags,
+    m_treeViewLogic->setLastSavedState(isSelectingFolder, currentSelectFolder, tags,
                                        expandedFolder);
-    auto currentSelectNotes = m_settingsDatabase->value(QStringLiteral("currentSelectNotesId"), QStringList{}).toStringList();
+    auto currentSelectNotes =
+            m_settingsDatabase->value(QStringLiteral("currentSelectNotesId"), QStringList{})
+                    .toStringList();
     QSet<int> notesId;
-    for (const auto& id : qAsConst(currentSelectNotes)) {
+    for (const auto &id : qAsConst(currentSelectNotes)) {
         notesId.insert(id.toInt());
     }
     m_listViewLogic->setLastSavedState(notesId);
@@ -1329,9 +1391,9 @@ void MainWindow::setButtonsAndFieldsEnabled(bool doEnable)
 void MainWindow::resetBlockFormat()
 {
     QTextCursor cursor = m_textEdit->textCursor();
-    if (!cursor.hasSelection()){
+    if (!cursor.hasSelection()) {
         cursor.select(QTextCursor::BlockUnderCursor);
-        if(!cursor.hasSelection()){
+        if (!cursor.hasSelection()) {
             return;
         }
     }
@@ -1348,13 +1410,13 @@ void MainWindow::resetBlockFormat()
 void MainWindow::resetFormat(const QString &formatChars)
 {
     QTextCursor cursor = m_textEdit->textCursor();
-    if(!cursor.hasSelection()){
+    if (!cursor.hasSelection()) {
         cursor.select(QTextCursor::WordUnderCursor);
         if (!cursor.hasSelection()) {
-            for (int i = 0; i < 2; ++i){
+            for (int i = 0; i < 2; ++i) {
                 QTextDocument *doc = m_textEdit->document();
-                cursor = doc->find(QRegularExpression(QRegularExpression::escape(formatChars)), cursor.selectionStart(),
-                                   QTextDocument::FindBackward);
+                cursor = doc->find(QRegularExpression(QRegularExpression::escape(formatChars)),
+                                   cursor.selectionStart(), QTextDocument::FindBackward);
                 if (!cursor.isNull()) {
                     cursor.deleteChar();
                 }
@@ -1365,13 +1427,13 @@ void MainWindow::resetFormat(const QString &formatChars)
     QString selectedText = cursor.selectedText();
     int start = cursor.selectionStart();
     int end = cursor.selectionEnd();
-    if(selectedText.startsWith(formatChars) && selectedText.endsWith(formatChars)){
-        if(selectedText.length() == formatChars.length()){
+    if (selectedText.startsWith(formatChars) && selectedText.endsWith(formatChars)) {
+        if (selectedText.length() == formatChars.length()) {
             return;
         }
         start += formatChars.length();
         end -= formatChars.length();
-    }else if(selectedText.startsWith(formatChars) || selectedText.endsWith(formatChars)){
+    } else if (selectedText.startsWith(formatChars) || selectedText.endsWith(formatChars)) {
         return;
     }
     cursor.beginEditBlock();
@@ -1410,7 +1472,7 @@ void MainWindow::onNewNoteButtonClicked()
     // save the data of the previous selected
     m_noteEditorLogic->saveNoteToDB();
 
-    if(!m_searchEdit->text().isEmpty()){
+    if (!m_searchEdit->text().isEmpty()) {
         m_listViewLogic->clearSearch(true);
     } else {
         this->createNewNote();
@@ -1457,8 +1519,8 @@ void MainWindow::onDotsButtonClicked()
     m_dotsButton->setIcon(QIcon(QStringLiteral(":/images/3dots_Regular.png")));
 
     QMenu mainMenu;
-    QMenu* viewMenu = mainMenu.addMenu(tr("&View"));
-    QMenu* importExportNotesMenu = mainMenu.addMenu(tr("&Import/Export Notes"));
+    QMenu *viewMenu = mainMenu.addMenu(tr("&View"));
+    QMenu *importExportNotesMenu = mainMenu.addMenu(tr("&Import/Export Notes"));
     importExportNotesMenu->setToolTipsVisible(true);
     viewMenu->setToolTipsVisible(true);
     mainMenu.setToolTipsVisible(true);
@@ -1468,15 +1530,13 @@ void MainWindow::onDotsButtonClicked()
     connect(closeMenu, &QShortcut::activated, &mainMenu, &QMenu::close);
 
 #if defined(Q_OS_WINDOWS) || defined(Q_OS_WIN)
-    mainMenu.setStyleSheet(QStringLiteral(
-                               "QMenu { "
-                               "  background-color: rgb(255, 255, 255); "
-                               "  border: 1px solid #C7C7C7; "
-                               "  }"
-                               "QMenu::item:selected { "
-                               "  background: 1px solid #308CC6; "
-                               "}")
-                           );
+    mainMenu.setStyleSheet(QStringLiteral("QMenu { "
+                                          "  background-color: rgb(255, 255, 255); "
+                                          "  border: 1px solid #C7C7C7; "
+                                          "  }"
+                                          "QMenu::item:selected { "
+                                          "  background: 1px solid #308CC6; "
+                                          "}"));
 #endif
 
 #ifdef __APPLE__
@@ -1491,47 +1551,47 @@ void MainWindow::onDotsButtonClicked()
 
     // note list visiblity action
     bool isNoteListCollapsed = (m_splitter->sizes().at(1) == 0);
-    QString actionLabel = isNoteListCollapsed? tr("Show &notes list")
-                                             : tr("Hide &notes list");
+    QString actionLabel = isNoteListCollapsed ? tr("Show &notes list") : tr("Hide &notes list");
 
-    QAction* noteListVisbilityAction = viewMenu->addAction(actionLabel);
+    QAction *noteListVisbilityAction = viewMenu->addAction(actionLabel);
     noteListVisbilityAction->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_J));
 #if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
     noteListVisbilityAction->setShortcutVisibleInContextMenu(true);
 #endif
-    if(isNoteListCollapsed){
+    if (isNoteListCollapsed) {
         connect(noteListVisbilityAction, &QAction::triggered, this, &MainWindow::expandNoteList);
-    }else{
+    } else {
         connect(noteListVisbilityAction, &QAction::triggered, this, &MainWindow::collapseNoteList);
     }
 
     // folder tree view visiblity action
     bool isFolderTreeCollapsed = (m_splitter->sizes().at(0) == 0);
-    QString factionLabel = isFolderTreeCollapsed? tr("Show &folders tree")
-                                                : tr("Hide &folders tree");
+    QString factionLabel =
+            isFolderTreeCollapsed ? tr("Show &folders tree") : tr("Hide &folders tree");
 
-    QAction* folderTreeVisbilityAction = viewMenu->addAction(factionLabel);
+    QAction *folderTreeVisbilityAction = viewMenu->addAction(factionLabel);
     folderTreeVisbilityAction->setShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_J));
 #if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
     folderTreeVisbilityAction->setShortcutVisibleInContextMenu(true);
 #endif
-    if(isFolderTreeCollapsed){
+    if (isFolderTreeCollapsed) {
         connect(folderTreeVisbilityAction, &QAction::triggered, this, &MainWindow::expandNodeTree);
-    }else{
-        connect(folderTreeVisbilityAction, &QAction::triggered, this, &MainWindow::collapseNodeTree);
+    } else {
+        connect(folderTreeVisbilityAction, &QAction::triggered, this,
+                &MainWindow::collapseNodeTree);
     }
 
     // Enable or Disable markdown
-    QString markDownLabel = m_noteEditorLogic->markdownEnabled() ? tr("Disable &Markdown")
-                                                                 : tr("Enable &Markdown");
+    QString markDownLabel =
+            m_noteEditorLogic->markdownEnabled() ? tr("Disable &Markdown") : tr("Enable &Markdown");
 
-    QAction* noteMarkdownVisibiltyAction = viewMenu->addAction(markDownLabel);
+    QAction *noteMarkdownVisibiltyAction = viewMenu->addAction(markDownLabel);
 #if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
     noteMarkdownVisibiltyAction->setShortcutVisibleInContextMenu(true);
 #endif
 
     connect(noteMarkdownVisibiltyAction, &QAction::triggered, m_noteEditorLogic, [this] {
-        if(m_noteEditorLogic->markdownEnabled()){
+        if (m_noteEditorLogic->markdownEnabled()) {
             m_noteEditorLogic->setMarkdownEnabled(false);
         } else {
             m_noteEditorLogic->setMarkdownEnabled(true);
@@ -1539,28 +1599,24 @@ void MainWindow::onDotsButtonClicked()
     });
 
     // Check for update action
-    QAction* checkForUpdatesAction = mainMenu.addAction(tr("Check For &Updates"));
-    connect (checkForUpdatesAction, &QAction::triggered, this, &MainWindow::checkForUpdates);
+    QAction *checkForUpdatesAction = mainMenu.addAction(tr("Check For &Updates"));
+    connect(checkForUpdatesAction, &QAction::triggered, this, &MainWindow::checkForUpdates);
 
     // Autostart
-    QAction* autostartAction = mainMenu.addAction(tr("&Start automatically"));
-    connect (autostartAction, &QAction::triggered, this, [=]() {
-        m_autostart.setAutostart(autostartAction->isChecked());
-    });
+    QAction *autostartAction = mainMenu.addAction(tr("&Start automatically"));
+    connect(autostartAction, &QAction::triggered, this,
+            [=]() { m_autostart.setAutostart(autostartAction->isChecked()); });
     autostartAction->setCheckable(true);
     autostartAction->setChecked(m_autostart.isAutostart());
 
-    QAction* changeDBPathAction = mainMenu.addAction(tr("&Change database path"));
-    connect (changeDBPathAction, &QAction::triggered, this, [=]() {
+    QAction *changeDBPathAction = mainMenu.addAction(tr("&Change database path"));
+    connect(changeDBPathAction, &QAction::triggered, this, [=]() {
         auto btn = QMessageBox::question(this, "Are you sure you want to change the database path?",
-                                         "Are you sure you want to change the database path?"
-                                         );
+                                         "Are you sure you want to change the database path?");
         if (btn == QMessageBox::Yes) {
             auto newDbPath = QFileDialog::getSaveFileName(this, "New Database path", "notes.db");
             if (!newDbPath.isEmpty()) {
-                m_settingsDatabase->setValue(
-                            QStringLiteral("noteDBFilePath"),
-                            newDbPath);
+                m_settingsDatabase->setValue(QStringLiteral("noteDBFilePath"), newDbPath);
                 QFileInfo noteDBFilePathInf(newDbPath);
                 QDir().mkpath(noteDBFilePathInf.absolutePath());
                 emit requestChangeDatabasePath(newDbPath);
@@ -1569,39 +1625,33 @@ void MainWindow::onDotsButtonClicked()
     });
 
     // About Notes
-    QAction* aboutAction = mainMenu.addAction(tr("&About Notes"));
-    connect (aboutAction, &QAction::triggered, this, [&]() {
-
-        m_aboutWindow.show();
-    });
+    QAction *aboutAction = mainMenu.addAction(tr("&About Notes"));
+    connect(aboutAction, &QAction::triggered, this, [&]() { m_aboutWindow.show(); });
 
     mainMenu.addSeparator();
 
     // Close the app
-    QAction* quitAppAction = mainMenu.addAction(tr("&Quit"));
-    connect (quitAppAction, &QAction::triggered, this, &MainWindow::QuitApplication);
+    QAction *quitAppAction = mainMenu.addAction(tr("&Quit"));
+    connect(quitAppAction, &QAction::triggered, this, &MainWindow::QuitApplication);
 
     // Export notes action
-    QAction* exportNotesFileAction = importExportNotesMenu->addAction (tr("&Export"));
+    QAction *exportNotesFileAction = importExportNotesMenu->addAction(tr("&Export"));
     exportNotesFileAction->setToolTip(tr("Save notes to a file"));
-    connect (exportNotesFileAction, &QAction::triggered,
-             this, &MainWindow::exportNotesFile);
+    connect(exportNotesFileAction, &QAction::triggered, this, &MainWindow::exportNotesFile);
 
     // Import notes action
-    QAction* importNotesFileAction = importExportNotesMenu->addAction (tr("&Import"));
+    QAction *importNotesFileAction = importExportNotesMenu->addAction(tr("&Import"));
     importNotesFileAction->setToolTip(tr("Add notes from a file"));
-    connect (importNotesFileAction, &QAction::triggered,
-             this, &MainWindow::importNotesFile);
+    connect(importNotesFileAction, &QAction::triggered, this, &MainWindow::importNotesFile);
 
     // Restore notes action
-    QAction* restoreNotesFileAction = importExportNotesMenu->addAction (tr("&Restore"));
+    QAction *restoreNotesFileAction = importExportNotesMenu->addAction(tr("&Restore"));
     restoreNotesFileAction->setToolTip(tr("Replace all notes with notes from a file"));
-    connect (restoreNotesFileAction, &QAction::triggered,
-             this, &MainWindow::restoreNotesFile);
+    connect(restoreNotesFileAction, &QAction::triggered, this, &MainWindow::restoreNotesFile);
 
-#if !defined (Q_OS_LINUX) && !defined(Q_OS_FREEBSD)
+#if !defined(Q_OS_LINUX) && !defined(Q_OS_FREEBSD)
     // Stay on top action
-    QAction* stayOnTopAction = viewMenu->addAction(tr("Always stay on top"));
+    QAction *stayOnTopAction = viewMenu->addAction(tr("Always stay on top"));
     stayOnTopAction->setToolTip(tr("Always keep the notes application on top of all windows"));
     stayOnTopAction->setCheckable(true);
     stayOnTopAction->setChecked(m_alwaysStayOnTop);
@@ -1610,11 +1660,12 @@ void MainWindow::onDotsButtonClicked()
 
 #ifndef __APPLE__
     // Use native frame action
-    QAction* useNativeFrameAction = viewMenu->addAction(tr("&Use native window frame"));
+    QAction *useNativeFrameAction = viewMenu->addAction(tr("&Use native window frame"));
     useNativeFrameAction->setToolTip(tr("Use the window frame provided by the window manager"));
     useNativeFrameAction->setCheckable(true);
     useNativeFrameAction->setChecked(m_useNativeWindowFrame);
-    connect(useNativeFrameAction, &QAction::triggered, this, &MainWindow::askBeforeSettingNativeWindowFrame);
+    connect(useNativeFrameAction, &QAction::triggered, this,
+            &MainWindow::askBeforeSettingNativeWindowFrame);
 #endif
 
     mainMenu.exec(m_dotsButton->mapToGlobal(QPoint(0, m_dotsButton->height())));
@@ -1647,11 +1698,12 @@ void MainWindow::onStyleEditorButtonClicked()
                                 "}");
     m_styleEditorButton->setStyleSheet(ss);
 
+    if (m_settingsDatabase->value(QStringLiteral("editorSettingsWindowGeometry"), "NULL") == "NULL")
+        m_styleEditorWindow.move(m_newNoteButton->mapToGlobal(
+                QPoint(-m_styleEditorWindow.width() - m_newNoteButton->width(),
+                       m_newNoteButton->height())));
 
-    if(m_settingsDatabase->value(QStringLiteral("editorSettingsWindowGeometry"), "NULL") == "NULL")
-        m_styleEditorWindow.move(m_newNoteButton->mapToGlobal(QPoint(-m_styleEditorWindow.width()-m_newNoteButton->width(),m_newNoteButton->height())));
-
-    if(m_styleEditorWindow.isVisible()) {
+    if (m_styleEditorWindow.isVisible()) {
         m_styleEditorWindow.hide();
     } else {
         m_styleEditorWindow.show();
@@ -1665,19 +1717,25 @@ void MainWindow::onStyleEditorButtonClicked()
  */
 void MainWindow::changeEditorFontTypeFromStyleButtons(FontTypeface fontTypeface)
 {
-    if(m_currentFontTypeface == fontTypeface) {
-        switch(fontTypeface) {
+    if (m_currentFontTypeface == fontTypeface) {
+        switch (fontTypeface) {
         case FontTypeface::Mono:
-            m_chosenMonoFontIndex = m_chosenMonoFontIndex < m_listOfMonoFonts.length()-1 ? m_chosenMonoFontIndex + 1 : 0;
+            m_chosenMonoFontIndex = m_chosenMonoFontIndex < m_listOfMonoFonts.length() - 1
+                    ? m_chosenMonoFontIndex + 1
+                    : 0;
             break;
         case FontTypeface::Serif:
-            m_chosenSerifFontIndex = m_chosenSerifFontIndex < m_listOfSerifFonts.length()-1 ? m_chosenSerifFontIndex + 1 : 0;
+            m_chosenSerifFontIndex = m_chosenSerifFontIndex < m_listOfSerifFonts.length() - 1
+                    ? m_chosenSerifFontIndex + 1
+                    : 0;
             break;
         case FontTypeface::SansSerif:
-            m_chosenSansSerifFontIndex = m_chosenSansSerifFontIndex < m_listOfSansSerifFonts.length()-1 ? m_chosenSansSerifFontIndex + 1 : 0;
+            m_chosenSansSerifFontIndex =
+                    m_chosenSansSerifFontIndex < m_listOfSansSerifFonts.length() - 1
+                    ? m_chosenSansSerifFontIndex + 1
+                    : 0;
             break;
         }
-
     }
 
     setCurrentFontBasedOnTypeface(fontTypeface);
@@ -1692,7 +1750,7 @@ void MainWindow::changeEditorFontTypeFromStyleButtons(FontTypeface fontTypeface)
  */
 void MainWindow::changeEditorFontSizeFromStyleButtons(FontSizeAction fontSizeAction)
 {
-    switch(fontSizeAction) {
+    switch (fontSizeAction) {
     case FontSizeAction::Increase:
         m_editorMediumFontSize += 1;
         setCurrentFontBasedOnTypeface(m_currentFontTypeface);
@@ -1711,16 +1769,16 @@ void MainWindow::changeEditorFontSizeFromStyleButtons(FontSizeAction fontSizeAct
  */
 void MainWindow::changeEditorTextWidthFromStyleButtons(EditorTextWidth editorTextWidth)
 {
-    switch(editorTextWidth) {
+    switch (editorTextWidth) {
     case EditorTextWidth::FullWidth:
-        if(m_textEdit->lineWrapMode() != QTextEdit::WidgetWidth)
+        if (m_textEdit->lineWrapMode() != QTextEdit::WidgetWidth)
             m_textEdit->setLineWrapMode(QTextEdit::WidgetWidth);
         else
             m_textEdit->setLineWrapMode(QTextEdit::FixedColumnWidth);
         break;
     case EditorTextWidth::Increase:
         m_textEdit->setLineWrapMode(QTextEdit::FixedColumnWidth);
-        switch(m_currentFontTypeface){
+        switch (m_currentFontTypeface) {
         case FontTypeface::Mono:
             m_currentCharsLimitPerFont.mono = m_currentCharsLimitPerFont.mono + 1;
             break;
@@ -1734,7 +1792,7 @@ void MainWindow::changeEditorTextWidthFromStyleButtons(EditorTextWidth editorTex
         break;
     case EditorTextWidth::Decrease:
         m_textEdit->setLineWrapMode(QTextEdit::FixedColumnWidth);
-        switch(m_currentFontTypeface){
+        switch (m_currentFontTypeface) {
         case FontTypeface::Mono:
             m_currentCharsLimitPerFont.mono -= 1;
             break;
@@ -1767,64 +1825,86 @@ void MainWindow::resetEditorToDefaultSettings()
 void MainWindow::setTheme(Theme theme)
 {
     m_currentTheme = theme;
-    switch(theme) {
-    case Theme::Light:
-    {
+    switch (theme) {
+    case Theme::Light: {
         m_currentThemeBackgroundColor = QColor(247, 247, 247);
         m_currentEditorTextColor = QColor(26, 26, 26);
         m_currentEditorBackgroundColor = m_currentThemeBackgroundColor;
         m_currentRightFrameColor = m_currentThemeBackgroundColor;
         this->setStyleSheet(QStringLiteral("QMainWindow { background-color: rgb(247, 247, 247);}"));
-        ui->verticalSpacer_upSearchEdit->setStyleSheet(QStringLiteral("QWidget{ background-color: %1;}").arg(m_currentThemeBackgroundColor.name()));
-        ui->verticalSpacer_upSearchEdit2->setStyleSheet(QStringLiteral("QWidget{ background-color: %1;}").arg(m_currentThemeBackgroundColor.name()));
-        ui->verticalSpacer_upTreeView->setStyleSheet(QStringLiteral("QWidget{ background-color: %1;}").arg(m_currentThemeBackgroundColor.name()));
-        setupTextEditStyleSheet(m_noteEditorLogic->currentMinimumEditorPadding(), m_noteEditorLogic->currentMinimumEditorPadding());
+        ui->verticalSpacer_upSearchEdit->setStyleSheet(
+                QStringLiteral("QWidget{ background-color: %1;}")
+                        .arg(m_currentThemeBackgroundColor.name()));
+        ui->verticalSpacer_upSearchEdit2->setStyleSheet(
+                QStringLiteral("QWidget{ background-color: %1;}")
+                        .arg(m_currentThemeBackgroundColor.name()));
+        ui->verticalSpacer_upTreeView->setStyleSheet(
+                QStringLiteral("QWidget{ background-color: %1;}")
+                        .arg(m_currentThemeBackgroundColor.name()));
+        setupTextEditStyleSheet(m_noteEditorLogic->currentMinimumEditorPadding(),
+                                m_noteEditorLogic->currentMinimumEditorPadding());
         m_listViewLogic->setTheme(Theme::Light);
-        m_styleEditorWindow.setTheme(Theme::Light, m_currentThemeBackgroundColor, m_currentEditorTextColor);
+        m_styleEditorWindow.setTheme(Theme::Light, m_currentThemeBackgroundColor,
+                                     m_currentEditorTextColor);
         m_aboutWindow.setTheme(m_currentThemeBackgroundColor, m_currentEditorTextColor);
         m_noteEditorLogic->setTheme(theme);
-        ui->listviewLabel1->setStyleSheet(QStringLiteral("QLabel { color : %1; }")
-                                          .arg(QColor(26, 26, 26).name()));
+        ui->listviewLabel1->setStyleSheet(
+                QStringLiteral("QLabel { color : %1; }").arg(QColor(26, 26, 26).name()));
         m_treeViewLogic->setTheme(theme);
         break;
     }
-    case Theme::Dark:
-    {
+    case Theme::Dark: {
         m_currentThemeBackgroundColor = QColor(30, 30, 30);
         m_currentEditorTextColor = QColor(204, 204, 204);
         m_currentEditorBackgroundColor = m_currentThemeBackgroundColor;
         m_currentRightFrameColor = m_currentThemeBackgroundColor;
         this->setStyleSheet(QStringLiteral("QMainWindow { background-color: rgb(26, 26, 26); }"));
-        ui->verticalSpacer_upSearchEdit->setStyleSheet(QStringLiteral("QWidget{ background-color: %1;}").arg(m_currentThemeBackgroundColor.name()));
-        ui->verticalSpacer_upSearchEdit2->setStyleSheet(QStringLiteral("QWidget{ background-color: %1;}").arg(m_currentThemeBackgroundColor.name()));
-        ui->verticalSpacer_upTreeView->setStyleSheet(QStringLiteral("QWidget{ background-color: %1;}").arg(m_currentThemeBackgroundColor.name()));
-        setupTextEditStyleSheet(m_noteEditorLogic->currentMinimumEditorPadding(), m_noteEditorLogic->currentMinimumEditorPadding());
+        ui->verticalSpacer_upSearchEdit->setStyleSheet(
+                QStringLiteral("QWidget{ background-color: %1;}")
+                        .arg(m_currentThemeBackgroundColor.name()));
+        ui->verticalSpacer_upSearchEdit2->setStyleSheet(
+                QStringLiteral("QWidget{ background-color: %1;}")
+                        .arg(m_currentThemeBackgroundColor.name()));
+        ui->verticalSpacer_upTreeView->setStyleSheet(
+                QStringLiteral("QWidget{ background-color: %1;}")
+                        .arg(m_currentThemeBackgroundColor.name()));
+        setupTextEditStyleSheet(m_noteEditorLogic->currentMinimumEditorPadding(),
+                                m_noteEditorLogic->currentMinimumEditorPadding());
         m_listViewLogic->setTheme(Theme::Dark);
-        m_styleEditorWindow.setTheme(Theme::Dark, m_currentThemeBackgroundColor, m_currentEditorTextColor);
+        m_styleEditorWindow.setTheme(Theme::Dark, m_currentThemeBackgroundColor,
+                                     m_currentEditorTextColor);
         m_aboutWindow.setTheme(m_currentThemeBackgroundColor, m_currentEditorTextColor);
         m_noteEditorLogic->setTheme(theme);
-        ui->listviewLabel1->setStyleSheet(QStringLiteral("QLabel { color : %1; }")
-                                          .arg(QColor(204, 204, 204).name()));
+        ui->listviewLabel1->setStyleSheet(
+                QStringLiteral("QLabel { color : %1; }").arg(QColor(204, 204, 204).name()));
         m_treeViewLogic->setTheme(theme);
         break;
     }
-    case Theme::Sepia:
-    {
+    case Theme::Sepia: {
         m_currentThemeBackgroundColor = QColor(251, 240, 217);
         m_currentEditorTextColor = QColor(95, 74, 50);
         m_currentEditorBackgroundColor = m_currentThemeBackgroundColor;
         m_currentRightFrameColor = m_currentThemeBackgroundColor;
-        this->setStyleSheet(QStringLiteral("QMainWindow { background-color: rgb(251, 240, 217); }"));
-        ui->verticalSpacer_upSearchEdit->setStyleSheet(QStringLiteral("QWidget{ background-color: %1;}").arg(m_currentThemeBackgroundColor.name()));
-        ui->verticalSpacer_upSearchEdit2->setStyleSheet(QStringLiteral("QWidget{ background-color: %1;}").arg(m_currentThemeBackgroundColor.name()));
-        ui->verticalSpacer_upTreeView->setStyleSheet(QStringLiteral("QWidget{ background-color: %1;}").arg(m_currentThemeBackgroundColor.name()));
-        setupTextEditStyleSheet(m_noteEditorLogic->currentMinimumEditorPadding(), m_noteEditorLogic->currentMinimumEditorPadding());
+        this->setStyleSheet(
+                QStringLiteral("QMainWindow { background-color: rgb(251, 240, 217); }"));
+        ui->verticalSpacer_upSearchEdit->setStyleSheet(
+                QStringLiteral("QWidget{ background-color: %1;}")
+                        .arg(m_currentThemeBackgroundColor.name()));
+        ui->verticalSpacer_upSearchEdit2->setStyleSheet(
+                QStringLiteral("QWidget{ background-color: %1;}")
+                        .arg(m_currentThemeBackgroundColor.name()));
+        ui->verticalSpacer_upTreeView->setStyleSheet(
+                QStringLiteral("QWidget{ background-color: %1;}")
+                        .arg(m_currentThemeBackgroundColor.name()));
+        setupTextEditStyleSheet(m_noteEditorLogic->currentMinimumEditorPadding(),
+                                m_noteEditorLogic->currentMinimumEditorPadding());
         m_listViewLogic->setTheme(Theme::Sepia);
-        m_styleEditorWindow.setTheme(Theme::Sepia, m_currentThemeBackgroundColor, QColor(26, 26, 26));
+        m_styleEditorWindow.setTheme(Theme::Sepia, m_currentThemeBackgroundColor,
+                                     QColor(26, 26, 26));
         m_aboutWindow.setTheme(m_currentThemeBackgroundColor, QColor(26, 26, 26));
         m_noteEditorLogic->setTheme(theme);
-        ui->listviewLabel1->setStyleSheet(QStringLiteral("QLabel { color : %1; }")
-                                          .arg(QColor(26, 26, 26).name()));
+        ui->listviewLabel1->setStyleSheet(
+                QStringLiteral("QLabel { color : %1; }").arg(QColor(26, 26, 26).name()));
         m_treeViewLogic->setTheme(theme);
         break;
     }
@@ -1840,7 +1920,6 @@ void MainWindow::deleteSelectedNote()
 {
     m_noteEditorLogic->deleteCurrentNote();
 }
-
 
 /*!
  * \brief MainWindow::onClearButtonClicked
@@ -1862,7 +1941,7 @@ void MainWindow::createNewNote()
 {
     m_listView->scrollToTop();
     QModelIndex newNoteIndex;
-    if (!m_noteEditorLogic->isTempNote()){
+    if (!m_noteEditorLogic->isTempNote()) {
         // clear the textEdit
         m_noteEditorLogic->closeEditor();
 
@@ -1877,8 +1956,7 @@ void MainWindow::createNewNote()
             NodeData parent;
             QMetaObject::invokeMethod(m_dbManager, "getNode", Qt::BlockingQueuedConnection,
                                       Q_RETURN_ARG(NodeData, parent),
-                                      Q_ARG(int, inf.parentFolderId)
-                                      );
+                                      Q_ARG(int, inf.parentFolderId));
             if (parent.nodeType() == NodeData::Folder) {
                 tmpNote.setParentId(parent.id());
                 tmpNote.setParentName(parent.fullTitle());
@@ -1892,8 +1970,7 @@ void MainWindow::createNewNote()
         }
         int noteId = SpecialNodeID::InvalidNodeId;
         QMetaObject::invokeMethod(m_dbManager, "nextAvailableNodeId", Qt::BlockingQueuedConnection,
-                                  Q_RETURN_ARG(int, noteId)
-                                  );
+                                  Q_RETURN_ARG(int, noteId));
         tmpNote.setId(noteId);
         tmpNote.setIsTempNote(true);
         if (inf.isInTag) {
@@ -1903,11 +1980,10 @@ void MainWindow::createNewNote()
         newNoteIndex = m_listModel->insertNote(tmpNote, 0);
 
         // update the editor
-        m_noteEditorLogic->showNotesInEditor({tmpNote});
+        m_noteEditorLogic->showNotesInEditor({ tmpNote });
     } else {
-        newNoteIndex = m_listModel->getNoteIndex(
-                    m_noteEditorLogic->currentEditingNoteId());
-        m_listView->animateAddedRow({newNoteIndex});
+        newNoteIndex = m_listModel->getNoteIndex(m_noteEditorLogic->currentEditingNoteId());
+        m_listView->animateAddedRow({ newNoteIndex });
     }
     // update the current selected index
     m_listView->setCurrentIndexC(newNoteIndex);
@@ -1925,7 +2001,8 @@ void MainWindow::selectNoteDown()
  */
 void MainWindow::setFocusOnText()
 {
-    if(m_noteEditorLogic->currentEditingNoteId() != SpecialNodeID::InvalidNodeId && !m_textEdit->hasFocus()) {
+    if (m_noteEditorLogic->currentEditingNoteId() != SpecialNodeID::InvalidNodeId
+        && !m_textEdit->hasFocus()) {
         m_listView->setCurrentRowActive(true);
         m_textEdit->setFocus();
     }
@@ -1943,23 +2020,25 @@ void MainWindow::selectNoteUp()
 void MainWindow::fullscreenWindow()
 {
 #if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-    if(isFullScreen()){
-        if(!isMaximized()) {
-            m_noteListWidth = m_splitter->sizes().at(0) != 0 ? m_splitter->sizes().at(0) : m_noteListWidth;
-            //            QMargins margins(m_layoutMargin,m_layoutMargin,m_layoutMargin,m_layoutMargin);
+    if (isFullScreen()) {
+        if (!isMaximized()) {
+            m_noteListWidth =
+                    m_splitter->sizes().at(0) != 0 ? m_splitter->sizes().at(0) : m_noteListWidth;
+            //            QMargins
+            //            margins(m_layoutMargin,m_layoutMargin,m_layoutMargin,m_layoutMargin);
             //            setMargins(margins);
         }
 
         setWindowState(windowState() & ~Qt::WindowFullScreen);
-    }else{
+    } else {
         setWindowState(windowState() | Qt::WindowFullScreen);
         //        setMargins(QMargins(0,0,0,0));
     }
 
 #elif _WIN32
-    if(isFullScreen()){
+    if (isFullScreen()) {
         showNormal();
-    }else{
+    } else {
         showFullScreen();
     }
 #endif
@@ -1987,12 +2066,13 @@ void MainWindow::makeStrikethrough()
 
 /*!
  * \brief MainWindow::applyFormat
- * Make selected text bold, italic, or strikethrough it, by inserting the passed formatting char(s) before
- * and after the selection. If nothing is selected, insert formating char(s) before/after the word under the cursor
+ * Make selected text bold, italic, or strikethrough it, by inserting the passed formatting char(s)
+ * before and after the selection. If nothing is selected, insert formating char(s) before/after the
+ * word under the cursor
  */
 void MainWindow::applyFormat(const QString &formatChars)
 {
-    if(alreadyAppliedFormat(formatChars)){
+    if (alreadyAppliedFormat(formatChars)) {
         resetFormat(formatChars);
         return;
     }
@@ -2000,7 +2080,7 @@ void MainWindow::applyFormat(const QString &formatChars)
     QTextCursor cursor = m_textEdit->textCursor();
     bool selected = cursor.hasSelection();
     bool wordUnderCursor = false;
-    if(!selected){
+    if (!selected) {
         cursor.select(QTextCursor::WordUnderCursor);
         wordUnderCursor = cursor.hasSelection();
     }
@@ -2012,14 +2092,15 @@ void MainWindow::applyFormat(const QString &formatChars)
     cursor.insertText(formatChars);
     cursor.setPosition(end + formatChars.length(), QTextCursor::MoveAnchor);
     cursor.insertText(formatChars);
-    cursor.movePosition(QTextCursor::PreviousCharacter, QTextCursor::MoveAnchor, formatChars.length());
+    cursor.movePosition(QTextCursor::PreviousCharacter, QTextCursor::MoveAnchor,
+                        formatChars.length());
     cursor.endEditBlock();
-    if(selected){
+    if (selected) {
         QTextDocument *doc = m_textEdit->document();
         QTextCursor found = doc->find(selectedText, start);
         m_textEdit->setTextCursor(found);
-    }else if(!wordUnderCursor){
-        for(int i = 0; i < formatChars.length(); ++i){
+    } else if (!wordUnderCursor) {
+        for (int i = 0; i < formatChars.length(); ++i) {
             m_textEdit->moveCursor(QTextCursor::Left, QTextCursor::MoveAnchor);
         }
     }
@@ -2032,29 +2113,30 @@ void MainWindow::applyFormat(const QString &formatChars)
 void MainWindow::maximizeWindow()
 {
 #if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-    if(isMaximized()){
-        if(!isFullScreen()){
-            m_noteListWidth = m_splitter->sizes().at(0) != 0 ? m_splitter->sizes().at(0) : m_noteListWidth;
-            QMargins margins(m_layoutMargin,m_layoutMargin,m_layoutMargin,m_layoutMargin);
+    if (isMaximized()) {
+        if (!isFullScreen()) {
+            m_noteListWidth =
+                    m_splitter->sizes().at(0) != 0 ? m_splitter->sizes().at(0) : m_noteListWidth;
+            QMargins margins(m_layoutMargin, m_layoutMargin, m_layoutMargin, m_layoutMargin);
 
             setMargins(margins);
             setWindowState(windowState() & ~Qt::WindowMaximized);
-        }else{
+        } else {
             setWindowState(windowState() & ~Qt::WindowFullScreen);
         }
 
-    }else{
+    } else {
         setWindowState(windowState() | Qt::WindowMaximized);
         //        setMargins(QMargins(0,0,0,0));
     }
 #elif _WIN32
-    if(isMaximized()){
+    if (isMaximized()) {
         setWindowState(windowState() & ~Qt::WindowMaximized);
         setWindowState(windowState() & ~Qt::WindowFullScreen);
-    }else if(isFullScreen()){
+    } else if (isFullScreen()) {
         setWindowState((windowState() | Qt::WindowMaximized) & ~Qt::WindowFullScreen);
         setGeometry(qApp->primaryScreen()->availableGeometry());
-    }else{
+    } else {
         setWindowState(windowState() | Qt::WindowMaximized);
         setGeometry(qApp->primaryScreen()->availableGeometry());
     }
@@ -2120,11 +2202,12 @@ void MainWindow::restoreNotesFile()
 {
     if (m_listModel->rowCount() > 0) {
         QMessageBox msgBox;
-        msgBox.setText(tr("Warning: All current notes will be lost. Make sure to create a backup copy before proceeding."));
+        msgBox.setText(tr("Warning: All current notes will be lost. Make sure to create a backup "
+                          "copy before proceeding."));
         msgBox.setInformativeText(tr("Would you like to continue?"));
         msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
         msgBox.setDefaultButton(QMessageBox::No);
-        if  (msgBox.exec() != QMessageBox::Yes) {
+        if (msgBox.exec() != QMessageBox::Yes) {
             return;
         }
     }
@@ -2139,8 +2222,7 @@ void MainWindow::restoreNotesFile()
  */
 void MainWindow::executeImport(const bool replace)
 {
-    QString fileName = QFileDialog::getOpenFileName(this,
-                                                    tr("Open Notes Backup File"), "",
+    QString fileName = QFileDialog::getOpenFileName(this, tr("Open Notes Backup File"), "",
                                                     tr("Notes Backup File (*.nbk)"));
     if (fileName.isEmpty()) {
         return;
@@ -2153,7 +2235,7 @@ void MainWindow::executeImport(const bool replace)
         file.close();
 
         setButtonsAndFieldsEnabled(false);
-        if(replace) {
+        if (replace) {
             emit requestRestoreNotes(fileName);
         } else {
             emit requestImportNotes(fileName);
@@ -2173,8 +2255,7 @@ void MainWindow::executeImport(const bool replace)
  */
 void MainWindow::exportNotesFile()
 {
-    QString fileName = QFileDialog::getSaveFileName(this,
-                                                    tr("Save Notes"), "notes.nbk",
+    QString fileName = QFileDialog::getSaveFileName(this, tr("Save Notes"), "notes.nbk",
                                                     tr("Notes Backup File (*.nbk)"));
     if (fileName.isEmpty()) {
         return;
@@ -2194,7 +2275,7 @@ void MainWindow::exportNotesFile()
  */
 void MainWindow::toggleNoteList()
 {
-    if(m_isNoteListCollapsed) {
+    if (m_isNoteListCollapsed) {
         expandNoteList();
     } else {
         collapseNoteList();
@@ -2215,7 +2296,7 @@ void MainWindow::expandNodeTree()
 
 void MainWindow::toggleNodeTree()
 {
-    if(m_isTreeCollapsed) {
+    if (m_isTreeCollapsed) {
         expandNodeTree();
     } else {
         collapseNodeTree();
@@ -2240,7 +2321,6 @@ void MainWindow::expandNoteList()
     updateFrame();
 }
 
-
 /*!
  * \brief MainWindow::onGreenMaximizeButtonPressed
  * When the green button is pressed set it's icon accordingly
@@ -2250,9 +2330,9 @@ void MainWindow::onGreenMaximizeButtonPressed()
 #ifdef _WIN32
     m_greenMaximizeButton->setIcon(QIcon(":images/windows_minimize_pressed.png"));
 #else
-    if(this->windowState() == Qt::WindowFullScreen){
+    if (this->windowState() == Qt::WindowFullScreen) {
         m_greenMaximizeButton->setIcon(QIcon(QStringLiteral(":images/greenInPressed.png")));
-    }else{
+    } else {
         m_greenMaximizeButton->setIcon(QIcon(QStringLiteral(":images/greenPressed.png")));
     }
 #endif
@@ -2265,10 +2345,12 @@ void MainWindow::onGreenMaximizeButtonPressed()
 void MainWindow::onYellowMinimizeButtonPressed()
 {
 #ifdef _WIN32
-    if(this->windowState() == Qt::WindowFullScreen){
-        m_yellowMinimizeButton->setIcon(QIcon(QStringLiteral(":images/windows_de-maximize_pressed.png")));
-    }else{
-        m_yellowMinimizeButton->setIcon(QIcon(QStringLiteral(":images/windows_maximize_pressed.png")));
+    if (this->windowState() == Qt::WindowFullScreen) {
+        m_yellowMinimizeButton->setIcon(
+                QIcon(QStringLiteral(":images/windows_de-maximize_pressed.png")));
+    } else {
+        m_yellowMinimizeButton->setIcon(
+                QIcon(QStringLiteral(":images/windows_maximize_pressed.png")));
     }
 #else
     m_yellowMinimizeButton->setIcon(QIcon(QStringLiteral(":images/yellowPressed.png")));
@@ -2313,7 +2395,8 @@ void MainWindow::onGreenMaximizeButtonClicked()
 void MainWindow::onYellowMinimizeButtonClicked()
 {
 #ifdef _WIN32
-    m_yellowMinimizeButton->setIcon(QIcon(QStringLiteral(":images/windows_de-maximize_regular.png")));
+    m_yellowMinimizeButton->setIcon(
+            QIcon(QStringLiteral(":images/windows_de-maximize_regular.png")));
 
     fullscreenWindow();
 #else
@@ -2347,12 +2430,13 @@ void MainWindow::onRedCloseButtonClicked()
  * save the current note if it's note temporary one otherwise remove it from DB
  * \param event
  */
-void MainWindow::closeEvent(QCloseEvent* event)
+void MainWindow::closeEvent(QCloseEvent *event)
 {
-    if(windowState() != Qt::WindowFullScreen) {
+    if (windowState() != Qt::WindowFullScreen) {
         m_settingsDatabase->setValue(QStringLiteral("windowGeometry"), saveGeometry());
-        if(m_styleEditorWindow.windowState() != Qt::WindowFullScreen)
-            m_settingsDatabase->setValue(QStringLiteral("editorSettingsWindowGeometry"), m_styleEditorWindow.saveGeometry());
+        if (m_styleEditorWindow.windowState() != Qt::WindowFullScreen)
+            m_settingsDatabase->setValue(QStringLiteral("editorSettingsWindowGeometry"),
+                                         m_styleEditorWindow.saveGeometry());
     }
 
     m_noteEditorLogic->saveNoteToDB();
@@ -2386,14 +2470,22 @@ void MainWindow::closeEvent(QCloseEvent* event)
     }
     m_settingsDatabase->setValue(QStringLiteral("selectedFontTypeface"), currentFontTypefaceString);
     m_settingsDatabase->setValue(QStringLiteral("editorMediumFontSize"), m_editorMediumFontSize);
-    m_settingsDatabase->setValue(QStringLiteral("isTextFullWidth"), m_textEdit->lineWrapMode() == QTextEdit::WidgetWidth ? true : false);
-    m_settingsDatabase->setValue(QStringLiteral("charsLimitPerFontMono"), m_currentCharsLimitPerFont.mono);
-    m_settingsDatabase->setValue(QStringLiteral("charsLimitPerFontSerif"), m_currentCharsLimitPerFont.serif);
-    m_settingsDatabase->setValue(QStringLiteral("charsLimitPerFontSansSerif"), m_currentCharsLimitPerFont.sansSerif);
+    m_settingsDatabase->setValue(QStringLiteral("isTextFullWidth"),
+                                 m_textEdit->lineWrapMode() == QTextEdit::WidgetWidth ? true
+                                                                                      : false);
+    m_settingsDatabase->setValue(QStringLiteral("charsLimitPerFontMono"),
+                                 m_currentCharsLimitPerFont.mono);
+    m_settingsDatabase->setValue(QStringLiteral("charsLimitPerFontSerif"),
+                                 m_currentCharsLimitPerFont.serif);
+    m_settingsDatabase->setValue(QStringLiteral("charsLimitPerFontSansSerif"),
+                                 m_currentCharsLimitPerFont.sansSerif);
     m_settingsDatabase->setValue(QStringLiteral("theme"), currentThemeString);
-    m_settingsDatabase->setValue(QStringLiteral("chosenMonoFont"), m_listOfMonoFonts.at(m_chosenMonoFontIndex));
-    m_settingsDatabase->setValue(QStringLiteral("chosenSerifFont"), m_listOfSerifFonts.at(m_chosenSerifFontIndex));
-    m_settingsDatabase->setValue(QStringLiteral("chosenSansSerifFont"), m_listOfSansSerifFonts.at(m_chosenSansSerifFontIndex));
+    m_settingsDatabase->setValue(QStringLiteral("chosenMonoFont"),
+                                 m_listOfMonoFonts.at(m_chosenMonoFontIndex));
+    m_settingsDatabase->setValue(QStringLiteral("chosenSerifFont"),
+                                 m_listOfSerifFonts.at(m_chosenSerifFontIndex));
+    m_settingsDatabase->setValue(QStringLiteral("chosenSansSerifFont"),
+                                 m_listOfSansSerifFonts.at(m_chosenSansSerifFontIndex));
 
     m_settingsDatabase->sync();
 
@@ -2406,57 +2498,60 @@ void MainWindow::closeEvent(QCloseEvent* event)
  * Set variables to the position of the window when the mouse is pressed
  * \param event
  */
-void MainWindow::mousePressEvent(QMouseEvent* event)
+void MainWindow::mousePressEvent(QMouseEvent *event)
 {
     m_mousePressX = event->pos().x();
     m_mousePressY = event->pos().y();
 
-    if(event->buttons() == Qt::LeftButton){
-        if(m_mousePressX < this->width() - m_layoutMargin
-                && m_mousePressX >m_layoutMargin
-                && m_mousePressY < this->height() - m_layoutMargin
-                && m_mousePressY > m_layoutMargin){
+    if (event->buttons() == Qt::LeftButton) {
+        if (m_mousePressX < this->width() - m_layoutMargin && m_mousePressX > m_layoutMargin
+            && m_mousePressY < this->height() - m_layoutMargin && m_mousePressY > m_layoutMargin) {
 
             m_canMoveWindow = true;
             //            QApplication::setOverrideCursor(QCursor(Qt::ClosedHandCursor));
 
-#ifndef __APPLE__
-        }else{
+#  ifndef __APPLE__
+        } else {
             m_canStretchWindow = true;
 
             int currentWidth = m_splitter->sizes().at(0);
-            if(currentWidth != 0)
+            if (currentWidth != 0)
                 m_noteListWidth = currentWidth;
 
-            if((m_mousePressX < this->width() && m_mousePressX > this->width() - m_layoutMargin)
-                    && (m_mousePressY < m_layoutMargin && m_mousePressY > 0)){
+            if ((m_mousePressX < this->width() && m_mousePressX > this->width() - m_layoutMargin)
+                && (m_mousePressY < m_layoutMargin && m_mousePressY > 0)) {
                 m_stretchSide = StretchSide::TopRight;
-            }else if((m_mousePressX < this->width() && m_mousePressX > this->width() - m_layoutMargin)
-                     && (m_mousePressY < this->height() && m_mousePressY > this->height() - m_layoutMargin)){
+            } else if ((m_mousePressX < this->width()
+                        && m_mousePressX > this->width() - m_layoutMargin)
+                       && (m_mousePressY < this->height()
+                           && m_mousePressY > this->height() - m_layoutMargin)) {
                 m_stretchSide = StretchSide::BottomRight;
-            }else if((m_mousePressX < m_layoutMargin && m_mousePressX > 0)
-                     && (m_mousePressY < m_layoutMargin && m_mousePressY > 0)){
+            } else if ((m_mousePressX < m_layoutMargin && m_mousePressX > 0)
+                       && (m_mousePressY < m_layoutMargin && m_mousePressY > 0)) {
                 m_stretchSide = StretchSide::TopLeft;
-            }else if((m_mousePressX < m_layoutMargin && m_mousePressX > 0)
-                     && (m_mousePressY < this->height() && m_mousePressY > this->height() - m_layoutMargin)){
+            } else if ((m_mousePressX < m_layoutMargin && m_mousePressX > 0)
+                       && (m_mousePressY < this->height()
+                           && m_mousePressY > this->height() - m_layoutMargin)) {
                 m_stretchSide = StretchSide::BottomLeft;
-            }else if(m_mousePressX < this->width() && m_mousePressX > this->width() - m_layoutMargin){
+            } else if (m_mousePressX < this->width()
+                       && m_mousePressX > this->width() - m_layoutMargin) {
                 m_stretchSide = StretchSide::Right;
-            }else if(m_mousePressX < m_layoutMargin && m_mousePressX > 0){
+            } else if (m_mousePressX < m_layoutMargin && m_mousePressX > 0) {
                 m_stretchSide = StretchSide::Left;
-            }else if(m_mousePressY < this->height() && m_mousePressY > this->height() - m_layoutMargin){
+            } else if (m_mousePressY < this->height()
+                       && m_mousePressY > this->height() - m_layoutMargin) {
                 m_stretchSide = StretchSide::Bottom;
-            }else if(m_mousePressY < m_layoutMargin && m_mousePressY > 0){
+            } else if (m_mousePressY < m_layoutMargin && m_mousePressY > 0) {
                 m_stretchSide = StretchSide::Top;
-            }else{
+            } else {
                 m_stretchSide = StretchSide::None;
             }
-#endif
+#  endif
         }
 
         event->accept();
 
-    }else{
+    } else {
         QMainWindow::mousePressEvent(event);
     }
 }
@@ -2466,39 +2561,43 @@ void MainWindow::mousePressEvent(QMouseEvent* event)
  * Move the window according to the mouse positions
  * \param event
  */
-void MainWindow::mouseMoveEvent(QMouseEvent* event)
+void MainWindow::mouseMoveEvent(QMouseEvent *event)
 {
-#ifndef __APPLE__
-    if(!m_canStretchWindow && !m_canMoveWindow){
+#  ifndef __APPLE__
+    if (!m_canStretchWindow && !m_canMoveWindow) {
         m_mousePressX = event->pos().x();
         m_mousePressY = event->pos().y();
 
-        if((m_mousePressX < this->width() && m_mousePressX > this->width() - m_layoutMargin)
-                && (m_mousePressY < m_layoutMargin && m_mousePressY > 0)){
+        if ((m_mousePressX < this->width() && m_mousePressX > this->width() - m_layoutMargin)
+            && (m_mousePressY < m_layoutMargin && m_mousePressY > 0)) {
             m_stretchSide = StretchSide::TopRight;
-        }else if((m_mousePressX < this->width() && m_mousePressX > this->width() - m_layoutMargin)
-                 && (m_mousePressY < this->height() && m_mousePressY > this->height() - m_layoutMargin)){
+        } else if ((m_mousePressX < this->width() && m_mousePressX > this->width() - m_layoutMargin)
+                   && (m_mousePressY < this->height()
+                       && m_mousePressY > this->height() - m_layoutMargin)) {
             m_stretchSide = StretchSide::BottomRight;
-        }else if((m_mousePressX < m_layoutMargin && m_mousePressX > 0)
-                 && (m_mousePressY < m_layoutMargin && m_mousePressY > 0)){
+        } else if ((m_mousePressX < m_layoutMargin && m_mousePressX > 0)
+                   && (m_mousePressY < m_layoutMargin && m_mousePressY > 0)) {
             m_stretchSide = StretchSide::TopLeft;
-        }else if((m_mousePressX < m_layoutMargin && m_mousePressX > 0)
-                 && (m_mousePressY < this->height() && m_mousePressY > this->height() - m_layoutMargin)){
+        } else if ((m_mousePressX < m_layoutMargin && m_mousePressX > 0)
+                   && (m_mousePressY < this->height()
+                       && m_mousePressY > this->height() - m_layoutMargin)) {
             m_stretchSide = StretchSide::BottomLeft;
-        }else if(m_mousePressX < this->width() && m_mousePressX > this->width() - m_layoutMargin){
+        } else if (m_mousePressX < this->width()
+                   && m_mousePressX > this->width() - m_layoutMargin) {
             m_stretchSide = StretchSide::Right;
-        }else if(m_mousePressX < m_layoutMargin && m_mousePressX > 0){
+        } else if (m_mousePressX < m_layoutMargin && m_mousePressX > 0) {
             m_stretchSide = StretchSide::Left;
-        }else if(m_mousePressY < this->height() && m_mousePressY > this->height() - m_layoutMargin){
+        } else if (m_mousePressY < this->height()
+                   && m_mousePressY > this->height() - m_layoutMargin) {
             m_stretchSide = StretchSide::Bottom;
-        }else if(m_mousePressY < m_layoutMargin && m_mousePressY > 0){
+        } else if (m_mousePressY < m_layoutMargin && m_mousePressY > 0) {
             m_stretchSide = StretchSide::Top;
-        }else{
+        } else {
             m_stretchSide = StretchSide::None;
         }
     }
 
-    if(!m_canMoveWindow){
+    if (!m_canMoveWindow) {
         switch (m_stretchSide) {
         case StretchSide::Right:
         case StretchSide::Left:
@@ -2517,61 +2616,69 @@ void MainWindow::mouseMoveEvent(QMouseEvent* event)
             ui->centralWidget->setCursor(Qt::SizeFDiagCursor);
             break;
         default:
-            if(!m_canStretchWindow)
+            if (!m_canStretchWindow)
                 ui->centralWidget->setCursor(Qt::ArrowCursor);
             break;
         }
     }
-#endif
+#  endif
 
-    if(m_canMoveWindow){
+    if (m_canMoveWindow) {
         int dx = event->globalX() - m_mousePressX;
         int dy = event->globalY() - m_mousePressY;
-        move (dx, dy);
+        move(dx, dy);
 
     }
-#ifndef __APPLE__
-    else if(m_canStretchWindow && !isMaximized() && !isFullScreen()){
+#  ifndef __APPLE__
+    else if (m_canStretchWindow && !isMaximized() && !isFullScreen()) {
         int newX = x();
         int newY = y();
         int newWidth = width();
         int newHeight = height();
 
-        int minY =  QApplication::primaryScreen()->availableGeometry().y();
+        int minY = QApplication::primaryScreen()->availableGeometry().y();
 
         switch (m_stretchSide) {
         case StretchSide::Right:
-            newWidth = abs(event->globalPos().x()-this->x()+1);
+            newWidth = abs(event->globalPos().x() - this->x() + 1);
             newWidth = newWidth < minimumWidth() ? minimumWidth() : newWidth;
             break;
         case StretchSide::Left:
             newX = event->globalPos().x() - m_mousePressX;
             newX = newX > 0 ? newX : 0;
-            newX = newX > geometry().bottomRight().x() - minimumWidth() ? geometry().bottomRight().x() - minimumWidth() : newX;
+            newX = newX > geometry().bottomRight().x() - minimumWidth()
+                    ? geometry().bottomRight().x() - minimumWidth()
+                    : newX;
             newWidth = geometry().topRight().x() - newX + 1;
             newWidth = newWidth < minimumWidth() ? minimumWidth() : newWidth;
             break;
         case StretchSide::Top:
             newY = event->globalY() - m_mousePressY;
             newY = newY < minY ? minY : newY;
-            newY = newY > geometry().bottomRight().y() - minimumHeight() ? geometry().bottomRight().y() - minimumHeight() : newY;
+            newY = newY > geometry().bottomRight().y() - minimumHeight()
+                    ? geometry().bottomRight().y() - minimumHeight()
+                    : newY;
             newHeight = geometry().bottomLeft().y() - newY + 1;
-            newHeight = newHeight < minimumHeight() ? minimumHeight() : newHeight ;
+            newHeight = newHeight < minimumHeight() ? minimumHeight() : newHeight;
 
             break;
         case StretchSide::Bottom:
-            newHeight = abs(event->globalY()-y()+1);
+            newHeight = abs(event->globalY() - y() + 1);
             newHeight = newHeight < minimumHeight() ? minimumHeight() : newHeight;
 
             break;
         case StretchSide::TopLeft:
             newX = event->globalPos().x() - m_mousePressX;
-            newX = newX < 0 ? 0: newX;
-            newX = newX > geometry().bottomRight().x() - minimumWidth() ? geometry().bottomRight().x()-minimumWidth() : newX;
+            newX = newX < 0 ? 0 : newX;
+            newX = newX > geometry().bottomRight().x() - minimumWidth()
+                    ? geometry().bottomRight().x() - minimumWidth()
+                    : newX;
 
             newY = event->globalY() - m_mousePressY;
             newY = newY < minY ? minY : newY;
-            newY = newY > geometry().bottomRight().y() - minimumHeight() ? geometry().bottomRight().y() - minimumHeight() : newY;
+            newY = newY > geometry().bottomRight().y() - minimumHeight()
+                    ? geometry().bottomRight().y() - minimumHeight()
+                    : newY;
 
             newWidth = geometry().bottomRight().x() - newX + 1;
             newWidth = newWidth < minimumWidth() ? minimumWidth() : newWidth;
@@ -2582,8 +2689,10 @@ void MainWindow::mouseMoveEvent(QMouseEvent* event)
             break;
         case StretchSide::BottomLeft:
             newX = event->globalPos().x() - m_mousePressX;
-            newX = newX < 0 ? 0: newX;
-            newX = newX > geometry().bottomRight().x() - minimumWidth() ? geometry().bottomRight().x()-minimumWidth() : newX;
+            newX = newX < 0 ? 0 : newX;
+            newX = newX > geometry().bottomRight().x() - minimumWidth()
+                    ? geometry().bottomRight().x() - minimumWidth()
+                    : newX;
 
             newWidth = geometry().bottomRight().x() - newX + 1;
             newWidth = newWidth < minimumWidth() ? minimumWidth() : newWidth;
@@ -2594,7 +2703,9 @@ void MainWindow::mouseMoveEvent(QMouseEvent* event)
             break;
         case StretchSide::TopRight:
             newY = event->globalY() - m_mousePressY;
-            newY = newY > geometry().bottomRight().y() - minimumHeight() ? geometry().bottomRight().y() - minimumHeight() : newY;
+            newY = newY > geometry().bottomRight().y() - minimumHeight()
+                    ? geometry().bottomRight().y() - minimumHeight()
+                    : newY;
             newY = newY < minY ? minY : newY;
 
             newWidth = event->globalPos().x() - x() + 1;
@@ -2618,13 +2729,13 @@ void MainWindow::mouseMoveEvent(QMouseEvent* event)
 
         setGeometry(newX, newY, newWidth, newHeight);
         QList<int> sizes = m_splitter->sizes();
-        if(sizes[0] != 0){
+        if (sizes[0] != 0) {
             sizes[0] = m_noteListWidth;
             sizes[1] = m_splitter->width() - m_noteListWidth;
             m_splitter->setSizes(sizes);
         }
     }
-#endif
+#  endif
     event->accept();
 }
 
@@ -2646,13 +2757,11 @@ void MainWindow::mouseReleaseEvent(QMouseEvent *event)
  * Set variables to the position of the window when the mouse is pressed
  * \param event
  */
-void MainWindow::mousePressEvent(QMouseEvent* event)
+void MainWindow::mousePressEvent(QMouseEvent *event)
 {
-    if (event->button() == Qt::LeftButton){
-        if(event->pos().x() < this->width() - 5
-                && event->pos().x() >5
-                && event->pos().y() < this->height()-5
-                && event->pos().y() > 5){
+    if (event->button() == Qt::LeftButton) {
+        if (event->pos().x() < this->width() - 5 && event->pos().x() > 5
+            && event->pos().y() < this->height() - 5 && event->pos().y() > 5) {
 
             m_canMoveWindow = true;
             m_mousePressX = event->pos().x();
@@ -2668,14 +2777,13 @@ void MainWindow::mousePressEvent(QMouseEvent* event)
  * Move the window according to the mouse positions
  * \param event
  */
-void MainWindow::mouseMoveEvent(QMouseEvent* event)
+void MainWindow::mouseMoveEvent(QMouseEvent *event)
 {
-    if(m_canMoveWindow){
+    if (m_canMoveWindow) {
         //        this->setCursor(Qt::ClosedHandCursor);
         int dx = event->globalPos().x() - m_mousePressX;
         int dy = event->globalY() - m_mousePressY;
-        move (dx, dy);
-
+        move(dx, dy);
     }
 }
 
@@ -2732,9 +2840,13 @@ void MainWindow::selectAllNotesInList()
 void MainWindow::updateFrame()
 {
     int minWidth = ui->frameMiddle->minimumWidth();
-    int noteListWidth = m_isNoteListCollapsed ? 0 : m_noteListWidth < minWidth ? minWidth : m_noteListWidth;
+    int noteListWidth = m_isNoteListCollapsed ? 0
+            : m_noteListWidth < minWidth      ? minWidth
+                                              : m_noteListWidth;
     minWidth = ui->frameLeft->minimumWidth();
-    int nodeTreeWidth = m_isTreeCollapsed ? 0 : m_nodeTreeWidth < minWidth ? minWidth : m_nodeTreeWidth;
+    int nodeTreeWidth = m_isTreeCollapsed ? 0
+            : m_nodeTreeWidth < minWidth  ? minWidth
+                                          : m_nodeTreeWidth;
     QList<int> sizes = m_splitter->sizes();
     sizes[0] = nodeTreeWidth;
     sizes[1] = noteListWidth;
@@ -2745,7 +2857,7 @@ void MainWindow::updateFrame()
     m_splitter->setCollapsible(1, false);
     m_splitter->setCollapsible(0, false);
 
-    if(m_isNoteListCollapsed && m_isTreeCollapsed) {
+    if (m_isNoteListCollapsed && m_isTreeCollapsed) {
         setWindowButtonsVisible(false);
     } else {
         setWindowButtonsVisible(true);
@@ -2761,12 +2873,12 @@ void MainWindow::migrateFromV0_9_0()
     QDir dir(fi.absolutePath());
 
     QString oldNoteDBPath(dir.path() + QDir::separator() + "Notes.ini");
-    if(QFile::exists(oldNoteDBPath)) {
+    if (QFile::exists(oldNoteDBPath)) {
         migrateNoteFromV0_9_0(oldNoteDBPath);
     }
 
     QString oldTrashDBPath(dir.path() + QDir::separator() + "Trash.ini");
-    if(QFile::exists(oldTrashDBPath)) {
+    if (QFile::exists(oldTrashDBPath)) {
         migrateTrashFromV0_9_0(oldTrashDBPath);
     }
 }
@@ -2782,28 +2894,32 @@ void MainWindow::migrateNoteFromV0_9_0(const QString &notePath)
     QVector<NodeData> noteList;
 
     auto it = dbKeys.begin();
-    for(; it < dbKeys.end()-1; it += 3){
+    for (; it < dbKeys.end() - 1; it += 3) {
         QString noteName = it->split(QStringLiteral("/"))[0];
         int id = noteName.split(QStringLiteral("_"))[1].toInt();
         NodeData newNote;
         newNote.setId(id);
-        QString createdDateDB = notesIni.value(noteName + QStringLiteral("/dateCreated"), "Error").toString();
+        QString createdDateDB =
+                notesIni.value(noteName + QStringLiteral("/dateCreated"), "Error").toString();
         newNote.setCreationDateTime(QDateTime::fromString(createdDateDB, Qt::ISODate));
-        QString lastEditedDateDB = notesIni.value(noteName + QStringLiteral("/dateEdited"), "Error").toString();
+        QString lastEditedDateDB =
+                notesIni.value(noteName + QStringLiteral("/dateEdited"), "Error").toString();
         newNote.setLastModificationDateTime(QDateTime::fromString(lastEditedDateDB, Qt::ISODate));
-        QString contentText = notesIni.value(noteName + QStringLiteral("/content"), "Error").toString();
+        QString contentText =
+                notesIni.value(noteName + QStringLiteral("/content"), "Error").toString();
         newNote.setContent(contentText);
         QString firstLine = NoteEditorLogic::getFirstLine(contentText);
         newNote.setFullTitle(firstLine);
         noteList.append(newNote);
     }
 
-    if(!noteList.isEmpty()) {
+    if (!noteList.isEmpty()) {
         emit requestMigrateNotesFromV0_9_0(noteList);
     }
 
     QFile oldNoteDBFile(notePath);
-    oldNoteDBFile.rename(QFileInfo(notePath).dir().path() + QDir::separator() + QStringLiteral("oldNotes.ini"));
+    oldNoteDBFile.rename(QFileInfo(notePath).dir().path() + QDir::separator()
+                         + QStringLiteral("oldNotes.ini"));
 }
 
 /*!
@@ -2818,27 +2934,31 @@ void MainWindow::migrateTrashFromV0_9_0(const QString &trashPath)
     QVector<NodeData> noteList;
 
     auto it = dbKeys.begin();
-    for(; it < dbKeys.end()-1; it += 3){
+    for (; it < dbKeys.end() - 1; it += 3) {
         QString noteName = it->split(QStringLiteral("/"))[0];
         int id = noteName.split(QStringLiteral("_"))[1].toInt();
         NodeData newNote;
         newNote.setId(id);
-        QString createdDateDB = trashIni.value(noteName + QStringLiteral("/dateCreated"), "Error").toString();
+        QString createdDateDB =
+                trashIni.value(noteName + QStringLiteral("/dateCreated"), "Error").toString();
         newNote.setCreationDateTime(QDateTime::fromString(createdDateDB, Qt::ISODate));
-        QString lastEditedDateDB = trashIni.value(noteName + QStringLiteral("/dateEdited"), "Error").toString();
+        QString lastEditedDateDB =
+                trashIni.value(noteName + QStringLiteral("/dateEdited"), "Error").toString();
         newNote.setLastModificationDateTime(QDateTime::fromString(lastEditedDateDB, Qt::ISODate));
-        QString contentText = trashIni.value(noteName + QStringLiteral("/content"), "Error").toString();
+        QString contentText =
+                trashIni.value(noteName + QStringLiteral("/content"), "Error").toString();
         newNote.setContent(contentText);
         QString firstLine = NoteEditorLogic::getFirstLine(contentText);
         newNote.setFullTitle(firstLine);
         noteList.append(newNote);
     }
 
-    if(!noteList.isEmpty()) {
+    if (!noteList.isEmpty()) {
         emit requestMigrateTrashFromV0_9_0(noteList);
     }
     QFile oldTrashDBFile(trashPath);
-    oldTrashDBFile.rename(QFileInfo(trashPath).dir().path() + QDir::separator() + QStringLiteral("oldTrash.ini"));
+    oldTrashDBFile.rename(QFileInfo(trashPath).dir().path() + QDir::separator()
+                          + QStringLiteral("oldTrash.ini"));
 }
 
 /*!
@@ -2847,20 +2967,17 @@ void MainWindow::migrateTrashFromV0_9_0(const QString &trashPath)
  * \param type
  * \param side
  */
-void MainWindow::dropShadow(QPainter& painter, ShadowType type, MainWindow::ShadowSide side)
+void MainWindow::dropShadow(QPainter &painter, ShadowType type, MainWindow::ShadowSide side)
 {
     int resizedShadowWidth = m_shadowWidth > m_layoutMargin ? m_layoutMargin : m_shadowWidth;
 
-    QRect mainRect   = rect();
+    QRect mainRect = rect();
 
-    QRect innerRect(m_layoutMargin,
-                    m_layoutMargin,
-                    mainRect.width() - 2 * resizedShadowWidth + 1,
+    QRect innerRect(m_layoutMargin, m_layoutMargin, mainRect.width() - 2 * resizedShadowWidth + 1,
                     mainRect.height() - 2 * resizedShadowWidth + 1);
-    QRect outerRect(innerRect.x() - resizedShadowWidth,
-                    innerRect.y() - resizedShadowWidth,
-                    innerRect.width() + 2* resizedShadowWidth,
-                    innerRect.height() + 2* resizedShadowWidth);
+    QRect outerRect(innerRect.x() - resizedShadowWidth, innerRect.y() - resizedShadowWidth,
+                    innerRect.width() + 2 * resizedShadowWidth,
+                    innerRect.height() + 2 * resizedShadowWidth);
 
     QPoint center;
     QPoint topLeft;
@@ -2871,52 +2988,51 @@ void MainWindow::dropShadow(QPainter& painter, ShadowType type, MainWindow::Shad
     QLinearGradient linearGradient;
 
     switch (side) {
-    case ShadowSide::Left :
-        topLeft     = QPoint(outerRect.left(), innerRect.top() + 1);
+    case ShadowSide::Left:
+        topLeft = QPoint(outerRect.left(), innerRect.top() + 1);
         bottomRight = QPoint(innerRect.left(), innerRect.bottom() - 1);
         shadowStart = QPoint(innerRect.left(), innerRect.top() + 1);
-        shadowStop  = QPoint(outerRect.left(), innerRect.top() + 1);
+        shadowStop = QPoint(outerRect.left(), innerRect.top() + 1);
         break;
-    case ShadowSide::Top :
-        topLeft     = QPoint(innerRect.left() + 1, outerRect.top());
+    case ShadowSide::Top:
+        topLeft = QPoint(innerRect.left() + 1, outerRect.top());
         bottomRight = QPoint(innerRect.right() - 1, innerRect.top());
         shadowStart = QPoint(innerRect.left() + 1, innerRect.top());
-        shadowStop  = QPoint(innerRect.left() + 1, outerRect.top());
+        shadowStop = QPoint(innerRect.left() + 1, outerRect.top());
         break;
-    case ShadowSide::Right :
-        topLeft     = QPoint(innerRect.right(), innerRect.top() + 1);
+    case ShadowSide::Right:
+        topLeft = QPoint(innerRect.right(), innerRect.top() + 1);
         bottomRight = QPoint(outerRect.right(), innerRect.bottom() - 1);
         shadowStart = QPoint(innerRect.right(), innerRect.top() + 1);
-        shadowStop  = QPoint(outerRect.right(), innerRect.top() + 1);
+        shadowStop = QPoint(outerRect.right(), innerRect.top() + 1);
         break;
-    case ShadowSide::Bottom :
-        topLeft     = QPoint(innerRect.left() + 1, innerRect.bottom());
+    case ShadowSide::Bottom:
+        topLeft = QPoint(innerRect.left() + 1, innerRect.bottom());
         bottomRight = QPoint(innerRect.right() - 1, outerRect.bottom());
         shadowStart = QPoint(innerRect.left() + 1, innerRect.bottom());
-        shadowStop  = QPoint(innerRect.left() + 1, outerRect.bottom());
+        shadowStop = QPoint(innerRect.left() + 1, outerRect.bottom());
         break;
     case ShadowSide::TopLeft:
-        topLeft     = outerRect.topLeft();
+        topLeft = outerRect.topLeft();
         bottomRight = innerRect.topLeft();
-        center      = innerRect.topLeft();
+        center = innerRect.topLeft();
         break;
     case ShadowSide::TopRight:
-        topLeft     = QPoint(innerRect.right(), outerRect.top());
+        topLeft = QPoint(innerRect.right(), outerRect.top());
         bottomRight = QPoint(outerRect.right(), innerRect.top());
-        center      = innerRect.topRight();
+        center = innerRect.topRight();
         break;
     case ShadowSide::BottomRight:
-        topLeft     = innerRect.bottomRight();
+        topLeft = innerRect.bottomRight();
         bottomRight = outerRect.bottomRight();
-        center      = innerRect.bottomRight();
+        center = innerRect.bottomRight();
         break;
     case ShadowSide::BottomLeft:
-        topLeft     = QPoint(outerRect.left(), innerRect.bottom());
+        topLeft = QPoint(outerRect.left(), innerRect.bottom());
         bottomRight = QPoint(innerRect.left(), outerRect.bottom());
-        center      = innerRect.bottomLeft();
+        center = innerRect.bottomLeft();
         break;
     }
-
 
     QRect zone(topLeft, bottomRight);
     radialGradient = QRadialGradient(center, resizedShadowWidth, center);
@@ -2925,10 +3041,10 @@ void MainWindow::dropShadow(QPainter& painter, ShadowType type, MainWindow::Shad
     linearGradient.setFinalStop(shadowStop);
 
     switch (type) {
-    case ShadowType::Radial :
+    case ShadowType::Radial:
         fillRectWithGradient(painter, zone, radialGradient);
         break;
-    case ShadowType::Linear :
+    case ShadowType::Linear:
         fillRectWithGradient(painter, zone, linearGradient);
         break;
     }
@@ -2940,18 +3056,18 @@ void MainWindow::dropShadow(QPainter& painter, ShadowType type, MainWindow::Shad
  * \param rect
  * \param gradient
  */
-void MainWindow::fillRectWithGradient(QPainter& painter, QRect rect, QGradient& gradient)
+void MainWindow::fillRectWithGradient(QPainter &painter, QRect rect, QGradient &gradient)
 {
     double variance = 0.2;
     double xMax = 1.10;
-    double q = 70/gaussianDist(0, 0, sqrt(variance));
+    double q = 70 / gaussianDist(0, 0, sqrt(variance));
     double nPt = 100.0;
 
-    for(int i=0; i<=nPt; i++){
-        double v = gaussianDist(i*xMax/nPt, 0, sqrt(variance));
+    for (int i = 0; i <= nPt; i++) {
+        double v = gaussianDist(i * xMax / nPt, 0, sqrt(variance));
 
-        QColor c(168, 168, 168, int(q*v));
-        gradient.setColorAt(i/nPt, c);
+        QColor c(168, 168, 168, int(q * v));
+        gradient.setColorAt(i / nPt, c);
     }
 
     painter.fillRect(rect, gradient);
@@ -2966,7 +3082,7 @@ void MainWindow::fillRectWithGradient(QPainter& painter, QRect rect, QGradient& 
  */
 double MainWindow::gaussianDist(double x, const double center, double sigma) const
 {
-    return (1.0 / (2 * M_PI * pow(sigma, 2)) * exp( - pow(x - center, 2) / (2 * pow(sigma, 2))));
+    return (1.0 / (2 * M_PI * pow(sigma, 2)) * exp(-pow(x - center, 2) / (2 * pow(sigma, 2))));
 }
 
 /*!
@@ -3000,7 +3116,7 @@ void MainWindow::setVisibilityOfFrameRightNonEditor(bool isVisible)
 {
     m_isFrameRightTopWidgetsVisible = isVisible;
 
-    if(isVisible) {
+    if (isVisible) {
         m_areNonEditorWidgetsVisible = true;
         m_editorDateLabel->setVisible(true);
         m_trashButton->setVisible(true);
@@ -3015,8 +3131,8 @@ void MainWindow::setVisibilityOfFrameRightNonEditor(bool isVisible)
     }
 
     // If the notes list is collapsed, hide the window buttons
-    if(m_splitter) {
-        if(m_isNoteListCollapsed && m_isTreeCollapsed) {
+    if (m_splitter) {
+        if (m_isNoteListCollapsed && m_isTreeCollapsed) {
             setWindowButtonsVisible(isVisible);
         }
     }
@@ -3043,58 +3159,63 @@ void MainWindow::setWindowButtonsVisible(bool isVisible)
  */
 bool MainWindow::eventFilter(QObject *object, QEvent *event)
 {
-    switch (event->type()){
-    case QEvent::Enter:{
-        if(qApp->applicationState() == Qt::ApplicationActive){
+    switch (event->type()) {
+    case QEvent::Enter: {
+        if (qApp->applicationState() == Qt::ApplicationActive) {
 #ifdef _WIN32
-            if(object == m_redCloseButton){
-                m_redCloseButton->setIcon(QIcon(QStringLiteral(":images/windows_close_hovered.png")));
+            if (object == m_redCloseButton) {
+                m_redCloseButton->setIcon(
+                        QIcon(QStringLiteral(":images/windows_close_hovered.png")));
             }
 
-            if(object == m_yellowMinimizeButton){
-                if(this->windowState() == Qt::WindowFullScreen){
-                    m_yellowMinimizeButton->setIcon(QIcon(QStringLiteral(":images/windows_de-maximize_hovered.png")));
-                }else{
-                    m_yellowMinimizeButton->setIcon(QIcon (QStringLiteral(":images/windows_maximize_hovered.png")));
+            if (object == m_yellowMinimizeButton) {
+                if (this->windowState() == Qt::WindowFullScreen) {
+                    m_yellowMinimizeButton->setIcon(
+                            QIcon(QStringLiteral(":images/windows_de-maximize_hovered.png")));
+                } else {
+                    m_yellowMinimizeButton->setIcon(
+                            QIcon(QStringLiteral(":images/windows_maximize_hovered.png")));
                 }
             }
 
-            if(object == m_greenMaximizeButton){
-                m_greenMaximizeButton->setIcon(QIcon(QStringLiteral(":images/windows_minimize_hovered.png")));
+            if (object == m_greenMaximizeButton) {
+                m_greenMaximizeButton->setIcon(
+                        QIcon(QStringLiteral(":images/windows_minimize_hovered.png")));
             }
 #else
             // When hovering one of the traffic light buttons (red, yellow, green),
             // set new icons to show their function
-            if(object == m_redCloseButton
-                    || object == m_yellowMinimizeButton
-                    || object == m_greenMaximizeButton){
+            if (object == m_redCloseButton || object == m_yellowMinimizeButton
+                || object == m_greenMaximizeButton) {
 
                 m_redCloseButton->setIcon(QIcon(QStringLiteral(":images/redHovered.png")));
                 m_yellowMinimizeButton->setIcon(QIcon(QStringLiteral(":images/yellowHovered.png")));
-                if(this->windowState() == Qt::WindowFullScreen){
-                    m_greenMaximizeButton->setIcon(QIcon(QStringLiteral(":images/greenInHovered.png")));
-                }else{
-                    m_greenMaximizeButton->setIcon(QIcon(QStringLiteral(":images/greenHovered.png")));
+                if (this->windowState() == Qt::WindowFullScreen) {
+                    m_greenMaximizeButton->setIcon(
+                            QIcon(QStringLiteral(":images/greenInHovered.png")));
+                } else {
+                    m_greenMaximizeButton->setIcon(
+                            QIcon(QStringLiteral(":images/greenHovered.png")));
                 }
             }
 #endif
 
-            if(object == m_newNoteButton){
+            if (object == m_newNoteButton) {
                 this->setCursor(Qt::PointingHandCursor);
                 m_newNoteButton->setIcon(QIcon(QStringLiteral(":/images/newNote_Hovered.png")));
             }
 
-            if(object == m_trashButton){
+            if (object == m_trashButton) {
                 this->setCursor(Qt::PointingHandCursor);
                 m_trashButton->setIcon(QIcon(QStringLiteral(":/images/trashCan_Hovered.png")));
             }
 
-            if(object == m_dotsButton){
+            if (object == m_dotsButton) {
                 this->setCursor(Qt::PointingHandCursor);
                 m_dotsButton->setIcon(QIcon(QStringLiteral(":/images/3dots_Hovered.png")));
             }
 
-            if(object == m_styleEditorButton){
+            if (object == m_styleEditorButton) {
                 this->setCursor(Qt::PointingHandCursor);
                 QString ss = QStringLiteral("QPushButton { "
                                             "  border: none; "
@@ -3104,32 +3225,35 @@ bool MainWindow::eventFilter(QObject *object, QEvent *event)
                 m_styleEditorButton->setStyleSheet(ss);
             }
 
-            if(object == ui->frameRightTop && !m_areNonEditorWidgetsVisible){
+            if (object == ui->frameRightTop && !m_areNonEditorWidgetsVisible) {
                 setVisibilityOfFrameRightNonEditor(true);
             }
         }
 
-        if(object == ui->frame){
+        if (object == ui->frame) {
             ui->centralWidget->setCursor(Qt::ArrowCursor);
         }
 
         break;
     }
-    case QEvent::Leave:{
-        if(qApp->applicationState() == Qt::ApplicationActive){
+    case QEvent::Leave: {
+        if (qApp->applicationState() == Qt::ApplicationActive) {
             // When not hovering, change back the icons of the traffic lights to their default icon
-            if(object == m_redCloseButton
-                    || object == m_yellowMinimizeButton
-                    || object == m_greenMaximizeButton){
+            if (object == m_redCloseButton || object == m_yellowMinimizeButton
+                || object == m_greenMaximizeButton) {
 
 #ifdef _WIN32
-                m_redCloseButton->setIcon(QIcon(QStringLiteral(":images/windows_close_regular.png")));
-                m_greenMaximizeButton->setIcon(QIcon(QStringLiteral(":images/windows_minimize_regular.png")));
+                m_redCloseButton->setIcon(
+                        QIcon(QStringLiteral(":images/windows_close_regular.png")));
+                m_greenMaximizeButton->setIcon(
+                        QIcon(QStringLiteral(":images/windows_minimize_regular.png")));
 
-                if(this->windowState() == Qt::WindowFullScreen){
-                    m_yellowMinimizeButton->setIcon(QIcon(QStringLiteral(":images/windows_de-maximize_regular.png")));
-                }else{
-                    m_yellowMinimizeButton->setIcon(QIcon (QStringLiteral(":images/windows_maximize_regular.png")));
+                if (this->windowState() == Qt::WindowFullScreen) {
+                    m_yellowMinimizeButton->setIcon(
+                            QIcon(QStringLiteral(":images/windows_de-maximize_regular.png")));
+                } else {
+                    m_yellowMinimizeButton->setIcon(
+                            QIcon(QStringLiteral(":images/windows_maximize_regular.png")));
                 }
 #else
                 m_redCloseButton->setIcon(QIcon(QStringLiteral(":images/red.png")));
@@ -3138,22 +3262,22 @@ bool MainWindow::eventFilter(QObject *object, QEvent *event)
 #endif
             }
 
-            if(object == m_newNoteButton){
+            if (object == m_newNoteButton) {
                 this->unsetCursor();
                 m_newNoteButton->setIcon(QIcon(QStringLiteral(":/images/newNote_Regular.png")));
             }
 
-            if(object == m_trashButton){
+            if (object == m_trashButton) {
                 this->unsetCursor();
                 m_trashButton->setIcon(QIcon(QStringLiteral(":/images/trashCan_Regular.png")));
             }
 
-            if(object == m_dotsButton){
+            if (object == m_dotsButton) {
                 this->unsetCursor();
                 m_dotsButton->setIcon(QIcon(QStringLiteral(":/images/3dots_Regular.png")));
             }
 
-            if(object == m_styleEditorButton){
+            if (object == m_styleEditorButton) {
                 this->unsetCursor();
                 QString ss = QStringLiteral("QPushButton { "
                                             "  border: none; "
@@ -3165,7 +3289,7 @@ bool MainWindow::eventFilter(QObject *object, QEvent *event)
         }
         break;
     }
-    case QEvent::WindowDeactivate:{
+    case QEvent::WindowDeactivate: {
 
         m_canMoveWindow = false;
         m_canStretchWindow = false;
@@ -3181,15 +3305,18 @@ bool MainWindow::eventFilter(QObject *object, QEvent *event)
         m_dotsButton->setIcon(QIcon(QStringLiteral(":/images/3dots_Regular.png")));
         break;
     }
-    case QEvent::WindowActivate:{
+    case QEvent::WindowActivate: {
 #ifdef _WIN32
         m_redCloseButton->setIcon(QIcon(QStringLiteral(":images/windows_close_regular.png")));
-        m_greenMaximizeButton->setIcon(QIcon(QStringLiteral(":images/windows_minimize_regular.png")));
+        m_greenMaximizeButton->setIcon(
+                QIcon(QStringLiteral(":images/windows_minimize_regular.png")));
 
-        if(this->windowState() == Qt::WindowFullScreen){
-            m_yellowMinimizeButton->setIcon(QIcon(QStringLiteral(":images/windows_de-maximize_regular.png")));
-        }else{
-            m_yellowMinimizeButton->setIcon(QIcon (QStringLiteral(":images/windows_maximize_regular.png")));
+        if (this->windowState() == Qt::WindowFullScreen) {
+            m_yellowMinimizeButton->setIcon(
+                    QIcon(QStringLiteral(":images/windows_de-maximize_regular.png")));
+        } else {
+            m_yellowMinimizeButton->setIcon(
+                    QIcon(QStringLiteral(":images/windows_maximize_regular.png")));
         }
 #else
         m_redCloseButton->setIcon(QIcon(QStringLiteral(":images/red.png")));
@@ -3202,38 +3329,38 @@ bool MainWindow::eventFilter(QObject *object, QEvent *event)
         break;
     }
 #ifndef __APPLE__
-    case QEvent::HoverEnter:{
-        if(object == m_textEdit->verticalScrollBar()){
+    case QEvent::HoverEnter: {
+        if (object == m_textEdit->verticalScrollBar()) {
             bool isSearching = !m_searchEdit->text().isEmpty();
-            if(isSearching)
+            if (isSearching)
                 m_textEdit->setFocusPolicy(Qt::NoFocus);
         }
         break;
     }
-    case QEvent::HoverLeave:{
+    case QEvent::HoverLeave: {
         bool isNoButtonClicked = qApp->mouseButtons() == Qt::NoButton;
-        if(isNoButtonClicked){
-            if(object == m_textEdit->verticalScrollBar()){
+        if (isNoButtonClicked) {
+            if (object == m_textEdit->verticalScrollBar()) {
                 m_textEdit->setFocusPolicy(Qt::StrongFocus);
             }
         }
         break;
     }
-    case QEvent::MouseButtonRelease:{
+    case QEvent::MouseButtonRelease: {
         bool isMouseOnScrollBar = qApp->widgetAt(QCursor::pos()) != m_textEdit->verticalScrollBar();
-        if(isMouseOnScrollBar){
-            if(object == m_textEdit->verticalScrollBar()){
+        if (isMouseOnScrollBar) {
+            if (object == m_textEdit->verticalScrollBar()) {
                 m_textEdit->setFocusPolicy(Qt::StrongFocus);
             }
         }
         break;
     }
 #endif
-    case QEvent::FocusIn:{
-        if(object == m_textEdit){
-            if(!m_isOperationRunning){
+    case QEvent::FocusIn: {
+        if (object == m_textEdit) {
+            if (!m_isOperationRunning) {
                 if (m_listModel->rowCount() == 0) {
-                    if(!m_searchEdit->text().isEmpty()) {
+                    if (!m_searchEdit->text().isEmpty()) {
                         m_listViewLogic->clearSearch(true);
                     } else {
                         this->createNewNote();
@@ -3244,29 +3371,29 @@ bool MainWindow::eventFilter(QObject *object, QEvent *event)
             m_textEdit->setFocus();
         }
 
-        if(object == m_searchEdit){
+        if (object == m_searchEdit) {
             setSearchEditStyleSheet(true);
         }
         break;
     }
-    case QEvent::FocusOut:{
-        if(object == m_searchEdit){
+    case QEvent::FocusOut: {
+        if (object == m_searchEdit) {
             setSearchEditStyleSheet(false);
         }
         break;
     }
-    case QEvent::Resize:{
-        if(m_textEdit->width() < m_smallEditorWidth) {
+    case QEvent::Resize: {
+        if (m_textEdit->width() < m_smallEditorWidth) {
             m_noteEditorLogic->setCurrentMinimumEditorPadding(15);
-        } else if(m_textEdit->width() > m_smallEditorWidth && m_textEdit->width() < 515) {
+        } else if (m_textEdit->width() > m_smallEditorWidth && m_textEdit->width() < 515) {
             m_noteEditorLogic->setCurrentMinimumEditorPadding(40);
-        } else if(m_textEdit->width() > 515 && m_textEdit->width() < 755) {
+        } else if (m_textEdit->width() > 515 && m_textEdit->width() < 755) {
             m_noteEditorLogic->setCurrentMinimumEditorPadding(50);
-        } else if(m_textEdit->width() > 755 && m_textEdit->width() < 775) {
+        } else if (m_textEdit->width() > 755 && m_textEdit->width() < 775) {
             m_noteEditorLogic->setCurrentMinimumEditorPadding(60);
-        } else if(m_textEdit->width() > 775 && m_textEdit->width() < 800) {
+        } else if (m_textEdit->width() > 775 && m_textEdit->width() < 800) {
             m_noteEditorLogic->setCurrentMinimumEditorPadding(70);
-        } else if(m_textEdit->width() > 800) {
+        } else if (m_textEdit->width() > 800) {
             m_noteEditorLogic->setCurrentMinimumEditorPadding(80);
         }
 
@@ -3276,14 +3403,14 @@ bool MainWindow::eventFilter(QObject *object, QEvent *event)
         break;
     }
     case QEvent::Show:
-        if(object == &m_updater){
+        if (object == &m_updater) {
 
             QRect rect = m_updater.geometry();
             QRect appRect = geometry();
-            int titleBarHeight = 28 ;
+            int titleBarHeight = 28;
 
-            int x = int(appRect.x() + (appRect.width() - rect.width())/2.0);
-            int y = int(appRect.y() + titleBarHeight  + (appRect.height() - rect.height())/2.0);
+            int x = int(appRect.x() + (appRect.width() - rect.width()) / 2.0);
+            int y = int(appRect.y() + titleBarHeight + (appRect.height() - rect.height()) / 2.0);
 
             m_updater.setGeometry(QRect(x, y, rect.width(), rect.height()));
         }
@@ -3292,33 +3419,29 @@ bool MainWindow::eventFilter(QObject *object, QEvent *event)
     case QEvent::MouseButtonDblClick:
         // Only allow double click (maximise/minimise) or dragging (move)
         // from the top part of the window
-        if(object == ui->frame){
-            QMouseEvent* mouseEvent = static_cast<QMouseEvent*>(event);
-            if(mouseEvent->pos().y() >= ui->searchEdit->y()){
+        if (object == ui->frame) {
+            QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);
+            if (mouseEvent->pos().y() >= ui->searchEdit->y()) {
                 return true;
             }
         }
         break;
-    case QEvent::KeyPress:
-    {
+    case QEvent::KeyPress: {
         auto *keyEvent = static_cast<QKeyEvent *>(event);
         if (keyEvent->key() == Qt::Key_Return && m_searchEdit->text().isEmpty()) {
             setFocusOnText();
-        } else if (keyEvent->key() == Qt::Key_Return &&
-                   keyEvent->modifiers().testFlag(Qt::ControlModifier)) {
+        } else if (keyEvent->key() == Qt::Key_Return
+                   && keyEvent->modifiers().testFlag(Qt::ControlModifier)) {
             setFocusOnText();
             return true;
         }
         break;
     }
-    case QEvent::MouseMove:
-    {
+    case QEvent::MouseMove: {
         // Apperantly we need this if m_layoutMargin is set to 0
-        if(object == ui->frame ||
-                object == ui->frameMiddle ||
-                object == ui->frameRight ||
-                object == ui->frameRightTop)
-            mouseMoveEvent(static_cast<QMouseEvent*>(event));
+        if (object == ui->frame || object == ui->frameMiddle || object == ui->frameRight
+            || object == ui->frameRightTop)
+            mouseMoveEvent(static_cast<QMouseEvent *>(event));
     }
     default:
         break;
@@ -3335,28 +3458,30 @@ bool MainWindow::eventFilter(QObject *object, QEvent *event)
 bool MainWindow::alreadyAppliedFormat(const QString &formatChars)
 {
     QTextCursor cursor = m_textEdit->textCursor();
-    if(!cursor.hasSelection()){
+    if (!cursor.hasSelection()) {
         cursor.select(QTextCursor::WordUnderCursor);
-        if(!cursor.hasSelection()){
+        if (!cursor.hasSelection()) {
             QTextDocument *doc = m_textEdit->document();
-            cursor = doc->find(QRegularExpression(QRegularExpression::escape(formatChars) + "[^ " +formatChars + "]+" +
-                                                  QRegularExpression::escape(formatChars) + "$"), cursor.selectionStart(),
-                               QTextDocument::FindBackward);
+            cursor = doc->find(QRegularExpression(QRegularExpression::escape(formatChars) + "[^ "
+                                                  + formatChars + "]+"
+                                                  + QRegularExpression::escape(formatChars) + "$"),
+                               cursor.selectionStart(), QTextDocument::FindBackward);
             if (!cursor.isNull()) {
-                //m_textEdit->setTextCursor(cursor);
+                // m_textEdit->setTextCursor(cursor);
                 return true;
             }
-            if(!cursor.hasSelection()){
+            if (!cursor.hasSelection()) {
                 return false;
             }
         }
     }
-    if(cursor.selectedText().contains(formatChars)){
+    if (cursor.selectedText().contains(formatChars)) {
         return true;
     }
     QString selectedText = cursor.selectedText();
     QTextDocument *doc = m_textEdit->document();
-    cursor = doc->find(formatChars + selectedText + formatChars, cursor.selectionStart() - formatChars.length());
+    cursor = doc->find(formatChars + selectedText + formatChars,
+                       cursor.selectionStart() - formatChars.length());
     return cursor.hasSelection();
 }
 
@@ -3389,9 +3514,10 @@ void MainWindow::stayOnTop(bool checked)
 void MainWindow::askBeforeSettingNativeWindowFrame()
 {
 #ifdef _WIN32
-    if(!m_useNativeWindowFrame) {
+    if (!m_useNativeWindowFrame) {
         QMessageBox msgBox;
-        msgBox.setText(tr("Warning: After performing this action, you will need to restart your system to revert to custom decoration."));
+        msgBox.setText(tr("Warning: After performing this action, you will need to restart your "
+                          "system to revert to custom decoration."));
         msgBox.setInformativeText(tr("Would you like to continue?"));
         msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
         msgBox.setDefaultButton(QMessageBox::No);
@@ -3414,7 +3540,7 @@ void MainWindow::increaseHeading()
     cursor.select(QTextCursor::BlockUnderCursor);
     QString selected_text = cursor.selectedText().trimmed();
     int count = QRegularExpression("^[#]*").match(selected_text).capturedLength();
-    if (count < 6){
+    if (count < 6) {
         setHeading(++count);
     }
 }
@@ -3429,7 +3555,7 @@ void MainWindow::decreaseHeading()
     cursor.select(QTextCursor::BlockUnderCursor);
     QString selected_text = cursor.selectedText().trimmed();
     int count = QRegularExpression("^[#]*").match(selected_text).capturedLength();
-    if (count > 0){
+    if (count > 0) {
         setHeading(--count);
     }
 }
@@ -3444,14 +3570,15 @@ void MainWindow::setHeading(int level)
     QTextCursor cursor = m_textEdit->textCursor();
     cursor.select(QTextCursor::BlockUnderCursor);
     QString new_text = "\n";
-    if(cursor.hasSelection()){
+    if (cursor.hasSelection()) {
         QString selected_text = cursor.selectedText();
-        if(selected_text.at(0).unicode() != 8233){ // if it doesn't start with a paragraph delimiter (first line)
+        if (selected_text.at(0).unicode()
+            != 8233) { // if it doesn't start with a paragraph delimiter (first line)
             new_text.clear();
         }
         selected_text = selected_text.trimmed().remove(QRegularExpression("^#*\\s?"));
         new_text += QString("#").repeated(level) + ((level == 0) ? "" : " ") + selected_text;
-    }else{
+    } else {
         new_text = QString("#").repeated(level) + " ";
     }
     cursor.insertText(new_text);
@@ -3468,18 +3595,17 @@ void MainWindow::adjustUpperWidgets(bool shouldPushUp)
 
     // Adjust space above search field
     const QSizePolicy policy = ui->verticalSpacer_upSearchEdit->sizePolicy();
-    ui->verticalSpacer_upSearchEdit->setMinimumSize(0,
-                                                    shouldPushUp ? ui->verticalSpacer_upScrollArea->sizeHint().height() : 25);
-    ui->verticalSpacer_upTreeView->setMinimumSize(0,
-                                                  shouldPushUp ? 9 : 25);
+    ui->verticalSpacer_upSearchEdit->setMinimumSize(
+            0, shouldPushUp ? ui->verticalSpacer_upScrollArea->sizeHint().height() : 25);
+    ui->verticalSpacer_upTreeView->setMinimumSize(0, shouldPushUp ? 9 : 25);
 
-    ui->verticalSpacer_upEditorDateLabel->changeSize(0,
-                                                     shouldPushUp ? ui->verticalSpacer_upScrollArea->sizeHint().height() : 25,
-                                                     policy.horizontalPolicy(),
-                                                     policy.verticalPolicy());
+    ui->verticalSpacer_upEditorDateLabel->changeSize(
+            0, shouldPushUp ? ui->verticalSpacer_upScrollArea->sizeHint().height() : 25,
+            policy.horizontalPolicy(), policy.verticalPolicy());
 
     // Force a full re-layout of the top right frame.
-    // This fixes some widgets not properly updating after switching between native and non-native window decoration modes.
+    // This fixes some widgets not properly updating after switching between native and non-native
+    // window decoration modes.
     ui->frameRightTop->setStyleSheet(ui->frameRightTop->styleSheet());
 }
 
@@ -3502,12 +3628,12 @@ void MainWindow::setUseNativeWindowFrame(bool useNativeWindowFrame)
 
     auto flags = windowFlags();
 
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+#  if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
     if (useNativeWindowFrame)
         flags &= ~Qt::FramelessWindowHint;
     else
         flags |= Qt::FramelessWindowHint;
-#elif _WIN32
+#  elif _WIN32
     if (useNativeWindowFrame) {
         flags &= ~Qt::CustomizeWindowHint;
         flags &= ~Qt::FramelessWindowHint;
@@ -3515,11 +3641,10 @@ void MainWindow::setUseNativeWindowFrame(bool useNativeWindowFrame)
         flags |= Qt::CustomizeWindowHint;
         flags |= Qt::FramelessWindowHint;
     }
-#endif
+#  endif
 
     setWindowFlags(flags);
 #endif
-
 
     //#if defined(Q_OS_LINUX)
     //    if (useNativeWindowFrame || isMaximized()) {
@@ -3557,13 +3682,14 @@ void MainWindow::toggleStayOnTop()
  */
 void MainWindow::onSearchEditReturnPressed()
 {
-    if (m_searchEdit->text().isEmpty()) return;
+    if (m_searchEdit->text().isEmpty())
+        return;
 
     QString searchText = m_searchEdit->text();
     QTextDocument *doc = m_textEdit->document();
-    //get current cursor
+    // get current cursor
     QTextCursor from = m_textEdit->textCursor();
-    //search
+    // search
     QTextCursor found = doc->find(searchText, from);
     m_textEdit->setTextCursor(found);
 }
@@ -3578,6 +3704,5 @@ void MainWindow::setMargins(QMargins margins)
         return;
 
     ui->centralWidget->layout()->setContentsMargins(margins);
-    m_trafficLightLayout.setGeometry(QRect(4+margins.left(),4+margins.top(),56,16));
+    m_trafficLightLayout.setGeometry(QRect(4 + margins.left(), 4 + margins.top(), 56, 16));
 }
-

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -1,8 +1,8 @@
 /*********************************************************************************************
-* Mozila License
-* Just a meantime project to see the ability of qt, the framework that my OS might be based on
-* And for those linux users that beleive in the power of notes
-*********************************************************************************************/
+ * Mozila License
+ * Just a meantime project to see the ability of qt, the framework that my OS might be based on
+ * And for those linux users that beleive in the power of notes
+ *********************************************************************************************/
 
 #ifndef MAINWINDOW_H
 #define MAINWINDOW_H
@@ -50,7 +50,7 @@ class SplitterStyle;
 //#if defined(__MINGW32__) || defined(__GNUC__)
 using MainWindowBase = QMainWindow;
 //#else
-//using MainWindowBase = CFramelessWindow;
+// using MainWindowBase = CFramelessWindow;
 //#endif
 #elif defined(Q_OS_MACOS)
 using MainWindowBase = CFramelessWindow;
@@ -62,13 +62,9 @@ class MainWindow : public MainWindowBase
     Q_OBJECT
 
 public:
+    enum class ShadowType { Linear = 0, Radial };
 
-    enum class ShadowType{
-        Linear = 0,
-        Radial
-        };
-
-    enum class ShadowSide{
+    enum class ShadowSide {
         Left = 0,
         Right,
         Top,
@@ -77,9 +73,9 @@ public:
         TopRight,
         BottomLeft,
         BottomRight
-        };
+    };
 
-    enum class StretchSide{
+    enum class StretchSide {
         None = 0,
         Left,
         Right,
@@ -89,7 +85,7 @@ public:
         TopRight,
         BottomLeft,
         BottomRight
-        };
+    };
 
     Q_ENUM(ShadowType)
     Q_ENUM(ShadowSide)
@@ -101,54 +97,55 @@ public:
     void setMainWindowVisibility(bool state);
 
 public slots:
-    void saveLastSelectedFolderTags(bool isFolder, const QString &folderPath, const QSet<int>& tagId);
-    void saveExpandedFolder(const QStringList& folderPaths);
+    void saveLastSelectedFolderTags(bool isFolder, const QString &folderPath,
+                                    const QSet<int> &tagId);
+    void saveExpandedFolder(const QStringList &folderPaths);
     void saveLastSelectedNote(const QSet<int> &notesId);
 
 protected:
-    void paintEvent(QPaintEvent* event) Q_DECL_OVERRIDE;
-    void resizeEvent(QResizeEvent* event) Q_DECL_OVERRIDE;
-    void closeEvent(QCloseEvent* event) Q_DECL_OVERRIDE;
-    void mousePressEvent(QMouseEvent* event) Q_DECL_OVERRIDE;
-    void mouseMoveEvent(QMouseEvent* event) Q_DECL_OVERRIDE;
-    void mouseReleaseEvent(QMouseEvent* event) Q_DECL_OVERRIDE;
-    void mouseDoubleClickEvent(QMouseEvent* event) Q_DECL_OVERRIDE;
-    void leaveEvent(QEvent*) Q_DECL_OVERRIDE;
-    bool eventFilter(QObject* object, QEvent* event) Q_DECL_OVERRIDE;
+    void paintEvent(QPaintEvent *event) Q_DECL_OVERRIDE;
+    void resizeEvent(QResizeEvent *event) Q_DECL_OVERRIDE;
+    void closeEvent(QCloseEvent *event) Q_DECL_OVERRIDE;
+    void mousePressEvent(QMouseEvent *event) Q_DECL_OVERRIDE;
+    void mouseMoveEvent(QMouseEvent *event) Q_DECL_OVERRIDE;
+    void mouseReleaseEvent(QMouseEvent *event) Q_DECL_OVERRIDE;
+    void mouseDoubleClickEvent(QMouseEvent *event) Q_DECL_OVERRIDE;
+    void leaveEvent(QEvent *) Q_DECL_OVERRIDE;
+    bool eventFilter(QObject *object, QEvent *event) Q_DECL_OVERRIDE;
 
 private:
-    Ui::MainWindow* ui;
+    Ui::MainWindow *ui;
 
-    QSettings* m_settingsDatabase;
-    QToolButton* m_clearButton;
-    QPushButton* m_greenMaximizeButton;
-    QPushButton* m_redCloseButton;
-    QPushButton* m_yellowMinimizeButton;
+    QSettings *m_settingsDatabase;
+    QToolButton *m_clearButton;
+    QPushButton *m_greenMaximizeButton;
+    QPushButton *m_redCloseButton;
+    QPushButton *m_yellowMinimizeButton;
     QHBoxLayout m_trafficLightLayout;
-    QPushButton* m_newNoteButton;
-    QPushButton* m_trashButton;
-    QPushButton* m_dotsButton;
-    QPushButton* m_styleEditorButton;
-    CustomDocument* m_textEdit;
-    NoteEditorLogic* m_noteEditorLogic;
-    QLineEdit* m_searchEdit;
-    QLabel* m_editorDateLabel;
+    QPushButton *m_newNoteButton;
+    QPushButton *m_trashButton;
+    QPushButton *m_dotsButton;
+    QPushButton *m_styleEditorButton;
+    CustomDocument *m_textEdit;
+    NoteEditorLogic *m_noteEditorLogic;
+    QLineEdit *m_searchEdit;
+    QLabel *m_editorDateLabel;
     QSplitter *m_splitter;
-    QSystemTrayIcon* m_trayIcon;
-    QAction* m_restoreAction;
-    QAction* m_quitAction;
-    QMenu* m_trayIconMenu;
+    QSystemTrayIcon *m_trayIcon;
+    QAction *m_restoreAction;
+    QAction *m_quitAction;
+    QMenu *m_trayIconMenu;
 
-    NoteListView* m_listView;
-    NoteListModel* m_listModel;
-    ListViewLogic* m_listViewLogic;
-    NodeTreeView* m_treeView;
-    NodeTreeModel* m_treeModel;
-    TreeViewLogic* m_treeViewLogic;
-    TagPool* m_tagPool;
-    DBManager* m_dbManager;
-    QThread* m_dbThread;
-	SplitterStyle* m_splitterStyle;
+    NoteListView *m_listView;
+    NoteListModel *m_listModel;
+    ListViewLogic *m_listViewLogic;
+    NodeTreeView *m_treeView;
+    NodeTreeModel *m_treeModel;
+    TreeViewLogic *m_treeViewLogic;
+    TagPool *m_tagPool;
+    DBManager *m_dbManager;
+    QThread *m_dbThread;
+    SplitterStyle *m_splitterStyle;
     UpdaterWindow m_updater;
     StyleEditorWindow m_styleEditorWindow;
     AboutWindow m_aboutWindow;
@@ -182,7 +179,8 @@ private:
     int m_currentFontPointSize;
     bool m_isNoteListCollapsed;
     bool m_isTreeCollapsed;
-    struct m_charsLimitPerFont {
+    struct m_charsLimitPerFont
+    {
         int mono;
         int serif;
         int sansSerif;
@@ -234,8 +232,8 @@ private:
     void adjustUpperWidgets(bool shouldPushUp);
     void setSearchEditStyleSheet(bool isFocused);
 
-    void dropShadow(QPainter& painter, ShadowType type, ShadowSide side);
-    void fillRectWithGradient(QPainter& painter, QRect rect, QGradient& gradient);
+    void dropShadow(QPainter &painter, ShadowType type, ShadowSide side);
+    void fillRectWithGradient(QPainter &painter, QRect rect, QGradient &gradient);
     double gaussianDist(double x, const double center, double sigma) const;
 
     void setMargins(QMargins margins);
@@ -296,21 +294,21 @@ private slots:
     void setTheme(Theme theme);
     void deleteSelectedNote();
     void clearSearch();
-    void showErrorMessage(const QString& title, const QString& content);
+    void showErrorMessage(const QString &title, const QString &content);
     void setNoteListLoading();
     void selectAllNotesInList();
     void updateFrame();
 
 signals:
     void requestNodesTree();
-    void requestOpenDBManager(const QString& path, bool doCreate);
-    void requestRestoreNotes(const QString& filePath);
-    void requestImportNotes(const QString& filePath);
+    void requestOpenDBManager(const QString &path, bool doCreate);
+    void requestRestoreNotes(const QString &filePath);
+    void requestImportNotes(const QString &filePath);
     void requestExportNotes(QString fileName);
-    void requestMigrateNotesFromV0_9_0(QVector<NodeData>& noteList);
-    void requestMigrateTrashFromV0_9_0(QVector<NodeData>& noteList);
-    void requestMigrateNotesFromV1_5_0(const QString& path);
-    void requestChangeDatabasePath(const QString& newPath);
+    void requestMigrateNotesFromV0_9_0(QVector<NodeData> &noteList);
+    void requestMigrateTrashFromV0_9_0(QVector<NodeData> &noteList);
+    void requestMigrateNotesFromV1_5_0(const QString &path);
+    void requestChangeDatabasePath(const QString &newPath);
 };
 
 #endif // MAINWINDOW_H

--- a/src/nodedata.cpp
+++ b/src/nodedata.cpp
@@ -1,18 +1,17 @@
 #include "nodedata.h"
 #include <QDataStream>
 
-NodeData::NodeData():
-    m_id{SpecialNodeID::InvalidNodeId},
-    m_isModified(false),
-    m_isSelected(false),
-    m_scrollBarPosition(0),
-    m_isTempNote{false},
-    m_isPinnedNote{false},
-    m_tagListScrollBarPos{0},
-    m_relativePosAN{0},
-    m_childNotesCount{0}
+NodeData::NodeData()
+    : m_id{ SpecialNodeID::InvalidNodeId },
+      m_isModified(false),
+      m_isSelected(false),
+      m_scrollBarPosition(0),
+      m_isTempNote{ false },
+      m_isPinnedNote{ false },
+      m_tagListScrollBarPos{ 0 },
+      m_relativePosAN{ 0 },
+      m_childNotesCount{ 0 }
 {
-
 }
 
 int NodeData::id() const
@@ -90,7 +89,7 @@ QDateTime NodeData::deletionDateTime() const
     return m_deletionDateTime;
 }
 
-void NodeData::setDeletionDateTime(const QDateTime& deletionDateTime)
+void NodeData::setDeletionDateTime(const QDateTime &deletionDateTime)
 {
     m_deletionDateTime = deletionDateTime;
 }
@@ -210,12 +209,13 @@ QDateTime NodeData::creationDateTime() const
     return m_creationDateTime;
 }
 
-void NodeData::setCreationDateTime(const QDateTime&creationDateTime)
+void NodeData::setCreationDateTime(const QDateTime &creationDateTime)
 {
     m_creationDateTime = creationDateTime;
 }
 
-QDataStream &operator>>(QDataStream &stream, NodeData &nodeData){
+QDataStream &operator>>(QDataStream &stream, NodeData &nodeData)
+{
     int id;
     QString fullTitle;
     QDateTime lastModificationDateTime;
@@ -230,7 +230,7 @@ QDataStream &operator>>(QDataStream &stream, NodeData &nodeData){
     return stream;
 }
 
-QDataStream &operator>>(QDataStream &stream, NodeData* &nodeData)
+QDataStream &operator>>(QDataStream &stream, NodeData *&nodeData)
 {
     nodeData = new NodeData();
     QString id;

--- a/src/nodedata.h
+++ b/src/nodedata.h
@@ -6,12 +6,12 @@
 #include <QSet>
 
 namespace SpecialNodeID {
-    enum Value {
-        InvalidNodeId = -1,
-        RootFolder = 0,
-        TrashFolder = 1,
-        DefaultNotesFolder = 2,
-    };
+enum Value {
+    InvalidNodeId = -1,
+    RootFolder = 0,
+    TrashFolder = 1,
+    DefaultNotesFolder = 2,
+};
 }
 
 class NodeData
@@ -19,10 +19,7 @@ class NodeData
 public:
     explicit NodeData();
 
-    enum Type {
-        Note = 0,
-        Folder
-    };
+    enum Type { Note = 0, Folder };
 
     int id() const;
     void setId(int id);
@@ -34,7 +31,7 @@ public:
     void setLastModificationDateTime(const QDateTime &lastModificationdateTime);
 
     QDateTime creationDateTime() const;
-    void setCreationDateTime(const QDateTime& creationDateTime);
+    void setCreationDateTime(const QDateTime &creationDateTime);
 
     QString content() const;
     void setContent(const QString &content);
@@ -49,7 +46,7 @@ public:
     void setScrollBarPosition(int scrollBarPosition);
 
     QDateTime deletionDateTime() const;
-    void setDeletionDateTime(const QDateTime& deletionDateTime);
+    void setDeletionDateTime(const QDateTime &deletionDateTime);
 
     NodeData::Type nodeType() const;
     void setNodeType(NodeData::Type newNodeType);
@@ -109,7 +106,7 @@ private:
 
 Q_DECLARE_METATYPE(NodeData)
 
-QDataStream &operator>>(QDataStream &stream, NodeData& nodeData);
-QDataStream &operator>>(QDataStream &stream, NodeData* &nodeData);
+QDataStream &operator>>(QDataStream &stream, NodeData &nodeData);
+QDataStream &operator>>(QDataStream &stream, NodeData *&nodeData);
 
 #endif // NODEDATA_H

--- a/src/nodepath.cpp
+++ b/src/nodepath.cpp
@@ -1,11 +1,7 @@
 #include "nodepath.h"
 #include "nodedata.h"
 
-NodePath::NodePath(const QString &path) :
-    m_path(path)
-{
-
-}
+NodePath::NodePath(const QString &path) : m_path(path) { }
 
 QStringList NodePath::seperate() const
 {
@@ -35,6 +31,6 @@ QString NodePath::getAllNoteFolderPath()
 
 QString NodePath::getTrashFolderPath()
 {
-    return PATH_SEPERATOR + QString::number(SpecialNodeID::RootFolder)
-            + PATH_SEPERATOR + QString::number(SpecialNodeID::TrashFolder);
+    return PATH_SEPERATOR + QString::number(SpecialNodeID::RootFolder) + PATH_SEPERATOR
+            + QString::number(SpecialNodeID::TrashFolder);
 }

--- a/src/nodepath.h
+++ b/src/nodepath.h
@@ -12,16 +12,16 @@
 class NodePath
 {
 public:
-    NodePath(const QString& path);
+    NodePath(const QString &path);
     QStringList seperate() const;
 
     QString path() const;
     NodePath parentPath() const;
     static QString getAllNoteFolderPath();
     static QString getTrashFolderPath();
+
 private:
     QString m_path;
 };
-
 
 #endif // NODEPATH_H

--- a/src/nodetreedelegate.cpp
+++ b/src/nodetreedelegate.cpp
@@ -13,47 +13,48 @@
 #include "allnotebuttontreedelegateeditor.h"
 #include <QFontMetrics>
 
-NodeTreeDelegate::NodeTreeDelegate(QTreeView *view, QObject *parent):
-    QStyledItemDelegate{parent},
-    #ifdef __APPLE__
-    m_displayFont(QFont(QStringLiteral("SF Pro Text")).exactMatch() ? QStringLiteral("SF Pro Text") : QStringLiteral("Roboto")),
-    #elif _WIN32
-    m_displayFont(QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI") : QStringLiteral("Roboto")),
-    #else
-    m_displayFont(QStringLiteral("Roboto")),
-    #endif
-    #ifdef __APPLE__
-	m_titleFont(m_displayFont, 13, QFont::DemiBold),
-    m_titleSelectedFont(m_displayFont, 13),
-    m_dateFont(m_displayFont, 13),
-    #else
-	m_titleFont(m_displayFont, 10, QFont::DemiBold),
-    m_titleSelectedFont(m_displayFont, 10),
-    m_dateFont(m_displayFont, 10),
-    #endif
-    m_titleColor(26, 26, 26),
-    m_titleSelectedColor(255, 255, 255),
-    m_dateColor(132, 132, 132),
-    m_ActiveColor(68, 138, 201),
-    m_notActiveColor(175, 212, 228),
-    m_hoverColor(207, 207, 207),
-    m_applicationInactiveColor(207, 207, 207),
-    m_separatorColor(221, 221, 221),
-    m_defaultColor(247, 247, 247),
-    m_separatorTextColor(143, 143, 143),
-    m_currentBackgroundColor(255, 255, 255),
-    m_view(view),
-    m_theme(Theme::Light)
+NodeTreeDelegate::NodeTreeDelegate(QTreeView *view, QObject *parent)
+    : QStyledItemDelegate{ parent },
+#ifdef __APPLE__
+      m_displayFont(QFont(QStringLiteral("SF Pro Text")).exactMatch()
+                            ? QStringLiteral("SF Pro Text")
+                            : QStringLiteral("Roboto")),
+#elif _WIN32
+      m_displayFont(QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI")
+                                                                   : QStringLiteral("Roboto")),
+#else
+      m_displayFont(QStringLiteral("Roboto")),
+#endif
+#ifdef __APPLE__
+      m_titleFont(m_displayFont, 13, QFont::DemiBold),
+      m_titleSelectedFont(m_displayFont, 13),
+      m_dateFont(m_displayFont, 13),
+#else
+      m_titleFont(m_displayFont, 10, QFont::DemiBold),
+      m_titleSelectedFont(m_displayFont, 10),
+      m_dateFont(m_displayFont, 10),
+#endif
+      m_titleColor(26, 26, 26),
+      m_titleSelectedColor(255, 255, 255),
+      m_dateColor(132, 132, 132),
+      m_ActiveColor(68, 138, 201),
+      m_notActiveColor(175, 212, 228),
+      m_hoverColor(207, 207, 207),
+      m_applicationInactiveColor(207, 207, 207),
+      m_separatorColor(221, 221, 221),
+      m_defaultColor(247, 247, 247),
+      m_separatorTextColor(143, 143, 143),
+      m_currentBackgroundColor(255, 255, 255),
+      m_view(view),
+      m_theme(Theme::Light)
 {
-
 }
 
 void NodeTreeDelegate::setTheme(Theme theme)
 {
     m_theme = theme;
     switch (theme) {
-    case Theme::Light:
-    {
+    case Theme::Light: {
         m_titleColor = QColor(26, 26, 26);
         m_dateColor = QColor(26, 26, 26);
         m_defaultColor = QColor(247, 247, 247);
@@ -63,8 +64,7 @@ void NodeTreeDelegate::setTheme(Theme theme)
         m_currentBackgroundColor = QColor(247, 247, 247);
         break;
     }
-    case Theme::Dark:
-    {
+    case Theme::Dark: {
         m_titleColor = QColor(204, 204, 204);
         m_dateColor = QColor(204, 204, 204);
         m_defaultColor = QColor(30, 30, 30);
@@ -74,8 +74,7 @@ void NodeTreeDelegate::setTheme(Theme theme)
         m_currentBackgroundColor = QColor(30, 30, 30);
         break;
     }
-    case Theme::Sepia:
-    {
+    case Theme::Sepia: {
         m_titleColor = QColor(26, 26, 26);
         m_dateColor = QColor(26, 26, 26);
         m_defaultColor = QColor(251, 240, 217);
@@ -88,8 +87,7 @@ void NodeTreeDelegate::setTheme(Theme theme)
     }
 }
 
-void NodeTreeDelegate::paint(QPainter *painter,
-                             const QStyleOptionViewItem &option,
+void NodeTreeDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option,
                              const QModelIndex &index) const
 {
     painter->setRenderHint(QPainter::Antialiasing);
@@ -103,7 +101,8 @@ void NodeTreeDelegate::paint(QPainter *painter,
     case NodeItem::Type::AllNoteButton:
     case NodeItem::Type::TrashButton: {
         paintBackgroundSelectable(painter, option, index);
-        auto iconRect = QRect(option.rect.x() + 5, option.rect.y() + (option.rect.height() - 20) / 2, 18, 20);
+        auto iconRect = QRect(option.rect.x() + 5,
+                              option.rect.y() + (option.rect.height() - 20) / 2, 18, 20);
         if (m_theme == Theme::Dark) {
             if (itemType == NodeItem::Type::AllNoteButton) {
                 painter->drawImage(iconRect, QImage(":/images/all-notes-icon-dark.png"));
@@ -118,7 +117,7 @@ void NodeTreeDelegate::paint(QPainter *painter,
         QRect nameRect(option.rect);
         nameRect.setLeft(iconRect.x() + iconRect.width() + 5);
         nameRect.setWidth(nameRect.width() - 5 - 40);
-        if((option.state & QStyle::State_Selected) == QStyle::State_Selected) {
+        if ((option.state & QStyle::State_Selected) == QStyle::State_Selected) {
             painter->setPen(m_titleSelectedColor);
         } else {
             painter->setPen(m_titleColor);
@@ -129,17 +128,18 @@ void NodeTreeDelegate::paint(QPainter *painter,
         childCountRect.setLeft(nameRect.right() + 5);
         childCountRect.setWidth(childCountRect.width() - 5);
         auto childCount = index.data(NodeItem::Roles::ChildCount).toInt();
-        if((option.state & QStyle::State_Selected) == QStyle::State_Selected) {
+        if ((option.state & QStyle::State_Selected) == QStyle::State_Selected) {
             painter->setPen(m_titleSelectedColor);
         } else {
             painter->setPen(m_titleColor);
         }
         painter->setFont(m_titleFont);
-        painter->drawText(childCountRect, Qt::AlignHCenter | Qt::AlignVCenter, QString::number(childCount));
+        painter->drawText(childCountRect, Qt::AlignHCenter | Qt::AlignVCenter,
+                          QString::number(childCount));
         break;
     }
     case NodeItem::Type::FolderSeparator:
-    case NodeItem::Type::TagSeparator:{
+    case NodeItem::Type::TagSeparator: {
         auto textRect = option.rect;
         textRect.moveLeft(textRect.x() + 5);
         auto displayName = index.data(NodeItem::Roles::DisplayText).toString();
@@ -150,16 +150,17 @@ void NodeTreeDelegate::paint(QPainter *painter,
     }
     case NodeItem::Type::FolderItem: {
         paintBackgroundSelectable(painter, option, index);
-        auto iconRect = QRect(option.rect.x() + 5, option.rect.y() + (option.rect.height() - 15) / 2, 15, 15);
+        auto iconRect = QRect(option.rect.x() + 5,
+                              option.rect.y() + (option.rect.height() - 15) / 2, 15, 15);
         QString iconPath;
         if (m_theme == Theme::Dark) {
-            if((option.state & QStyle::State_Open) == QStyle::State_Open) {
+            if ((option.state & QStyle::State_Open) == QStyle::State_Open) {
                 iconPath = ":/images/tree-node-expanded-dark.png";
             } else {
                 iconPath = ":/images/tree-node-normal-dark.png";
             }
         } else {
-            if((option.state & QStyle::State_Open) == QStyle::State_Open) {
+            if ((option.state & QStyle::State_Open) == QStyle::State_Open) {
                 iconPath = ":/images/tree-node-expanded.png";
             } else {
                 iconPath = ":/images/tree-node-normal.png";
@@ -174,7 +175,7 @@ void NodeTreeDelegate::paint(QPainter *painter,
         QFontMetrics fm(m_titleFont);
         auto displayName = index.data(NodeItem::Roles::DisplayText).toString();
         displayName = fm.elidedText(displayName, Qt::ElideRight, nameRect.width());
-        if((option.state & QStyle::State_Selected) == QStyle::State_Selected) {
+        if ((option.state & QStyle::State_Selected) == QStyle::State_Selected) {
             painter->setPen(m_titleSelectedColor);
         } else {
             painter->setPen(m_titleColor);
@@ -185,13 +186,14 @@ void NodeTreeDelegate::paint(QPainter *painter,
         childCountRect.setLeft(nameRect.right() + 5);
         childCountRect.setWidth(childCountRect.width() - 5);
         auto childCount = index.data(NodeItem::Roles::ChildCount).toInt();
-        if((option.state & QStyle::State_Selected) == QStyle::State_Selected) {
+        if ((option.state & QStyle::State_Selected) == QStyle::State_Selected) {
             painter->setPen(m_titleSelectedColor);
         } else {
             painter->setPen(m_titleColor);
         }
         painter->setFont(m_titleFont);
-        painter->drawText(childCountRect, Qt::AlignHCenter | Qt::AlignVCenter, QString::number(childCount));
+        painter->drawText(childCountRect, Qt::AlignHCenter | Qt::AlignVCenter,
+                          QString::number(childCount));
         break;
     }
     case NodeItem::Type::NoteItem: {
@@ -202,7 +204,7 @@ void NodeTreeDelegate::paint(QPainter *painter,
         auto displayName = index.data(NodeItem::Roles::DisplayText).toString();
         QFontMetrics fm(m_titleFont);
         displayName = fm.elidedText(displayName, Qt::ElideRight, nameRect.width());
-        if((option.state & QStyle::State_Selected) == QStyle::State_Selected) {
+        if ((option.state & QStyle::State_Selected) == QStyle::State_Selected) {
             painter->setPen(m_titleSelectedColor);
         } else {
             painter->setPen(m_titleColor);
@@ -213,7 +215,8 @@ void NodeTreeDelegate::paint(QPainter *painter,
     }
     case NodeItem::Type::TagItem: {
         paintBackgroundSelectable(painter, option, index);
-        auto iconRect = QRect(option.rect.x() + 10, option.rect.y() + (option.rect.height() - 14) / 2, 14, 14);
+        auto iconRect = QRect(option.rect.x() + 10,
+                              option.rect.y() + (option.rect.height() - 14) / 2, 14, 14);
         auto tagColor = index.data(NodeItem::Roles::TagColor).toString();
         painter->setBrush(QColor(tagColor));
         painter->setPen(QColor(tagColor));
@@ -226,7 +229,7 @@ void NodeTreeDelegate::paint(QPainter *painter,
         auto displayName = index.data(NodeItem::Roles::DisplayText).toString();
         QFontMetrics fm(m_titleFont);
         displayName = fm.elidedText(displayName, Qt::ElideRight, nameRect.width());
-        if((option.state & QStyle::State_Selected) == QStyle::State_Selected) {
+        if ((option.state & QStyle::State_Selected) == QStyle::State_Selected) {
             painter->setPen(m_titleSelectedColor);
         } else {
             painter->setPen(m_titleColor);
@@ -237,24 +240,27 @@ void NodeTreeDelegate::paint(QPainter *painter,
         childCountRect.setLeft(nameRect.right() + 5);
         childCountRect.setWidth(childCountRect.width() - 5);
         auto childCount = index.data(NodeItem::Roles::ChildCount).toInt();
-        if((option.state & QStyle::State_Selected) == QStyle::State_Selected) {
+        if ((option.state & QStyle::State_Selected) == QStyle::State_Selected) {
             painter->setPen(m_titleSelectedColor);
         } else {
             painter->setPen(m_titleColor);
         }
         painter->setFont(m_titleFont);
-        painter->drawText(childCountRect, Qt::AlignHCenter | Qt::AlignVCenter, QString::number(childCount));
+        painter->drawText(childCountRect, Qt::AlignHCenter | Qt::AlignVCenter,
+                          QString::number(childCount));
         break;
     }
     }
 }
 
-void NodeTreeDelegate::paintBackgroundSelectable(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex& index) const
+void NodeTreeDelegate::paintBackgroundSelectable(QPainter *painter,
+                                                 const QStyleOptionViewItem &option,
+                                                 const QModelIndex &index) const
 {
-    if((option.state & QStyle::State_Selected) == QStyle::State_Selected) {
+    if ((option.state & QStyle::State_Selected) == QStyle::State_Selected) {
         painter->fillRect(option.rect, QBrush(m_ActiveColor));
-    } else if((option.state & QStyle::State_MouseOver) == QStyle::State_MouseOver) {
-        auto treeView = dynamic_cast<NodeTreeView*>(m_view);
+    } else if ((option.state & QStyle::State_MouseOver) == QStyle::State_MouseOver) {
+        auto treeView = dynamic_cast<NodeTreeView *>(m_view);
         auto itemType = static_cast<NodeItem::Type>(index.data(NodeItem::Roles::ItemType).toInt());
         if (itemType == NodeItem::Type::TrashButton) {
             return;
@@ -273,9 +279,8 @@ QSize NodeTreeDelegate::sizeHint(const QStyleOptionViewItem &option, const QMode
         result.setHeight(NoteTreeConstant::folderLabelHeight);
     } else if (itemType == NodeItem::Type::TagSeparator) {
         result.setHeight(NoteTreeConstant::tagLabelHeight);
-    } else if (itemType == NodeItem::Type::FolderItem ||
-               itemType == NodeItem::Type::TrashButton ||
-               itemType == NodeItem::Type::AllNoteButton) {
+    } else if (itemType == NodeItem::Type::FolderItem || itemType == NodeItem::Type::TrashButton
+               || itemType == NodeItem::Type::AllNoteButton) {
         result.setHeight(NoteTreeConstant::folderItemHeight);
     } else if (itemType == NodeItem::Type::TagItem) {
         result.setHeight(NoteTreeConstant::tagItemHeight);
@@ -286,7 +291,8 @@ QSize NodeTreeDelegate::sizeHint(const QStyleOptionViewItem &option, const QMode
     return result;
 }
 
-QWidget *NodeTreeDelegate::createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const
+QWidget *NodeTreeDelegate::createEditor(QWidget *parent, const QStyleOptionViewItem &option,
+                                        const QModelIndex &index) const
 {
     auto itemType = static_cast<NodeItem::Type>(index.data(NodeItem::Roles::ItemType).toInt());
     if (itemType == NodeItem::Type::FolderSeparator || itemType == NodeItem::Type::TagSeparator) {
@@ -298,15 +304,15 @@ QWidget *NodeTreeDelegate::createEditor(QWidget *parent, const QStyleOptionViewI
         auto label = new QLabel(widget);
         auto displayName = index.data(NodeItem::Roles::DisplayText).toString();
         label->setStyleSheet(QStringLiteral("QLabel{color: rgb(%1, %2, %3);}")
-                             .arg(QString::number(m_separatorTextColor.red()),
-                                  QString::number(m_separatorTextColor.green()),
-                                  QString::number(m_separatorTextColor.blue())));
+                                     .arg(QString::number(m_separatorTextColor.red()),
+                                          QString::number(m_separatorTextColor.green()),
+                                          QString::number(m_separatorTextColor.blue())));
         label->setFont(m_titleFont);
         label->setText(displayName);
         layout->addWidget(label);
         auto addButton = new PushButtonType(parent);
-        addButton->setMaximumSize({38, 25});
-        addButton->setMinimumSize({38, 25});
+        addButton->setMaximumSize({ 38, 25 });
+        addButton->setMinimumSize({ 38, 25 });
         addButton->setCursor(QCursor(Qt::PointingHandCursor));
         addButton->setFocusPolicy(Qt::TabFocus);
         addButton->setNormalIcon(QIcon(QString::fromUtf8(":/images/newNote_Regular.png")));
@@ -318,11 +324,9 @@ QWidget *NodeTreeDelegate::createEditor(QWidget *parent, const QStyleOptionViewI
                                                 R"(    padding: 0px; )"
                                                 R"(})"));
         if (itemType == NodeItem::Type::FolderSeparator) {
-            connect(addButton, &QPushButton::clicked,
-                    this, &NodeTreeDelegate::addFolderRequested);
+            connect(addButton, &QPushButton::clicked, this, &NodeTreeDelegate::addFolderRequested);
         } else {
-            connect(addButton, &QPushButton::clicked,
-                    this, &NodeTreeDelegate::addTagRequested);
+            connect(addButton, &QPushButton::clicked, this, &NodeTreeDelegate::addTagRequested);
         }
         layout->addWidget(addButton, 1, Qt::AlignRight);
         return widget;
@@ -348,7 +352,8 @@ QWidget *NodeTreeDelegate::createEditor(QWidget *parent, const QStyleOptionViewI
     return nullptr;
 }
 
-void NodeTreeDelegate::updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex &index) const
+void NodeTreeDelegate::updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option,
+                                            const QModelIndex &index) const
 {
     QStyledItemDelegate::updateEditorGeometry(editor, option, index);
     auto itemType = static_cast<NodeItem::Type>(index.data(NodeItem::Roles::ItemType).toInt());

--- a/src/nodetreedelegate.h
+++ b/src/nodetreedelegate.h
@@ -10,7 +10,7 @@ class NodeTreeDelegate : public QStyledItemDelegate
 {
     Q_OBJECT
 public:
-    explicit NodeTreeDelegate(QTreeView* view, QObject *parent = Q_NULLPTR);
+    explicit NodeTreeDelegate(QTreeView *view, QObject *parent = Q_NULLPTR);
     void setTheme(Theme theme);
 signals:
     void addFolderRequested();
@@ -18,13 +18,18 @@ signals:
 
     // QAbstractItemDelegate interface
 public:
-    virtual void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
-    virtual QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const override;
-    virtual QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
-    virtual void updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+    virtual void paint(QPainter *painter, const QStyleOptionViewItem &option,
+                       const QModelIndex &index) const override;
+    virtual QSize sizeHint(const QStyleOptionViewItem &option,
+                           const QModelIndex &index) const override;
+    virtual QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option,
+                                  const QModelIndex &index) const override;
+    virtual void updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option,
+                                      const QModelIndex &index) const override;
 
 private:
-    void paintBackgroundSelectable(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
+    void paintBackgroundSelectable(QPainter *painter, const QStyleOptionViewItem &option,
+                                   const QModelIndex &index) const;
 
 private:
     QString m_displayFont;
@@ -42,7 +47,7 @@ private:
     QColor m_defaultColor;
     QColor m_separatorTextColor;
     QColor m_currentBackgroundColor;
-    QTreeView* m_view;
+    QTreeView *m_view;
     Theme m_theme;
 };
 

--- a/src/nodetreemodel.cpp
+++ b/src/nodetreemodel.cpp
@@ -3,10 +3,10 @@
 #include <QRegularExpression>
 #include <QMimeData>
 
-
 NodeTreeItem::NodeTreeItem(const QHash<NodeItem::Roles, QVariant> &data, NodeTreeItem *parent)
     : m_itemData(data), m_parentItem(parent)
-{}
+{
+}
 
 NodeTreeItem::~NodeTreeItem()
 {
@@ -60,7 +60,7 @@ int NodeTreeItem::columnCount() const
 int NodeTreeItem::recursiveNodeCount() const
 {
     int res = 1;
-    for (const auto& child: m_childItems) {
+    for (const auto &child : m_childItems) {
         res += child->recursiveNodeCount();
     }
     return res;
@@ -69,8 +69,7 @@ int NodeTreeItem::recursiveNodeCount() const
 void NodeTreeItem::recursiveUpdateFolderPath(const QString &oldP, const QString &newP)
 {
     {
-        auto type = static_cast<NodeItem::Type>(
-                    data(NodeItem::Roles::ItemType).toInt());
+        auto type = static_cast<NodeItem::Type>(data(NodeItem::Roles::ItemType).toInt());
         if (type != NodeItem::Type::FolderItem) {
             return;
         }
@@ -78,7 +77,7 @@ void NodeTreeItem::recursiveUpdateFolderPath(const QString &oldP, const QString 
         currP.replace(currP.indexOf(oldP), oldP.size(), newP);
         setData(NodeItem::Roles::AbsPath, currP);
     }
-    for (auto& child: m_childItems) {
+    for (auto &child : m_childItems) {
         child->recursiveUpdateFolderPath(oldP, newP);
     }
 }
@@ -110,21 +109,21 @@ void NodeTreeItem::moveChild(int from, int to)
 
 void NodeTreeItem::recursiveSort()
 {
-    auto type = static_cast<NodeItem::Type>(
-                data(NodeItem::Roles::ItemType).toInt());
-    auto relPosComparator = [] (const NodeTreeItem* a, const NodeTreeItem* b) {
+    auto type = static_cast<NodeItem::Type>(data(NodeItem::Roles::ItemType).toInt());
+    auto relPosComparator = [](const NodeTreeItem *a, const NodeTreeItem *b) {
         return a->data(NodeItem::Roles::RelPos).toInt() < b->data(NodeItem::Roles::RelPos).toInt();
     };
     if (type == NodeItem::Type::FolderItem) {
         std::sort(m_childItems.begin(), m_childItems.end(), relPosComparator);
-        for (auto& child: m_childItems) {
+        for (auto &child : m_childItems) {
             child->recursiveSort();
         }
     } else if (type == NodeItem::Type::RootItem) {
-        QVector<NodeTreeItem*> allNoteButton, trashFolder, folderSep, folderItems, tagSep, tagItems;
+        QVector<NodeTreeItem *> allNoteButton, trashFolder, folderSep, folderItems, tagSep,
+                tagItems;
         for (const auto child : qAsConst(m_childItems)) {
-            auto childType = static_cast<NodeItem::Type>(
-                        child->data(NodeItem::Roles::ItemType).toInt());
+            auto childType =
+                    static_cast<NodeItem::Type>(child->data(NodeItem::Roles::ItemType).toInt());
             if (childType == NodeItem::Type::AllNoteButton) {
                 allNoteButton.append(child);
             } else if (childType == NodeItem::Type::TrashButton) {
@@ -143,7 +142,7 @@ void NodeTreeItem::recursiveSort()
         }
         m_childItems.clear();
         std::sort(folderItems.begin(), folderItems.end(), relPosComparator);
-        for (auto& child: folderItems) {
+        for (auto &child : folderItems) {
             child->recursiveSort();
         }
         std::sort(tagItems.begin(), tagItems.end(), relPosComparator);
@@ -159,15 +158,13 @@ void NodeTreeItem::recursiveSort()
 int NodeTreeItem::row() const
 {
     if (m_parentItem) {
-        return m_parentItem->m_childItems.indexOf(const_cast<NodeTreeItem*>(this));
+        return m_parentItem->m_childItems.indexOf(const_cast<NodeTreeItem *>(this));
     }
 
     return 0;
 }
 
-NodeTreeModel::NodeTreeModel(QObject *parent) :
-    QAbstractItemModel(parent),
-    rootItem(nullptr)
+NodeTreeModel::NodeTreeModel(QObject *parent) : QAbstractItemModel(parent), rootItem(nullptr)
 {
     auto hs = QHash<NodeItem::Roles, QVariant>{};
     hs[NodeItem::Roles::ItemType] = NodeItem::Type::RootItem;
@@ -185,15 +182,17 @@ void NodeTreeModel::appendChildNodeToParent(const QModelIndex &parentIndex,
     if (rootItem) {
         const auto type = static_cast<NodeItem::Type>(data[NodeItem::Roles::ItemType].toInt());
         if (type == NodeItem::Type::FolderItem) {
-            auto parentItem = static_cast<NodeTreeItem*>(parentIndex.internalPointer());
+            auto parentItem = static_cast<NodeTreeItem *>(parentIndex.internalPointer());
             if (!parentItem || parentItem == rootItem) {
                 parentItem = rootItem;
                 int row = 0;
                 for (int i = 0; i < parentItem->childCount(); ++i) {
                     auto childItem = parentItem->child(i);
-                    auto childType = static_cast<NodeItem::Type>(childItem->data(NodeItem::Roles::ItemType).toInt());
-                    if (childType == NodeItem::Type::FolderItem &&
-                            childItem->data(NodeItem::Roles::NodeId).toInt() == SpecialNodeID::DefaultNotesFolder) {
+                    auto childType = static_cast<NodeItem::Type>(
+                            childItem->data(NodeItem::Roles::ItemType).toInt());
+                    if (childType == NodeItem::Type::FolderItem
+                        && childItem->data(NodeItem::Roles::NodeId).toInt()
+                                == SpecialNodeID::DefaultNotesFolder) {
                         row = i + 1;
                         break;
                     }
@@ -214,8 +213,8 @@ void NodeTreeModel::appendChildNodeToParent(const QModelIndex &parentIndex,
                 updateChildRelativePosition(parentItem, NodeItem::Type::FolderItem);
             }
         } else if (type == NodeItem::Type::TagItem) {
-            //tag always in root level
-            auto parentItem = static_cast<NodeTreeItem*>(parentIndex.internalPointer());
+            // tag always in root level
+            auto parentItem = static_cast<NodeTreeItem *>(parentIndex.internalPointer());
             if (parentItem != rootItem) {
                 qDebug() << "tag only go into root level";
                 return;
@@ -223,7 +222,8 @@ void NodeTreeModel::appendChildNodeToParent(const QModelIndex &parentIndex,
             int row = 0;
             for (int i = 0; i < parentItem->childCount(); ++i) {
                 auto childItem = parentItem->child(i);
-                auto childType = static_cast<NodeItem::Type>(childItem->data(NodeItem::Roles::ItemType).toInt());
+                auto childType = static_cast<NodeItem::Type>(
+                        childItem->data(NodeItem::Roles::ItemType).toInt());
                 if (childType == NodeItem::Type::TagSeparator) {
                     row = i + 1;
                     break;
@@ -254,7 +254,7 @@ QModelIndex NodeTreeModel::index(int row, int column, const QModelIndex &parent)
     if (!parent.isValid()) {
         parentItem = rootItem;
     } else {
-        parentItem = static_cast<NodeTreeItem*>(parent.internalPointer());
+        parentItem = static_cast<NodeTreeItem *>(parent.internalPointer());
     }
 
     NodeTreeItem *childItem = parentItem->child(row);
@@ -270,7 +270,7 @@ QModelIndex NodeTreeModel::parent(const QModelIndex &index) const
         return QModelIndex();
     }
 
-    NodeTreeItem *childItem = static_cast<NodeTreeItem*>(index.internalPointer());
+    NodeTreeItem *childItem = static_cast<NodeTreeItem *>(index.internalPointer());
     if ((!childItem) || (childItem == rootItem)) {
         return QModelIndex();
     }
@@ -291,7 +291,7 @@ int NodeTreeModel::rowCount(const QModelIndex &parent) const
     if (!parent.isValid()) {
         parentItem = rootItem;
     } else {
-        parentItem = static_cast<NodeTreeItem*>(parent.internalPointer());
+        parentItem = static_cast<NodeTreeItem *>(parent.internalPointer());
     }
 
     return parentItem->childCount();
@@ -300,7 +300,7 @@ int NodeTreeModel::rowCount(const QModelIndex &parent) const
 int NodeTreeModel::columnCount(const QModelIndex &parent) const
 {
     if (parent.isValid()) {
-        return static_cast<NodeTreeItem*>(parent.internalPointer())->columnCount();
+        return static_cast<NodeTreeItem *>(parent.internalPointer())->columnCount();
     }
     return rootItem->columnCount();
 }
@@ -311,7 +311,7 @@ QVariant NodeTreeModel::data(const QModelIndex &index, int role) const
         return QVariant();
     }
 
-    NodeTreeItem *item = static_cast<NodeTreeItem*>(index.internalPointer());
+    NodeTreeItem *item = static_cast<NodeTreeItem *>(index.internalPointer());
     if (static_cast<NodeItem::Roles>(role) == NodeItem::Roles::IsExpandable) {
         return item->childCount() > 0;
     }
@@ -333,7 +333,7 @@ QModelIndex NodeTreeModel::folderIndexFromIdPath(const NodePath &idPath)
     }
     auto ps = idPath.seperate();
     auto item = rootItem;
-    for (const auto& ite : qAsConst(ps)) {
+    for (const auto &ite : qAsConst(ps)) {
         bool ok = false;
         auto id = ite.toInt(&ok);
         if (!ok) {
@@ -344,11 +344,10 @@ QModelIndex NodeTreeModel::folderIndexFromIdPath(const NodePath &idPath)
             continue;
         }
         bool foundChild = false;
-        for (int i = 0 ; i < item->childCount(); ++i) {
+        for (int i = 0; i < item->childCount(); ++i) {
             auto child = item->child(i);
-            if (static_cast<NodeItem::Type>(
-                        child->data(NodeItem::Roles::ItemType).toInt())
-                    != NodeItem::FolderItem) {
+            if (static_cast<NodeItem::Type>(child->data(NodeItem::Roles::ItemType).toInt())
+                != NodeItem::FolderItem) {
                 continue;
             }
             if (id == static_cast<int>(child->data(NodeItem::Roles::NodeId).toInt())) {
@@ -358,8 +357,8 @@ QModelIndex NodeTreeModel::folderIndexFromIdPath(const NodePath &idPath)
             }
         }
         if (!foundChild) {
-//            qDebug() << __FUNCTION__ << "Can't find child id" << id << "inside parent"
-//                     << static_cast<int>(item->data(NodeItem::Roles::NodeId).toInt());
+            //            qDebug() << __FUNCTION__ << "Can't find child id" << id << "inside parent"
+            //                     << static_cast<int>(item->data(NodeItem::Roles::NodeId).toInt());
             return QModelIndex();
         }
     }
@@ -370,9 +369,9 @@ QModelIndex NodeTreeModel::tagIndexFromId(int id)
 {
     for (int i = 0; i < rootItem->childCount(); ++i) {
         auto child = rootItem->child(i);
-        if (static_cast<NodeItem::Type>(
-                    child->data(NodeItem::Roles::ItemType).toInt()) == NodeItem::Type::TagItem &&
-                static_cast<int>(child->data(NodeItem::Roles::NodeId).toInt() == id)) {
+        if (static_cast<NodeItem::Type>(child->data(NodeItem::Roles::ItemType).toInt())
+                    == NodeItem::Type::TagItem
+            && static_cast<int>(child->data(NodeItem::Roles::NodeId).toInt() == id)) {
             return createIndex(i, 0, child);
         }
     }
@@ -383,7 +382,7 @@ QString NodeTreeModel::getNewFolderPlaceholderName(const QModelIndex &parentInde
 {
     QString result = "New Folder";
     if (parentIndex.isValid()) {
-        auto parentItem = static_cast<NodeTreeItem*>(parentIndex.internalPointer());
+        auto parentItem = static_cast<NodeTreeItem *>(parentIndex.internalPointer());
         if (parentItem) {
             QRegularExpression reg(R"(^New Folder\s\((\d+)\))");
             int n = 0;
@@ -458,8 +457,9 @@ QModelIndex NodeTreeModel::getDefaultNotesIndex()
         for (int i = 0; i < rootItem->childCount(); ++i) {
             auto child = rootItem->child(i);
             auto type = static_cast<NodeItem::Type>(child->data(NodeItem::Roles::ItemType).toInt());
-            if (type == NodeItem::Type::FolderItem &&
-                    child->data(NodeItem::Roles::NodeId).toInt() == SpecialNodeID::DefaultNotesFolder) {
+            if (type == NodeItem::Type::FolderItem
+                && child->data(NodeItem::Roles::NodeId).toInt()
+                        == SpecialNodeID::DefaultNotesFolder) {
                 return createIndex(i, 0, child);
             }
         }
@@ -495,18 +495,17 @@ QModelIndex NodeTreeModel::getTrashButtonIndex()
     return QModelIndex{};
 }
 
-void NodeTreeModel::deleteRow(const QModelIndex &rowIndex, const QModelIndex& parentIndex)
+void NodeTreeModel::deleteRow(const QModelIndex &rowIndex, const QModelIndex &parentIndex)
 {
     auto type = static_cast<NodeItem::Type>(rowIndex.data(NodeItem::Roles::ItemType).toInt());
     auto id = rowIndex.data(NodeItem::Roles::NodeId).toInt();
-    if (!((type == NodeItem::Type::FolderItem &&
-           id > SpecialNodeID::DefaultNotesFolder) ||
-          type == NodeItem::Type::TagItem)) {
+    if (!((type == NodeItem::Type::FolderItem && id > SpecialNodeID::DefaultNotesFolder)
+          || type == NodeItem::Type::TagItem)) {
         qDebug() << "Can not delete this row with id" << id;
         return;
     }
-    auto parentItem = static_cast<NodeTreeItem*>(parentIndex.internalPointer());
-    auto item = static_cast<NodeTreeItem*>(rowIndex.internalPointer());
+    auto parentItem = static_cast<NodeTreeItem *>(parentIndex.internalPointer());
+    auto item = static_cast<NodeTreeItem *>(rowIndex.internalPointer());
     int row = item->row();
 
     setData(rowIndex, "deleted", NodeItem::DisplayText);
@@ -517,7 +516,7 @@ void NodeTreeModel::deleteRow(const QModelIndex &rowIndex, const QModelIndex& pa
         emit topLevelItemLayoutChanged();
     } else {
         int count = item->recursiveNodeCount();
-        beginRemoveRows(parentIndex, row, row + count -1);
+        beginRemoveRows(parentIndex, row, row + count - 1);
         parentItem->removeChild(row);
         endRemoveRows();
     }
@@ -543,10 +542,9 @@ void NodeTreeModel::loadNodeTree(const QVector<NodeData> &nodeData, NodeTreeItem
 {
     QHash<int, NodeTreeItem *> itemMap;
     itemMap[SpecialNodeID::RootFolder] = rootNode;
-    for (const auto& node: nodeData) {
-        if (node.id() != SpecialNodeID::RootFolder &&
-                node.id() != SpecialNodeID::TrashFolder &&
-                node.parentId() != SpecialNodeID::TrashFolder) {
+    for (const auto &node : nodeData) {
+        if (node.id() != SpecialNodeID::RootFolder && node.id() != SpecialNodeID::TrashFolder
+            && node.parentId() != SpecialNodeID::TrashFolder) {
             auto hs = QHash<NodeItem::Roles, QVariant>{};
             if (node.nodeType() == NodeData::Folder) {
                 hs[NodeItem::Roles::ItemType] = NodeItem::Type::FolderItem;
@@ -566,15 +564,13 @@ void NodeTreeModel::loadNodeTree(const QVector<NodeData> &nodeData, NodeTreeItem
         }
     }
 
-    for (const auto& node: nodeData) {
-        if (node.id() != SpecialNodeID::RootFolder &&
-                node.parentId() != -1 &&
-                node.id() != SpecialNodeID::TrashFolder &&
-                node.parentId() != SpecialNodeID::TrashFolder) {
+    for (const auto &node : nodeData) {
+        if (node.id() != SpecialNodeID::RootFolder && node.parentId() != -1
+            && node.id() != SpecialNodeID::TrashFolder
+            && node.parentId() != SpecialNodeID::TrashFolder) {
             auto parentNode = itemMap.find(node.parentId());
             auto nodeItem = itemMap.find(node.id());
-            if (parentNode != itemMap.end() &&
-                    nodeItem != itemMap.end()) {
+            if (parentNode != itemMap.end() && nodeItem != itemMap.end()) {
                 (*parentNode)->appendChild(*nodeItem);
                 (*nodeItem)->setParentItem(*parentNode);
             } else {
@@ -625,7 +621,7 @@ void NodeTreeModel::appendTagsSeparator(NodeTreeItem *rootNode)
 
 void NodeTreeModel::loadTagList(const QVector<TagData> &tagData, NodeTreeItem *rootNode)
 {
-    for (const auto& tag: tagData) {
+    for (const auto &tag : tagData) {
         auto hs = QHash<NodeItem::Roles, QVariant>{};
         hs[NodeItem::Roles::ItemType] = NodeItem::Type::TagItem;
         hs[NodeItem::Roles::DisplayText] = tag.name();
@@ -644,18 +640,16 @@ void NodeTreeModel::updateChildRelativePosition(NodeTreeItem *parent, const Node
     int relId = 0;
     for (int i = 0; i < parent->childCount(); ++i) {
         auto child = parent->child(i);
-        auto childType = static_cast<NodeItem::Type>(
-                    child->data(NodeItem::Roles::ItemType).toInt());
+        auto childType =
+                static_cast<NodeItem::Type>(child->data(NodeItem::Roles::ItemType).toInt());
         if (childType == type) {
             if (type == NodeItem::Type::FolderItem) {
-                emit requestUpdateNodeRelativePosition(
-                            child->data(NodeItem::Roles::NodeId).toInt(),
-                            relId);
+                emit requestUpdateNodeRelativePosition(child->data(NodeItem::Roles::NodeId).toInt(),
+                                                       relId);
                 ++relId;
             } else if (type == NodeItem::Type::TagItem) {
-                emit requestUpdateTagRelativePosition(
-                            child->data(NodeItem::Roles::NodeId).toInt(),
-                            relId);
+                emit requestUpdateTagRelativePosition(child->data(NodeItem::Roles::NodeId).toInt(),
+                                                      relId);
                 ++relId;
             } else {
                 qDebug() << __FUNCTION__ << "Wrong type";
@@ -678,21 +672,21 @@ bool NodeTreeModel::setData(const QModelIndex &index, const QVariant &value, int
 {
     if (index.isValid()) {
         if (role == NodeItem::Roles::DisplayText) {
-            static_cast<NodeTreeItem*>(index.internalPointer())->setData(
-                        static_cast<NodeItem::Roles>(role), value);
-            emit dataChanged(index, index, {role});
+            static_cast<NodeTreeItem *>(index.internalPointer())
+                    ->setData(static_cast<NodeItem::Roles>(role), value);
+            emit dataChanged(index, index, { role });
             return true;
         }
         if (role == NodeItem::Roles::TagColor) {
-            static_cast<NodeTreeItem*>(index.internalPointer())->setData(
-                        static_cast<NodeItem::Roles>(role), value);
-            emit dataChanged(index, index, {role});
+            static_cast<NodeTreeItem *>(index.internalPointer())
+                    ->setData(static_cast<NodeItem::Roles>(role), value);
+            emit dataChanged(index, index, { role });
             return true;
         }
         if (role == NodeItem::Roles::ChildCount) {
-            static_cast<NodeTreeItem*>(index.internalPointer())->setData(
-                        static_cast<NodeItem::Roles>(role), value);
-            emit dataChanged(index, index, {role});
+            static_cast<NodeTreeItem *>(index.internalPointer())
+                    ->setData(static_cast<NodeItem::Roles>(role), value);
+            emit dataChanged(index, index, { role });
             return true;
         }
     }
@@ -719,13 +713,11 @@ QMimeData *NodeTreeModel::mimeData(const QModelIndexList &indexes) const
     if (indexes.isEmpty()) {
         return nullptr;
     }
-    auto itemType = static_cast<NodeItem::Type>(
-                indexes[0].data(NodeItem::Roles::ItemType).toInt());
+    auto itemType = static_cast<NodeItem::Type>(indexes[0].data(NodeItem::Roles::ItemType).toInt());
     if (itemType == NodeItem::Type::TagItem) {
         QStringList d;
-        for (const auto& index : indexes) {
-            auto type = static_cast<NodeItem::Type>(
-                        index.data(NodeItem::Roles::ItemType).toInt());
+        for (const auto &index : indexes) {
+            auto type = static_cast<NodeItem::Type>(index.data(NodeItem::Roles::ItemType).toInt());
             if (type != itemType) {
                 continue;
             }
@@ -739,7 +731,7 @@ QMimeData *NodeTreeModel::mimeData(const QModelIndexList &indexes) const
         mimeData->setData(TAG_MIME, d.join(QStringLiteral(PATH_SEPERATOR)).toUtf8());
         return mimeData;
     } else if (itemType == NodeItem::Type::FolderItem) {
-        const auto& index = indexes[0];
+        const auto &index = indexes[0];
         auto id = index.data(NodeItem::Roles::NodeId).toInt();
         if (id == SpecialNodeID::DefaultNotesFolder) {
             return nullptr;
@@ -753,15 +745,11 @@ QMimeData *NodeTreeModel::mimeData(const QModelIndexList &indexes) const
     }
 }
 
-bool NodeTreeModel::dropMimeData(const QMimeData *mime,
-                                 Qt::DropAction action,
-                                 int row, int column,
+bool NodeTreeModel::dropMimeData(const QMimeData *mime, Qt::DropAction action, int row, int column,
                                  const QModelIndex &parent)
 {
     Q_UNUSED(column);
-    if (!(mime->hasFormat(TAG_MIME) ||
-          mime->hasFormat(FOLDER_MIME)) &&
-            action == Qt::MoveAction) {
+    if (!(mime->hasFormat(TAG_MIME) || mime->hasFormat(FOLDER_MIME)) && action == Qt::MoveAction) {
         return false;
     }
     if (mime->hasFormat(TAG_MIME)) {
@@ -778,18 +766,17 @@ bool NodeTreeModel::dropMimeData(const QMimeData *mime,
         if ((sep.size() == 2) && (row <= sep[1].row())) {
             return false;
         }
-        auto idl = QString::fromUtf8(mime->data(TAG_MIME))
-                .split(QStringLiteral(PATH_SEPERATOR));
+        auto idl = QString::fromUtf8(mime->data(TAG_MIME)).split(QStringLiteral(PATH_SEPERATOR));
         beginResetModel();
         QSet<int> movedIds;
-        for (const auto& id_s : qAsConst(idl)) {
+        for (const auto &id_s : qAsConst(idl)) {
             auto id = id_s.toInt();
             for (int i = 0; i < rootItem->childCount(); ++i) {
                 auto child = rootItem->child(i);
-                auto childType = static_cast<NodeItem::Type>(
-                            child->data(NodeItem::Roles::ItemType).toInt());
-                if (childType == NodeItem::Type::TagItem &&
-                        child->data(NodeItem::Roles::NodeId).toInt() == id) {
+                auto childType =
+                        static_cast<NodeItem::Type>(child->data(NodeItem::Roles::ItemType).toInt());
+                if (childType == NodeItem::Type::TagItem
+                    && child->data(NodeItem::Roles::NodeId).toInt() == id) {
                     if (row >= rootItem->childCount()) {
                         row = rootItem->childCount() - 1;
                     }
@@ -824,16 +811,15 @@ bool NodeTreeModel::dropMimeData(const QMimeData *mime,
         if (!parent.isValid()) {
             parentItem = rootItem;
         } else {
-            parentItem = static_cast<NodeTreeItem*>(parent.internalPointer());
+            parentItem = static_cast<NodeTreeItem *>(parent.internalPointer());
         }
-        auto parentType = static_cast<NodeItem::Type>(
-                    parentItem->data(NodeItem::Roles::ItemType).toInt());
-        if (!(parentType == NodeItem::Type::FolderItem ||
-              parentType == NodeItem::Type::RootItem ||
-              parentType == NodeItem::Type::TrashButton)) {
+        auto parentType =
+                static_cast<NodeItem::Type>(parentItem->data(NodeItem::Roles::ItemType).toInt());
+        if (!(parentType == NodeItem::Type::FolderItem || parentType == NodeItem::Type::RootItem
+              || parentType == NodeItem::Type::TrashButton)) {
             return false;
         }
-        movingItem = static_cast<NodeTreeItem*>(index.internalPointer());
+        movingItem = static_cast<NodeTreeItem *>(index.internalPointer());
         if (parentType == NodeItem::Type::TrashButton) {
             auto abs = movingItem->data(NodeItem::Roles::AbsPath).toString();
             auto movingIndex = folderIndexFromIdPath(abs);
@@ -858,10 +844,11 @@ bool NodeTreeModel::dropMimeData(const QMimeData *mime,
             beginResetModel();
             for (int i = 0; i < parentItem->childCount(); ++i) {
                 auto child = parentItem->child(i);
-                auto childType = static_cast<NodeItem::Type>(
-                            child->data(NodeItem::Roles::ItemType).toInt());
-                if (childType == NodeItem::Type::FolderItem &&
-                        child->data(NodeItem::Roles::NodeId) == movingItem->data(NodeItem::Roles::NodeId)) {
+                auto childType =
+                        static_cast<NodeItem::Type>(child->data(NodeItem::Roles::ItemType).toInt());
+                if (childType == NodeItem::Type::FolderItem
+                    && child->data(NodeItem::Roles::NodeId)
+                            == movingItem->data(NodeItem::Roles::NodeId)) {
                     int targetRow = row;
                     if (row > i && row > 0) {
                         targetRow -= 1;
@@ -879,10 +866,11 @@ bool NodeTreeModel::dropMimeData(const QMimeData *mime,
             int r = -1;
             for (int i = 0; i < movingParent->childCount(); ++i) {
                 auto child = movingParent->child(i);
-                auto childType = static_cast<NodeItem::Type>(
-                            child->data(NodeItem::Roles::ItemType).toInt());
-                if ((childType == NodeItem::Type::FolderItem) &&
-                        (child->data(NodeItem::Roles::NodeId).toInt() == movingItem->data(NodeItem::Roles::NodeId).toInt())) {
+                auto childType =
+                        static_cast<NodeItem::Type>(child->data(NodeItem::Roles::ItemType).toInt());
+                if ((childType == NodeItem::Type::FolderItem)
+                    && (child->data(NodeItem::Roles::NodeId).toInt()
+                        == movingItem->data(NodeItem::Roles::NodeId).toInt())) {
                     r = i;
                     break;
                 }
@@ -893,7 +881,8 @@ bool NodeTreeModel::dropMimeData(const QMimeData *mime,
             movingItem = movingParent->child(r);
             auto oldAbsolutePath = movingItem->data(NodeItem::Roles::AbsPath).toString();
             QString newAbsolutePath = parentItem->data(NodeItem::Roles::AbsPath).toString()
-                    + PATH_SEPERATOR + QString::number(movingItem->data(NodeItem::Roles::NodeId).toInt());
+                    + PATH_SEPERATOR
+                    + QString::number(movingItem->data(NodeItem::Roles::NodeId).toInt());
             emit requestUpdateAbsPath(oldAbsolutePath, newAbsolutePath);
             beginResetModel();
             movingParent->takeChildAt(r);
@@ -912,4 +901,3 @@ bool NodeTreeModel::dropMimeData(const QMimeData *mime,
     }
     return false;
 }
-

--- a/src/nodetreemodel.h
+++ b/src/nodetreemodel.h
@@ -35,11 +35,13 @@ enum Type {
     TagItem,
     RootItem
 };
-}
+} // namespace NodeItem
 
-class NodeTreeItem {
+class NodeTreeItem
+{
 public:
-    explicit NodeTreeItem(const QHash<NodeItem::Roles, QVariant> &data, NodeTreeItem *parentItem = nullptr);
+    explicit NodeTreeItem(const QHash<NodeItem::Roles, QVariant> &data,
+                          NodeTreeItem *parentItem = nullptr);
     ~NodeTreeItem();
 
     void appendChild(NodeTreeItem *child);
@@ -50,16 +52,17 @@ public:
     int childCount() const;
     int columnCount() const;
     int recursiveNodeCount() const;
-    void recursiveUpdateFolderPath(const QString& oldP, const QString &newP);
+    void recursiveUpdateFolderPath(const QString &oldP, const QString &newP);
     QVariant data(NodeItem::Roles role) const;
-    void setData(NodeItem::Roles role, const QVariant& d);
+    void setData(NodeItem::Roles role, const QVariant &d);
     int row() const;
     NodeTreeItem *parentItem();
-    void setParentItem(NodeTreeItem* parentItem);
+    void setParentItem(NodeTreeItem *parentItem);
     void moveChild(int from, int to);
     void recursiveSort();
+
 private:
-    QVector<NodeTreeItem*> m_childItems;
+    QVector<NodeTreeItem *> m_childItems;
     QHash<NodeItem::Roles, QVariant> m_itemData;
     NodeTreeItem *m_parentItem;
 };
@@ -71,21 +74,21 @@ public:
     explicit NodeTreeModel(QObject *parent = nullptr);
     ~NodeTreeModel();
 
-    void appendChildNodeToParent(const QModelIndex& parentIndex,
-                                 const QHash<NodeItem::Roles, QVariant>& data);
+    void appendChildNodeToParent(const QModelIndex &parentIndex,
+                                 const QHash<NodeItem::Roles, QVariant> &data);
     QModelIndex rootIndex() const;
-    QModelIndex folderIndexFromIdPath(const NodePath& idPath);
+    QModelIndex folderIndexFromIdPath(const NodePath &idPath);
     QModelIndex tagIndexFromId(int id);
-    QString getNewFolderPlaceholderName(const QModelIndex& parentIndex);
+    QString getNewFolderPlaceholderName(const QModelIndex &parentIndex);
     QString getNewTagPlaceholderName();
     QVector<QModelIndex> getSeparatorIndex();
     QModelIndex getDefaultNotesIndex();
     QModelIndex getAllNotesButtonIndex();
     QModelIndex getTrashButtonIndex();
-    void deleteRow(const QModelIndex& rowIndex, const QModelIndex& parentIndex);
+    void deleteRow(const QModelIndex &rowIndex, const QModelIndex &parentIndex);
 
 public slots:
-    void setTreeData(const NodeTagTreeData& treeData);
+    void setTreeData(const NodeTagTreeData &treeData);
 
     // QAbstractItemModel interface
 public:
@@ -100,27 +103,28 @@ public:
     virtual Qt::DropActions supportedDragActions() const override;
     virtual QStringList mimeTypes() const override;
     virtual QMimeData *mimeData(const QModelIndexList &indexes) const override;
-    virtual bool dropMimeData(const QMimeData *mime, Qt::DropAction action, int row, int column, const QModelIndex &parent) override;
+    virtual bool dropMimeData(const QMimeData *mime, Qt::DropAction action, int row, int column,
+                              const QModelIndex &parent) override;
 
 signals:
     void topLevelItemLayoutChanged();
-    void requestExpand(const QString& indexPath);
+    void requestExpand(const QString &indexPath);
     void requestMoveNode(int nodeId, int targetId);
     void requestUpdateNodeRelativePosition(int nodeId, int relativePosition);
     void requestUpdateTagRelativePosition(int nodeId, int relativePosition);
-    void requestUpdateAbsPath(const QString& oldPath, const QString& newPath);
-    void dropFolderSuccessfull(const QString& paths);
-    void dropTagsSuccessfull(const QSet<int>& ids);
-    void requestMoveFolderToTrash(const QModelIndex& index);
+    void requestUpdateAbsPath(const QString &oldPath, const QString &newPath);
+    void dropFolderSuccessfull(const QString &paths);
+    void dropTagsSuccessfull(const QSet<int> &ids);
+    void requestMoveFolderToTrash(const QModelIndex &index);
 
 private:
     NodeTreeItem *rootItem;
-    void loadNodeTree(const QVector<NodeData>& nodeData, NodeTreeItem* rootNode);
-    void appendAllNotesAndTrashButton(NodeTreeItem* rootNode);
-    void appendFolderSeparator(NodeTreeItem* rootNode);
-    void appendTagsSeparator(NodeTreeItem* rootNode);
-    void loadTagList(const QVector<TagData>& tagData, NodeTreeItem* rootNode);
-    void updateChildRelativePosition(NodeTreeItem* parent, const NodeItem::Type type);
+    void loadNodeTree(const QVector<NodeData> &nodeData, NodeTreeItem *rootNode);
+    void appendAllNotesAndTrashButton(NodeTreeItem *rootNode);
+    void appendFolderSeparator(NodeTreeItem *rootNode);
+    void appendTagsSeparator(NodeTreeItem *rootNode);
+    void loadTagList(const QVector<TagData> &tagData, NodeTreeItem *rootNode);
+    void updateChildRelativePosition(NodeTreeItem *parent, const NodeItem::Type type);
 };
 
 #endif // NODETREEMODEL_H

--- a/src/nodetreeview.cpp
+++ b/src/nodetreeview.cpp
@@ -8,56 +8,52 @@
 #include <QApplication>
 #include "nodetreeview_p.h"
 
-NodeTreeView::NodeTreeView(QWidget *parent) :
-    QTreeView(parent),
-    m_isContextMenuOpened{false},
-    m_isEditing{false},
-    m_ignoreThisCurrentLoad{false},
-    m_isLastSelectedFolder{false}
+NodeTreeView::NodeTreeView(QWidget *parent)
+    : QTreeView(parent),
+      m_isContextMenuOpened{ false },
+      m_isEditing{ false },
+      m_ignoreThisCurrentLoad{ false },
+      m_isLastSelectedFolder{ false }
 {
     setHeaderHidden(true);
-#if defined(Q_OS_LINUX) || defined (Q_OS_FREEBSD)
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
     setStyleSheet(
-                R"(QTreeView {)"
-                R"(    border-style: none;)"
-                R"(    background-color: rgb(255, 255, 255);)"
-                R"(    selection-background-color: white;)"
-                R"(    selection-color: white;)"
-                R"(})"
-                R"()"
-                R"(QTreeView::branch{)"
-                R"(    border-image: url(none.png);)"
-                R"(})"
-                R"(QScrollBar::handle:vertical:hover { background: rgb(170, 170, 171); } )"
-                R"(QScrollBar::handle:vertical:pressed { background: rgb(149, 149, 149); } )"
-                R"(QScrollBar::handle:vertical { border-radius: 4px; background: rgb(188, 188, 188); min-height: 20px; }  )"
-                R"(QScrollBar::vertical {border-radius: 4px; width: 8px; color: rgba(255, 255, 255,0);} )"
-                R"(QScrollBar {margin: 0; background: transparent;} )"
-                R"(QScrollBar:hover { background-color: rgb(217, 217, 217);})"
-                R"(QScrollBar::add-line:vertical { width:0px; height: 0px; subcontrol-position: bottom; subcontrol-origin: margin; }  )"
-                R"(QScrollBar::sub-line:vertical { width:0px; height: 0px; subcontrol-position: top; subcontrol-origin: margin; })"
-                );
+            R"(QTreeView {)"
+            R"(    border-style: none;)"
+            R"(    background-color: rgb(255, 255, 255);)"
+            R"(    selection-background-color: white;)"
+            R"(    selection-color: white;)"
+            R"(})"
+            R"()"
+            R"(QTreeView::branch{)"
+            R"(    border-image: url(none.png);)"
+            R"(})"
+            R"(QScrollBar::handle:vertical:hover { background: rgb(170, 170, 171); } )"
+            R"(QScrollBar::handle:vertical:pressed { background: rgb(149, 149, 149); } )"
+            R"(QScrollBar::handle:vertical { border-radius: 4px; background: rgb(188, 188, 188); min-height: 20px; }  )"
+            R"(QScrollBar::vertical {border-radius: 4px; width: 8px; color: rgba(255, 255, 255,0);} )"
+            R"(QScrollBar {margin: 0; background: transparent;} )"
+            R"(QScrollBar:hover { background-color: rgb(217, 217, 217);})"
+            R"(QScrollBar::add-line:vertical { width:0px; height: 0px; subcontrol-position: bottom; subcontrol-origin: margin; }  )"
+            R"(QScrollBar::sub-line:vertical { width:0px; height: 0px; subcontrol-position: top; subcontrol-origin: margin; })");
 #else
-    setStyleSheet(
-                R"(QTreeView {)"
-                R"(    border-style: none;)"
-                R"(    background-color: rgb(255, 255, 255);)"
-                R"(    selection-background-color: white;)"
-                R"(    selection-color: white;)"
-                R"(})"
-                R"()"
-                R"(QTreeView::branch{)"
-                R"(    border-image: url(none.png);)"
-                R"(})"
-                );
+    setStyleSheet(R"(QTreeView {)"
+                  R"(    border-style: none;)"
+                  R"(    background-color: rgb(255, 255, 255);)"
+                  R"(    selection-background-color: white;)"
+                  R"(    selection-color: white;)"
+                  R"(})"
+                  R"()"
+                  R"(QTreeView::branch{)"
+                  R"(    border-image: url(none.png);)"
+                  R"(})");
 #endif
 
     setRootIsDecorated(false);
     setMouseTracking(true);
     setSelectionMode(QAbstractItemView::MultiSelection);
     setContextMenuPolicy(Qt::CustomContextMenu);
-    connect(this, &QWidget::customContextMenuRequested,
-            this, &NodeTreeView::onCustomContextMenu);
+    connect(this, &QWidget::customContextMenuRequested, this, &NodeTreeView::onCustomContextMenu);
     contextMenu = new QMenu(this);
     renameFolderAction = new QAction(tr("Rename Folder"), this);
     connect(renameFolderAction, &QAction::triggered, this, [this] {
@@ -79,11 +75,10 @@ NodeTreeView::NodeTreeView(QWidget *parent) :
     deleteTagAction = new QAction(tr("Delete Tag"), this);
     connect(deleteTagAction, &QAction::triggered, this, &NodeTreeView::onDeleteNodeAction);
     clearSelectionAction = new QAction(tr("Clear Selection"), this);
-    connect(clearSelectionAction, &QAction::triggered,
-            this, [this] {
+    connect(clearSelectionAction, &QAction::triggered, this, [this] {
         closeCurrentEditor();
         clearSelection();
-        setCurrentIndexC(dynamic_cast<NodeTreeModel*>(model())->getAllNotesButtonIndex());
+        setCurrentIndexC(dynamic_cast<NodeTreeModel *>(model())->getAllNotesButtonIndex());
     });
 
     contextMenuTimer.setInterval(100);
@@ -109,7 +104,8 @@ NodeTreeView::NodeTreeView(QWidget *parent) :
 
 void NodeTreeView::onDeleteNodeAction()
 {
-    auto itemType = static_cast<NodeItem::Type>(m_currentEditingIndex.data(NodeItem::Roles::ItemType).toInt());
+    auto itemType = static_cast<NodeItem::Type>(
+            m_currentEditingIndex.data(NodeItem::Roles::ItemType).toInt());
     auto id = m_currentEditingIndex.data(NodeItem::Roles::NodeId).toInt();
     if (itemType == NodeItem::Type::FolderItem || itemType == NodeItem::Type::NoteItem) {
         if (id > SpecialNodeID::DefaultNotesFolder) {
@@ -146,7 +142,7 @@ void NodeTreeView::setIgnoreThisCurrentLoad(bool newIgnoreThisCurrentLoad)
 
 void NodeTreeView::onFolderDropSuccessfull(const QString &path)
 {
-    auto m_model = dynamic_cast<NodeTreeModel*>(model());
+    auto m_model = dynamic_cast<NodeTreeModel *>(model());
     auto index = m_model->folderIndexFromIdPath(path);
     if (index.isValid()) {
         setCurrentIndexC(index);
@@ -157,11 +153,11 @@ void NodeTreeView::onFolderDropSuccessfull(const QString &path)
 
 void NodeTreeView::onTagsDropSuccessfull(const QSet<int> &ids)
 {
-    auto m_model = dynamic_cast<NodeTreeModel*>(model());
+    auto m_model = dynamic_cast<NodeTreeModel *>(model());
     setCurrentIndex(QModelIndex());
     clearSelection();
     setSelectionMode(QAbstractItemView::MultiSelection);
-    for (const auto& id: qAsConst(ids)) {
+    for (const auto &id : qAsConst(ids)) {
         auto index = m_model->tagIndexFromId(id);
         if (index.isValid()) {
             setCurrentIndex(index);
@@ -190,8 +186,8 @@ void NodeTreeView::reExpandC()
     auto needExpand = std::move(m_expanded);
     m_expanded.clear();
     QTreeView::reset();
-    for (const auto& path: needExpand) {
-        auto m_model = dynamic_cast<NodeTreeModel*>(model());
+    for (const auto &path : needExpand) {
+        auto m_model = dynamic_cast<NodeTreeModel *>(model());
         auto index = m_model->folderIndexFromIdPath(path);
         if (index.isValid()) {
             expand(index);
@@ -208,7 +204,8 @@ void NodeTreeView::reExpandC(const QStringList &expanded)
 
 void NodeTreeView::onChangeTagColorAction()
 {
-    auto itemType = static_cast<NodeItem::Type>(m_currentEditingIndex.data(NodeItem::Roles::ItemType).toInt());
+    auto itemType = static_cast<NodeItem::Type>(
+            m_currentEditingIndex.data(NodeItem::Roles::ItemType).toInt());
     if (itemType == NodeItem::Type::TagItem) {
         auto index = m_currentEditingIndex;
         emit changeTagColorRequested(index);
@@ -217,14 +214,13 @@ void NodeTreeView::onChangeTagColorAction()
 
 void NodeTreeView::onRequestExpand(const QString &folderPath)
 {
-    auto m_model = dynamic_cast<NodeTreeModel*>(model());
+    auto m_model = dynamic_cast<NodeTreeModel *>(model());
     expand(m_model->folderIndexFromIdPath(folderPath));
 }
 
 void NodeTreeView::onUpdateAbsPath(const QString &oldPath, const QString &newPath)
 {
-    std::transform(m_expanded.begin(), m_expanded.end(),
-                   m_expanded.begin(), [&] (QString s) {
+    std::transform(m_expanded.begin(), m_expanded.end(), m_expanded.begin(), [&](QString s) {
         s.replace(s.indexOf(oldPath), oldPath.size(), newPath);
         return s;
     });
@@ -233,12 +229,11 @@ void NodeTreeView::onUpdateAbsPath(const QString &oldPath, const QString &newPat
 void NodeTreeView::updateEditingIndex(QPoint pos)
 {
     auto index = indexAt(pos);
-    if(indexAt(pos) != m_currentEditingIndex && !m_isContextMenuOpened && !m_isEditing) {
+    if (indexAt(pos) != m_currentEditingIndex && !m_isContextMenuOpened && !m_isEditing) {
         auto itemType = static_cast<NodeItem::Type>(index.data(NodeItem::Roles::ItemType).toInt());
-        if (itemType == NodeItem::Type::FolderItem
-                || itemType == NodeItem::Type::TagItem
-                || itemType == NodeItem::Type::TrashButton
-                || itemType == NodeItem::Type::AllNoteButton) {
+        if (itemType == NodeItem::Type::FolderItem || itemType == NodeItem::Type::TagItem
+            || itemType == NodeItem::Type::TrashButton
+            || itemType == NodeItem::Type::AllNoteButton) {
             closePersistentEditor(m_currentEditingIndex);
             openPersistentEditor(index);
             m_currentEditingIndex = index;
@@ -254,7 +249,8 @@ void NodeTreeView::closeCurrentEditor()
     m_currentEditingIndex = QModelIndex();
 }
 
-void NodeTreeView::selectionChanged(const QItemSelection &selected, const QItemSelection &deselected)
+void NodeTreeView::selectionChanged(const QItemSelection &selected,
+                                    const QItemSelection &deselected)
 {
     QTreeView::selectionChanged(selected, deselected);
     if (m_ignoreThisCurrentLoad) {
@@ -350,10 +346,10 @@ void NodeTreeView::dragMoveEvent(QDragMoveEvent *event)
                 return;
             }
         } else if (event->mimeData()->hasFormat(FOLDER_MIME)) {
-            auto trashRect = visualRect(dynamic_cast<NodeTreeModel*>(model())
-                                        ->getTrashButtonIndex());
-            if (event->pos().y() > (trashRect.y() + 5) &&
-                    event->pos().y() < (trashRect.bottom() - 5)) {
+            auto trashRect =
+                    visualRect(dynamic_cast<NodeTreeModel *>(model())->getTrashButtonIndex());
+            if (event->pos().y() > (trashRect.y() + 5)
+                && event->pos().y() < (trashRect.bottom() - 5)) {
                 setDropIndicatorShown(true);
                 QTreeView::dragMoveEvent(event);
                 return;
@@ -383,11 +379,12 @@ void NodeTreeView::dropEvent(QDropEvent *event)
     if (event->mimeData()->hasFormat(NOTE_MIME)) {
         auto dropIndex = indexAt(event->pos());
         if (dropIndex.isValid()) {
-            auto itemType = static_cast<NodeItem::Type>(dropIndex.data(NodeItem::Roles::ItemType).toInt());
+            auto itemType =
+                    static_cast<NodeItem::Type>(dropIndex.data(NodeItem::Roles::ItemType).toInt());
             bool ok = false;
             auto idl = QString::fromUtf8(event->mimeData()->data(NOTE_MIME))
-                    .split(QStringLiteral(PATH_SEPERATOR));
-            for (const auto& s : qAsConst(idl)) {
+                               .split(QStringLiteral(PATH_SEPERATOR));
+            for (const auto &s : qAsConst(idl)) {
                 auto nodeId = s.toInt(&ok);
                 if (ok) {
                     if (itemType == NodeItem::Type::FolderItem) {
@@ -407,7 +404,6 @@ void NodeTreeView::dropEvent(QDropEvent *event)
     }
 }
 
-
 void NodeTreeView::setIsEditing(bool newIsEditing)
 {
     m_isEditing = newIsEditing;
@@ -416,7 +412,8 @@ void NodeTreeView::setIsEditing(bool newIsEditing)
 void NodeTreeView::onRenameFolderFinished(const QString &newName)
 {
     if (m_currentEditingIndex.isValid()) {
-        auto itemType = static_cast<NodeItem::Type>(m_currentEditingIndex.data(NodeItem::Roles::ItemType).toInt());
+        auto itemType = static_cast<NodeItem::Type>(
+                m_currentEditingIndex.data(NodeItem::Roles::ItemType).toInt());
         if (itemType == NodeItem::Type::FolderItem) {
             QModelIndex index = m_currentEditingIndex;
             closeCurrentEditor();
@@ -432,7 +429,8 @@ void NodeTreeView::onRenameFolderFinished(const QString &newName)
 void NodeTreeView::onRenameTagFinished(const QString &newName)
 {
     if (m_currentEditingIndex.isValid()) {
-        auto itemType = static_cast<NodeItem::Type>(m_currentEditingIndex.data(NodeItem::Roles::ItemType).toInt());
+        auto itemType = static_cast<NodeItem::Type>(
+                m_currentEditingIndex.data(NodeItem::Roles::ItemType).toInt());
         if (itemType == NodeItem::Type::TagItem) {
             QModelIndex index = m_currentEditingIndex;
             closeCurrentEditor();
@@ -461,57 +459,52 @@ void NodeTreeView::setCurrentIndexNC(const QModelIndex &index)
 void NodeTreeView::setTheme(Theme theme)
 {
     m_theme = theme;
-#if defined(Q_OS_LINUX) || defined(Q_OS_WINDOWS) || defined(Q_OS_WIN) || defined (Q_OS_FREEBSD)
+#if defined(Q_OS_LINUX) || defined(Q_OS_WINDOWS) || defined(Q_OS_WIN) || defined(Q_OS_FREEBSD)
     QString ss = QStringLiteral(
-                R"(QTreeView {)"
-                R"(    border-style: none;)"
-                R"(    background-color: %1;)"
-                R"(    selection-background-color: %1;)"
-                R"(    selection-color: white;)"
-                R"(})"
-                R"()"
-                R"(QTreeView::branch{)"
-                R"(    border-image: url(none.png);)"
-                R"(})"
-                R"(QScrollBar::handle:vertical:hover { background: rgba(40, 40, 40, 0.5); } )"
-                R"(QScrollBar::handle:vertical:pressed { background: rgba(40, 40, 40, 0.5); } )"
-                R"(QScrollBar::handle:vertical { border-radius: 4px; background: rgba(100, 100, 100, 0.5); min-height: 20px; }  )"
-                R"(QScrollBar::vertical {border-radius: 6px; width: 10px; color: rgba(255, 255, 255,0);} )"
-                R"(QScrollBar {margin-right: 2px; background: transparent;} )"
-                R"(QScrollBar::add-line:vertical { width:0px; height: 0px; subcontrol-position: bottom; subcontrol-origin: margin; }  )"
-                R"(QScrollBar::sub-line:vertical { width:0px; height: 0px; subcontrol-position: top; subcontrol-origin: margin; })");
+            R"(QTreeView {)"
+            R"(    border-style: none;)"
+            R"(    background-color: %1;)"
+            R"(    selection-background-color: %1;)"
+            R"(    selection-color: white;)"
+            R"(})"
+            R"()"
+            R"(QTreeView::branch{)"
+            R"(    border-image: url(none.png);)"
+            R"(})"
+            R"(QScrollBar::handle:vertical:hover { background: rgba(40, 40, 40, 0.5); } )"
+            R"(QScrollBar::handle:vertical:pressed { background: rgba(40, 40, 40, 0.5); } )"
+            R"(QScrollBar::handle:vertical { border-radius: 4px; background: rgba(100, 100, 100, 0.5); min-height: 20px; }  )"
+            R"(QScrollBar::vertical {border-radius: 6px; width: 10px; color: rgba(255, 255, 255,0);} )"
+            R"(QScrollBar {margin-right: 2px; background: transparent;} )"
+            R"(QScrollBar::add-line:vertical { width:0px; height: 0px; subcontrol-position: bottom; subcontrol-origin: margin; }  )"
+            R"(QScrollBar::sub-line:vertical { width:0px; height: 0px; subcontrol-position: top; subcontrol-origin: margin; })");
 #else
-    QString ss = QStringLiteral(
-                R"(QTreeView {)"
-                R"(    border-style: none;)"
-                R"(    background-color: %1;)"
-                R"(    selection-background-color: %1;)"
-                R"(    selection-color: white;)"
-                R"(})"
-                R"()"
-                R"(QTreeView::branch{)"
-                R"(    border-image: url(none.png);)"
-                R"(})");
+    QString ss = QStringLiteral(R"(QTreeView {)"
+                                R"(    border-style: none;)"
+                                R"(    background-color: %1;)"
+                                R"(    selection-background-color: %1;)"
+                                R"(    selection-color: white;)"
+                                R"(})"
+                                R"()"
+                                R"(QTreeView::branch{)"
+                                R"(    border-image: url(none.png);)"
+                                R"(})");
 #endif
 
-    switch(theme){
-    case Theme::Light:
-    {
+    switch (theme) {
+    case Theme::Light: {
         setStyleSheet(ss.arg(QColor(247, 247, 247).name()));
         break;
     }
-    case Theme::Dark:
-    {
+    case Theme::Dark: {
         setStyleSheet(ss.arg(QColor(26, 26, 26).name()));
         break;
     }
-    case Theme::Sepia:
-    {
+    case Theme::Sepia: {
         setStyleSheet(ss.arg(QColor(251, 240, 217).name()));
         break;
     }
     }
-
 }
 
 void NodeTreeView::onCustomContextMenu(QPoint point)
@@ -543,13 +536,13 @@ void NodeTreeView::onCustomContextMenu(QPoint point)
 }
 
 void NodeTreeView::setTreeSeparator(const QVector<QModelIndex> &newTreeSeparator,
-                                    const QModelIndex& defaultNotesIndex)
+                                    const QModelIndex &defaultNotesIndex)
 {
-    for (const auto& sep : qAsConst(m_treeSeparator)) {
+    for (const auto &sep : qAsConst(m_treeSeparator)) {
         closePersistentEditor(sep);
     }
     m_treeSeparator = newTreeSeparator;
-    for (const auto& sep : qAsConst(m_treeSeparator)) {
+    for (const auto &sep : qAsConst(m_treeSeparator)) {
         openPersistentEditor(sep);
     }
     m_defaultNotesIndex = defaultNotesIndex;
@@ -575,9 +568,8 @@ void NodeTreeView::mouseMoveEvent(QMouseEvent *event)
         }
         return;
     }
-    if (d->pressedIndex.isValid()
-            && (state() != DragSelectingState)
-            && (event->buttons() != Qt::NoButton)) {
+    if (d->pressedIndex.isValid() && (state() != DragSelectingState)
+        && (event->buttons() != Qt::NoButton)) {
         setState(DraggingState);
         return;
     }
@@ -590,7 +582,8 @@ void NodeTreeView::mousePressEvent(QMouseEvent *event)
     {
         auto index = indexAt(event->pos());
         if (index.isValid()) {
-            auto itemType = static_cast<NodeItem::Type>(index.data(NodeItem::Roles::ItemType).toInt());
+            auto itemType =
+                    static_cast<NodeItem::Type>(index.data(NodeItem::Roles::ItemType).toInt());
             switch (itemType) {
             case NodeItem::Type::FolderItem: {
                 auto rect = visualRect(index);
@@ -608,8 +601,9 @@ void NodeTreeView::mousePressEvent(QMouseEvent *event)
             }
             case NodeItem::Type::TagItem: {
                 auto oldIndexes = selectionModel()->selectedIndexes();
-                for (const auto& ix : qAsConst(oldIndexes)) {
-                    auto itemType = static_cast<NodeItem::Type>(ix.data(NodeItem::Roles::ItemType).toInt());
+                for (const auto &ix : qAsConst(oldIndexes)) {
+                    auto itemType =
+                            static_cast<NodeItem::Type>(ix.data(NodeItem::Roles::ItemType).toInt());
                     if (itemType != NodeItem::Type::TagItem) {
                         setCurrentIndex(QModelIndex());
                         clearSelection();
@@ -663,16 +657,17 @@ void NodeTreeView::mouseReleaseEvent(QMouseEvent *event)
         selectionModel()->select(m_needReleaseIndex, QItemSelectionModel::Deselect);
         if (selectionModel()->selectedIndexes().isEmpty()) {
             if (!m_isLastSelectedFolder) {
-                auto index = dynamic_cast<NodeTreeModel*>(model())
-                        ->folderIndexFromIdPath(m_lastSelectFolder);
+                auto index = dynamic_cast<NodeTreeModel *>(model())->folderIndexFromIdPath(
+                        m_lastSelectFolder);
                 if (index.isValid()) {
                     emit requestLoadLastSelectedNote();
                     setCurrentIndexC(index);
                 } else {
-                    setCurrentIndexC(dynamic_cast<NodeTreeModel*>(model())->getAllNotesButtonIndex());
+                    setCurrentIndexC(
+                            dynamic_cast<NodeTreeModel *>(model())->getAllNotesButtonIndex());
                 }
             } else {
-                setCurrentIndexC(dynamic_cast<NodeTreeModel*>(model())->getAllNotesButtonIndex());
+                setCurrentIndexC(dynamic_cast<NodeTreeModel *>(model())->getAllNotesButtonIndex());
             }
         }
     }

--- a/src/nodetreeview.h
+++ b/src/nodetreeview.h
@@ -9,7 +9,8 @@
 class QMenu;
 class QAction;
 class NodeTreeViewPrivate;
-struct NoteTreeConstant {
+struct NoteTreeConstant
+{
     static constexpr int folderItemHeight = 30;
     static constexpr int tagItemHeight = 30;
     static constexpr int folderLabelHeight = 25;
@@ -20,19 +21,20 @@ class NodeTreeView : public QTreeView
 {
     Q_OBJECT
 public:
-    explicit NodeTreeView(QWidget* parent = Q_NULLPTR);
+    explicit NodeTreeView(QWidget *parent = Q_NULLPTR);
 
-    void setTreeSeparator(const QVector<QModelIndex> &newTreeSeparator, const QModelIndex &defaultNotesIndex);
+    void setTreeSeparator(const QVector<QModelIndex> &newTreeSeparator,
+                          const QModelIndex &defaultNotesIndex);
     void setIsEditing(bool newIsEditing);
-    void onRenameFolderFinished(const QString& newName);
-    void onRenameTagFinished(const QString& newName);
-    void setCurrentIndexC(const QModelIndex& index);
-    void setCurrentIndexNC(const QModelIndex& index);
+    void onRenameFolderFinished(const QString &newName);
+    void onRenameTagFinished(const QString &newName);
+    void setCurrentIndexC(const QModelIndex &index);
+    void setCurrentIndexNC(const QModelIndex &index);
     void setTheme(Theme theme);
     Theme theme() const;
     bool isDragging() const;
     void reExpandC();
-    void reExpandC(const QStringList& expanded);
+    void reExpandC(const QStringList &expanded);
 
     void setIgnoreThisCurrentLoad(bool newIgnoreThisCurrentLoad);
     const QModelIndex &currentEditingIndex() const;
@@ -40,45 +42,45 @@ public:
 public slots:
     void onCustomContextMenu(QPoint point);
     void onChangeTagColorAction();
-    void onRequestExpand(const QString& folderPath);
-    void onUpdateAbsPath(const QString& oldPath, const QString& newPath);
-    void onFolderDropSuccessfull(const QString& path);
-    void onTagsDropSuccessfull(const QSet<int>& ids);
+    void onRequestExpand(const QString &folderPath);
+    void onUpdateAbsPath(const QString &oldPath, const QString &newPath);
+    void onFolderDropSuccessfull(const QString &path);
+    void onTagsDropSuccessfull(const QSet<int> &ids);
 
 signals:
     void addFolderRequested();
     void renameFolderRequested();
-    void renameFolderInDatabase(const QModelIndex& index, const QString& newName);
-    void renameTagInDatabase(const QModelIndex& index, const QString& newName);
-    void deleteNodeRequested(const QModelIndex& index);
-    void loadNotesInFolderRequested(int folderID, bool isRecursive,
-                                    bool notInterested = false, int scrollToId = SpecialNodeID::InvalidNodeId);
-    void loadNotesInTagsRequested(const QSet<int>& tagIds,
-                                  bool notInterested = false, int scrollToId = SpecialNodeID::InvalidNodeId);
+    void renameFolderInDatabase(const QModelIndex &index, const QString &newName);
+    void renameTagInDatabase(const QModelIndex &index, const QString &newName);
+    void deleteNodeRequested(const QModelIndex &index);
+    void loadNotesInFolderRequested(int folderID, bool isRecursive, bool notInterested = false,
+                                    int scrollToId = SpecialNodeID::InvalidNodeId);
+    void loadNotesInTagsRequested(const QSet<int> &tagIds, bool notInterested = false,
+                                  int scrollToId = SpecialNodeID::InvalidNodeId);
     void moveNodeRequested(int node, int target);
     void renameTagRequested();
-    void changeTagColorRequested(const QModelIndex& index);
-    void deleteTagRequested(const QModelIndex& index);
+    void changeTagColorRequested(const QModelIndex &index);
+    void deleteTagRequested(const QModelIndex &index);
     void addNoteToTag(int noteId, int tagId);
-    void saveExpand(const QStringList& ex);
-    void saveSelected(bool isSelectingFolder, const QString& folder, const QSet<int>& tags);
+    void saveExpand(const QStringList &ex);
+    void saveSelected(bool isSelectingFolder, const QString &folder, const QSet<int> &tags);
     void saveLastSelectedNote();
     void requestLoadLastSelectedNote();
 
 private slots:
     void onDeleteNodeAction();
-    void onExpanded(const QModelIndex& index);
-    void onCollapsed(const QModelIndex& index);
+    void onExpanded(const QModelIndex &index);
+    void onCollapsed(const QModelIndex &index);
 
 private:
-    QMenu* contextMenu;
-    QAction* renameFolderAction;
-    QAction* deleteFolderAction;
-    QAction* addSubfolderAction;
-    QAction* renameTagAction;
-    QAction* changeTagColorAction;
-    QAction* deleteTagAction;
-    QAction* clearSelectionAction;
+    QMenu *contextMenu;
+    QAction *renameFolderAction;
+    QAction *deleteFolderAction;
+    QAction *addSubfolderAction;
+    QAction *renameTagAction;
+    QAction *changeTagColorAction;
+    QAction *deleteTagAction;
+    QAction *clearSelectionAction;
     QTimer contextMenuTimer;
     QVector<QModelIndex> m_treeSeparator;
     QModelIndex m_defaultNotesIndex;
@@ -96,7 +98,8 @@ private:
 
     // QAbstractItemView interface
 protected slots:
-    virtual void selectionChanged(const QItemSelection &selected, const QItemSelection &deselected) override;
+    virtual void selectionChanged(const QItemSelection &selected,
+                                  const QItemSelection &deselected) override;
     virtual void currentChanged(const QModelIndex &current, const QModelIndex &previous) override;
 
     // QWidget interface

--- a/src/nodetreeview_p.h
+++ b/src/nodetreeview_p.h
@@ -8,9 +8,8 @@ class NodeTreeViewPrivate : public QAbstractItemViewPrivate
     Q_DECLARE_PUBLIC(NodeTreeView)
 
 public:
-    NodeTreeViewPrivate(): QAbstractItemViewPrivate() {};
-    virtual ~NodeTreeViewPrivate() {}
+    NodeTreeViewPrivate() : QAbstractItemViewPrivate(){};
+    virtual ~NodeTreeViewPrivate() { }
 };
-
 
 #endif // NODETREEVIEW_P_H

--- a/src/noteeditorlogic.cpp
+++ b/src/noteeditorlogic.cpp
@@ -15,45 +15,37 @@
 
 #define FIRST_LINE_MAX 80
 
-
-NoteEditorLogic::NoteEditorLogic(CustomDocument *textEdit,
-                                 QLabel* editorDateLabel,
-                                 QLineEdit* searchEdit,
-                                 TagListView *tagListView, TagPool *tagPool,
-                                 DBManager *dbManager,
-                                 QObject *parent) : QObject(parent),
-    m_textEdit{textEdit},
-    m_editorDateLabel{editorDateLabel},
-    m_searchEdit{searchEdit},
-    m_tagListView{tagListView},
-    m_dbManager{dbManager},
-    m_isContentModified{false},
-    m_spacerColor{26, 26, 26},
-    m_currentAdaptableEditorPadding{0},
-    m_currentMinimumEditorPadding{0}
+NoteEditorLogic::NoteEditorLogic(CustomDocument *textEdit, QLabel *editorDateLabel,
+                                 QLineEdit *searchEdit, TagListView *tagListView, TagPool *tagPool,
+                                 DBManager *dbManager, QObject *parent)
+    : QObject(parent),
+      m_textEdit{ textEdit },
+      m_editorDateLabel{ editorDateLabel },
+      m_searchEdit{ searchEdit },
+      m_tagListView{ tagListView },
+      m_dbManager{ dbManager },
+      m_isContentModified{ false },
+      m_spacerColor{ 26, 26, 26 },
+      m_currentAdaptableEditorPadding{ 0 },
+      m_currentMinimumEditorPadding{ 0 }
 {
     m_highlighter = new MarkdownHighlighter(m_textEdit->document());
     connect(m_textEdit, &QTextEdit::textChanged, this, &NoteEditorLogic::onTextEditTextChanged);
     connect(m_textEdit, &CustomDocument::resized, this, &NoteEditorLogic::editorResized);
-    connect(this, &NoteEditorLogic::requestCreateUpdateNote,
-            m_dbManager, &DBManager::onCreateUpdateRequestedNoteContent, Qt::QueuedConnection);
+    connect(this, &NoteEditorLogic::requestCreateUpdateNote, m_dbManager,
+            &DBManager::onCreateUpdateRequestedNoteContent, Qt::QueuedConnection);
     // auto save timer
     m_autoSaveTimer.setSingleShot(true);
     m_autoSaveTimer.setInterval(50);
-    connect(&m_autoSaveTimer, &QTimer::timeout, this, [this]() {
-        saveNoteToDB();
-    });
-    m_tagListModel = new TagListModel{this};
+    connect(&m_autoSaveTimer, &QTimer::timeout, this, [this]() { saveNoteToDB(); });
+    m_tagListModel = new TagListModel{ this };
     m_tagListModel->setTagPool(tagPool);
     m_tagListView->setModel(m_tagListModel);
-    m_tagListDelegate = new TagListDelegate{this};
+    m_tagListDelegate = new TagListDelegate{ this };
     m_tagListView->setItemDelegate(m_tagListDelegate);
-    connect(tagPool, &TagPool::dataUpdated, this, [this] (int) {
-        showTagListForCurrentNote();
-    });
-    connect(m_textEdit->verticalScrollBar(), &QScrollBar::valueChanged,
-            this, [this](int value) {
-        if (m_currentNotes.size() == 1 && m_currentNotes[0].id() != SpecialNodeID::InvalidNodeId ) {
+    connect(tagPool, &TagPool::dataUpdated, this, [this](int) { showTagListForCurrentNote(); });
+    connect(m_textEdit->verticalScrollBar(), &QScrollBar::valueChanged, this, [this](int value) {
+        if (m_currentNotes.size() == 1 && m_currentNotes[0].id() != SpecialNodeID::InvalidNodeId) {
             m_currentNotes[0].setScrollBarPosition(value);
             emit updateNoteDataInList(m_currentNotes[0]);
             m_isContentModified = true;
@@ -83,7 +75,7 @@ void NoteEditorLogic::setMarkdownEnabled(bool newMarkdownEnabled)
 
 void NoteEditorLogic::showNotesInEditor(const QVector<NodeData> &notes)
 {
-    if (notes.size() == 1 && notes[0].id() != SpecialNodeID::InvalidNodeId ) {
+    if (notes.size() == 1 && notes[0].id() != SpecialNodeID::InvalidNodeId) {
         auto currentId = currentEditingNoteId();
         if (currentId != SpecialNodeID::InvalidNodeId && notes[0].id() != currentId) {
             emit noteEditClosed(m_currentNotes[0], false);
@@ -93,7 +85,7 @@ void NoteEditorLogic::showNotesInEditor(const QVector<NodeData> &notes)
         m_currentNotes = notes;
         showTagListForCurrentNote();
         //     fixing bug #202
-        m_textEdit->setTextBackgroundColor(QColor(247,247,247, 0));
+        m_textEdit->setTextBackgroundColor(QColor(247, 247, 247, 0));
 
         QString content = notes[0].content();
         QDateTime dateTime = notes[0].lastModificationdateTime();
@@ -116,15 +108,15 @@ void NoteEditorLogic::showNotesInEditor(const QVector<NodeData> &notes)
         m_tagListView->setVisible(false);
         m_textEdit->blockSignals(true);
         m_textEdit->clear();
-        auto padding = m_currentAdaptableEditorPadding > m_currentMinimumEditorPadding ?
-                    m_currentAdaptableEditorPadding : m_currentMinimumEditorPadding;
-        QPixmap sep(QSize{m_textEdit->width() - padding * 2 - 20, 19});
+        auto padding = m_currentAdaptableEditorPadding > m_currentMinimumEditorPadding
+                ? m_currentAdaptableEditorPadding
+                : m_currentMinimumEditorPadding;
+        QPixmap sep(QSize{ m_textEdit->width() - padding * 2 - 20, 19 });
         sep.fill(Qt::transparent);
         QPainter painter(&sep);
         painter.setPen(m_spacerColor);
         painter.drawLine(10, 10, sep.width(), 10);
-        m_textEdit->document()->addResource(QTextDocument::ImageResource,
-                                            QUrl("mydata://sep.png"),
+        m_textEdit->document()->addResource(QTextDocument::ImageResource, QUrl("mydata://sep.png"),
                                             sep);
         for (int i = 0; i < notes.size(); ++i) {
             auto cursor = m_textEdit->textCursor();
@@ -156,7 +148,7 @@ void NoteEditorLogic::onTextEditTextChanged()
     if (currentEditingNoteId() != SpecialNodeID::InvalidNodeId) {
         m_textEdit->blockSignals(true);
         QString content = m_currentNotes[0].content();
-        if(m_textEdit->toPlainText() != content){
+        if (m_textEdit->toPlainText() != content) {
             // move note to the top of the list
             emit moveNoteToListViewTop(m_currentNotes[0]);
 
@@ -241,8 +233,8 @@ int NoteEditorLogic::currentEditingNoteId() const
 
 void NoteEditorLogic::saveNoteToDB()
 {
-    if(currentEditingNoteId() != SpecialNodeID::InvalidNodeId
-            && m_isContentModified && !m_currentNotes[0].isTempNote()) {
+    if (currentEditingNoteId() != SpecialNodeID::InvalidNodeId && m_isContentModified
+        && !m_currentNotes[0].isTempNote()) {
         emit requestCreateUpdateNote(m_currentNotes[0]);
         m_isContentModified = false;
     }
@@ -284,7 +276,6 @@ void NoteEditorLogic::editorResized()
     }
 }
 
-
 void NoteEditorLogic::deleteCurrentNote()
 {
     if (isTempNote()) {
@@ -316,7 +307,7 @@ void NoteEditorLogic::deleteCurrentNote()
  * \param str
  * \return
  */
-QString NoteEditorLogic::getFirstLine(const QString& str)
+QString NoteEditorLogic::getFirstLine(const QString &str)
 {
     QString text = str.trimmed();
     if (text.isEmpty()) {
@@ -352,26 +343,24 @@ QString NoteEditorLogic::getSecondLine(const QString &str)
 void NoteEditorLogic::setTheme(Theme newTheme)
 {
     m_tagListDelegate->setTheme(newTheme);
-    switch(newTheme){
-    case Theme::Light:
-    {
+    switch (newTheme) {
+    case Theme::Light: {
         m_spacerColor = QColor(26, 26, 26);
         break;
     }
-    case Theme::Dark:
-    {
+    case Theme::Dark: {
         m_spacerColor = QColor(204, 204, 204);
         break;
     }
-    case Theme::Sepia:
-    {
+    case Theme::Sepia: {
         m_spacerColor = QColor(26, 26, 26);
         break;
     }
     }
     if (currentEditingNoteId() != SpecialNodeID::InvalidNodeId) {
         int verticalScrollBarValueToRestore = m_textEdit->verticalScrollBar()->value();
-        m_textEdit->setText(m_textEdit->toPlainText()); // TODO: Update the text color without setting the text
+        m_textEdit->setText(
+                m_textEdit->toPlainText()); // TODO: Update the text color without setting the text
         m_textEdit->verticalScrollBar()->setValue(verticalScrollBarValueToRestore);
     } else {
         int verticalScrollBarValueToRestore = m_textEdit->verticalScrollBar()->value();
@@ -402,7 +391,7 @@ void NoteEditorLogic::highlightSearch() const
     highlightFormat.setBackground(Qt::yellow);
 
     while (m_textEdit->find(searchString))
-        extraSelections.append({ m_textEdit->textCursor(), highlightFormat});
+        extraSelections.append({ m_textEdit->textCursor(), highlightFormat });
 
     if (!extraSelections.isEmpty()) {
         m_textEdit->setTextCursor(extraSelections.first().cursor);

--- a/src/noteeditorlogic.h
+++ b/src/noteeditorlogic.h
@@ -20,13 +20,9 @@ class NoteEditorLogic : public QObject
 {
     Q_OBJECT
 public:
-    explicit NoteEditorLogic(CustomDocument* textEdit,
-                             QLabel* editorDateLabel,
-                             QLineEdit* searchEdit,
-                             TagListView* tagListView,
-                             TagPool* tagPool,
-                             DBManager* dbManager,
-                             QObject *parent = nullptr);
+    explicit NoteEditorLogic(CustomDocument *textEdit, QLabel *editorDateLabel,
+                             QLineEdit *searchEdit, TagListView *tagListView, TagPool *tagPool,
+                             DBManager *dbManager, QObject *parent = nullptr);
 
     bool markdownEnabled() const;
     void setMarkdownEnabled(bool newMarkdownEnabled);
@@ -48,36 +44,37 @@ public:
     void setCurrentMinimumEditorPadding(int newCurrentMinimumEditorPadding);
 
 public slots:
-    void showNotesInEditor(const QVector<NodeData>& notes);
+    void showNotesInEditor(const QVector<NodeData> &notes);
     void onTextEditTextChanged();
     void closeEditor();
     void onNoteTagListChanged(int noteId, const QSet<int> &tagIds);
 private slots:
     void editorResized();
 signals:
-    void requestCreateUpdateNote(const NodeData& note);
-    void noteEditClosed(const NodeData& note, bool selectNext);
+    void requestCreateUpdateNote(const NodeData &note);
+    void noteEditClosed(const NodeData &note, bool selectNext);
     void setVisibilityOfFrameRightNonEditor(bool);
-    void moveNoteToListViewTop(const NodeData& note);
-    void updateNoteDataInList(const NodeData& note);
-    void deleteNoteRequested(const NodeData& note);
+    void moveNoteToListViewTop(const NodeData &note);
+    void updateNoteDataInList(const NodeData &note);
+    void deleteNoteRequested(const NodeData &note);
+
 private:
     static QDateTime getQDateTime(const QString &date);
     void showTagListForCurrentNote();
     bool isInEditMode() const;
 
 private:
-    CustomDocument* m_textEdit;
+    CustomDocument *m_textEdit;
     MarkdownHighlighter *m_highlighter;
-    QLabel* m_editorDateLabel;
-    QLineEdit* m_searchEdit;
-    TagListView* m_tagListView;
-    DBManager* m_dbManager;
+    QLabel *m_editorDateLabel;
+    QLineEdit *m_searchEdit;
+    TagListView *m_tagListView;
+    DBManager *m_dbManager;
     QVector<NodeData> m_currentNotes;
     bool m_isContentModified;
     QTimer m_autoSaveTimer;
-    TagListDelegate* m_tagListDelegate;
-    TagListModel* m_tagListModel;
+    TagListDelegate *m_tagListDelegate;
+    TagListModel *m_tagListModel;
     QColor m_spacerColor;
     int m_currentAdaptableEditorPadding;
     int m_currentMinimumEditorPadding;

--- a/src/notelistdelegate.cpp
+++ b/src/notelistdelegate.cpp
@@ -14,27 +14,30 @@
 
 NoteListDelegate::NoteListDelegate(NoteListView *view, TagPool *tagPool, QObject *parent)
     : QStyledItemDelegate(parent),
-      m_view{view},
-      m_tagPool{tagPool},
-      #ifdef __APPLE__
-      m_displayFont(QFont(QStringLiteral("SF Pro Text")).exactMatch() ? QStringLiteral("SF Pro Text") : QStringLiteral("Roboto")),
-      #elif _WIN32
-      m_displayFont(QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI") : QStringLiteral("Roboto")),
-      #else
+      m_view{ view },
+      m_tagPool{ tagPool },
+#ifdef __APPLE__
+      m_displayFont(QFont(QStringLiteral("SF Pro Text")).exactMatch()
+                            ? QStringLiteral("SF Pro Text")
+                            : QStringLiteral("Roboto")),
+#elif _WIN32
+      m_displayFont(QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI")
+                                                                   : QStringLiteral("Roboto")),
+#else
       m_displayFont(QStringLiteral("Roboto")),
-      #endif
+#endif
 
-      #ifdef __APPLE__
+#ifdef __APPLE__
       m_titleFont(m_displayFont, 13, QFont::DemiBold),
       m_titleSelectedFont(m_displayFont, 13, QFont::DemiBold),
       m_dateFont(m_displayFont, 13),
       m_headerFont(m_displayFont, 10, QFont::DemiBold),
-      #else
+#else
       m_titleFont(m_displayFont, 10, QFont::DemiBold),
       m_titleSelectedFont(m_displayFont, 10),
       m_dateFont(m_displayFont, 10),
       m_headerFont(m_displayFont, 10, QFont::DemiBold),
-      #endif
+#endif
       m_titleColor(26, 26, 26),
       m_dateColor(26, 26, 26),
       m_contentColor(142, 146, 150),
@@ -53,29 +56,29 @@ NoteListDelegate::NoteListDelegate(NoteListView *view, TagPool *tagPool, QObject
       m_theme(Theme::Light)
 {
     m_timeLine = new QTimeLine(300, this);
-    m_timeLine->setFrameRange(0,m_maxFrame);
+    m_timeLine->setFrameRange(0, m_maxFrame);
     m_timeLine->setUpdateInterval(10);
     m_timeLine->setEasingCurve(QEasingCurve::InCurve);
     m_folderIcon = QImage(":/images/folder.png");
     m_pinnedExpandIcon = QImage(":/images/pinned-expand.png");
     m_pinnedCollapseIcon = QImage(":/images/pinned-collasped.png");
-    connect(m_timeLine, &QTimeLine::frameChanged, this, [this](){
-        for (const auto& index : qAsConst(m_animatedIndexes)) {
+    connect(m_timeLine, &QTimeLine::frameChanged, this, [this]() {
+        for (const auto &index : qAsConst(m_animatedIndexes)) {
             emit sizeHintChanged(index);
         }
     });
 
     connect(m_timeLine, &QTimeLine::finished, this, [this]() {
         emit animationFinished(m_state);
-        for (const auto& index : qAsConst(m_animatedIndexes)) {
+        for (const auto &index : qAsConst(m_animatedIndexes)) {
             m_view->openPersistentEditorC(index);
         }
         if (!animationQueue.empty()) {
             auto a = animationQueue.front();
             animationQueue.pop_front();
             QModelIndexList indexes;
-            for (const auto& id : qAsConst(a.first)) {
-                auto model = dynamic_cast<NoteListModel*>(m_view->model());
+            for (const auto &id : qAsConst(a.first)) {
+                auto model = dynamic_cast<NoteListModel *>(m_view->model());
                 if (model) {
                     auto index = model->getNoteIndex(id);
                     if (index.isValid()) {
@@ -95,7 +98,7 @@ void NoteListDelegate::setState(NoteListState NewState, QModelIndexList indexes)
 {
     if (animationState() != QTimeLine::NotRunning) {
         QSet<int> ids;
-        for (const auto& index : qAsConst(indexes)) {
+        for (const auto &index : qAsConst(indexes)) {
             auto noteId = index.data(NoteListModel::NoteID).toInt();
             if (noteId != SpecialNodeID::InvalidNodeId) {
                 ids.insert(noteId);
@@ -114,14 +117,15 @@ void NoteListDelegate::setAnimationDuration(const int duration)
     m_timeLine->setDuration(duration);
 }
 
-void NoteListDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
+void NoteListDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option,
+                             const QModelIndex &index) const
 {
     bool isHaveTags = index.data(NoteListModel::NoteTagsList).value<QSet<int>>().size() > 0;
-    if((!m_animatedIndexes.contains(index)) && isHaveTags) {
+    if ((!m_animatedIndexes.contains(index)) && isHaveTags) {
         return;
     }
     if (m_view->isPinnedNotesCollapsed()) {
-        auto model = dynamic_cast<NoteListModel*>(m_view->model());
+        auto model = dynamic_cast<NoteListModel *>(m_view->model());
         auto isPinned = index.data(NoteListModel::NoteIsPinned).value<bool>();
         if (isPinned) {
             if (model && (!model->isFirstPinnedNote(index))) {
@@ -135,14 +139,14 @@ void NoteListDelegate::paint(QPainter *painter, const QStyleOptionViewItem &opti
     opt.rect.setWidth(option.rect.width() - m_rowRightOffset);
 
     int currentFrame = m_timeLine->currentFrame();
-    double rate = (currentFrame/(m_maxFrame * 1.0));
+    double rate = (currentFrame / (m_maxFrame * 1.0));
     double height = m_rowHeight * rate;
 
-    switch (m_state){
+    switch (m_state) {
     case NoteListState::Insert:
     case NoteListState::Remove:
     case NoteListState::MoveOut:
-        if(m_animatedIndexes.contains(index)){
+        if (m_animatedIndexes.contains(index)) {
             opt.rect.setHeight(int(height));
             opt.backgroundBrush.setColor(m_notActiveColor);
         }
@@ -159,16 +163,17 @@ void NoteListDelegate::paint(QPainter *painter, const QStyleOptionViewItem &opti
 
 QSize NoteListDelegate::sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const
 {
-    QSize result;// = QStyledItemDelegate::sizeHint(option, index);
+    QSize result; // = QStyledItemDelegate::sizeHint(option, index);
     result.setWidth(option.rect.width());
-    auto model = dynamic_cast<NoteListModel*>(m_view->model());
-    const auto& note = model->getNote(index);
+    auto model = dynamic_cast<NoteListModel *>(m_view->model());
+    const auto &note = model->getNote(index);
     auto id = note.id();
     bool isHaveTags = note.tagIds().size() > 0;
 #if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
     if ((!m_animatedIndexes.contains(index)) && isHaveTags) {
 #else
-    if (m_view->isPersistentEditorOpen(index) && (!m_animatedIndexes.contains(index)) && isHaveTags) {
+    if (m_view->isPersistentEditorOpen(index) && (!m_animatedIndexes.contains(index))
+        && isHaveTags) {
 #endif
         if (szMap.contains(id)) {
             result.setHeight(szMap[id].height());
@@ -179,11 +184,11 @@ QSize NoteListDelegate::sizeHint(const QStyleOptionViewItem &option, const QMode
     if (isHaveTags) {
         rowHeight = m_rowHeight;
     }
-    if (m_animatedIndexes.contains(index)){
-        if (m_state == NoteListState::MoveIn){
+    if (m_animatedIndexes.contains(index)) {
+        if (m_state == NoteListState::MoveIn) {
             result.setHeight(rowHeight);
         } else {
-            double rate = m_timeLine->currentFrame()/(m_maxFrame * 1.0);
+            double rate = m_timeLine->currentFrame() / (m_maxFrame * 1.0);
             double height = rowHeight * rate;
             result.setHeight(int(height));
         }
@@ -207,8 +212,8 @@ QSize NoteListDelegate::sizeHint(const QStyleOptionViewItem &option, const QMode
             result.setHeight(result.height() + 25);
         }
     } else {
-        if (model->hasPinnedNote() &&
-                (model->isFirstPinnedNote(index) || model->isFirstUnpinnedNote(index))) {
+        if (model->hasPinnedNote()
+            && (model->isFirstPinnedNote(index) || model->isFirstUnpinnedNote(index))) {
             result.setHeight(result.height() + 25);
         }
     }
@@ -226,7 +231,7 @@ QSize NoteListDelegate::sizeHint(const QStyleOptionViewItem &option, const QMode
     }
     int fifthYOffset = 0;
     if (model && model->hasPinnedNote() && !m_view->isPinnedNotesCollapsed()
-            && model->isFirstUnpinnedNote(index)) {
+        && model->isFirstUnpinnedNote(index)) {
         fifthYOffset = NoteListConstant::lastPinnedToUnpinnedHeader;
     }
 
@@ -235,7 +240,8 @@ QSize NoteListDelegate::sizeHint(const QStyleOptionViewItem &option, const QMode
     return result;
 }
 
-QSize NoteListDelegate::bufferSizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const
+QSize NoteListDelegate::bufferSizeHint(const QStyleOptionViewItem &option,
+                                       const QModelIndex &index) const
 {
     QSize result = QStyledItemDelegate::sizeHint(option, index);
     result.setWidth(option.rect.width());
@@ -244,7 +250,8 @@ QSize NoteListDelegate::bufferSizeHint(const QStyleOptionViewItem &option, const
 #if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
     if (!m_animatedIndexes.contains(index) && isHaveTags) {
 #else
-    if (m_view->isPersistentEditorOpen(index) && (!m_animatedIndexes.contains(index)) && isHaveTags) {
+    if (m_view->isPersistentEditorOpen(index) && (!m_animatedIndexes.contains(index))
+        && isHaveTags) {
 #endif
         if (szMap.contains(id)) {
             result.setHeight(szMap[id].height());
@@ -259,7 +266,7 @@ QSize NoteListDelegate::bufferSizeHint(const QStyleOptionViewItem &option, const
     if (m_isInAllNotes) {
         result.setHeight(result.height() + 20);
     }
-    auto model = dynamic_cast<NoteListModel*>(m_view->model());
+    auto model = dynamic_cast<NoteListModel *>(m_view->model());
     //    if (model) {
     //        if (model->hasPinnedNote() &&
     //                (model->isFirstPinnedNote(index) || model->isFirstUnpinnedNote(index))) {
@@ -290,13 +297,13 @@ QSize NoteListDelegate::bufferSizeHint(const QStyleOptionViewItem &option, const
     if (model && model->isFirstUnpinnedNote(index)) {
         fouthYOffset = NoteListConstant::unpinnedHeaderToNoteSpace;
     }
-//    int fifthYOffset = 0;
-//    if (model && model->hasPinnedNote() && !m_view->isPinnedNotesCollapsed()
-//            && model->isFirstUnpinnedNote(index)) {
-//        fifthYOffset = NoteListConstant::lastPinnedToUnpinnedHeader;
-//    }
+    //    int fifthYOffset = 0;
+    //    if (model && model->hasPinnedNote() && !m_view->isPinnedNotesCollapsed()
+    //            && model->isFirstUnpinnedNote(index)) {
+    //        fifthYOffset = NoteListConstant::lastPinnedToUnpinnedHeader;
+    //    }
 
-    int yOffsets = secondYOffset + thirdYOffset + fouthYOffset;// + fifthYOffset;
+    int yOffsets = secondYOffset + thirdYOffset + fouthYOffset; // + fifthYOffset;
     result.setHeight(result.height() - 10 + NoteListConstant::lastElSepSpace + yOffsets);
     return result;
 }
@@ -306,32 +313,32 @@ QTimeLine::State NoteListDelegate::animationState()
     return m_timeLine->state();
 }
 
-void NoteListDelegate::paintBackground(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
+void NoteListDelegate::paintBackground(QPainter *painter, const QStyleOptionViewItem &option,
+                                       const QModelIndex &index) const
 {
     auto bufferSize = bufferSizeHint(option, index);
-    QPixmap buffer{bufferSize};
+    QPixmap buffer{ bufferSize };
     buffer.fill(Qt::transparent);
-    QPainter bufferPainter{&buffer};
+    QPainter bufferPainter{ &buffer };
     bufferPainter.setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform);
     QRect bufferRect = buffer.rect();
     auto isPinned = index.data(NoteListModel::NoteIsPinned).toBool();
-    auto model = dynamic_cast<NoteListModel*>(m_view->model());
-    if (model && model->hasPinnedNote()
-            && model->isFirstPinnedNote(index)
-            && dynamic_cast<NoteListView*>(m_view)->isPinnedNotesCollapsed()) {
+    auto model = dynamic_cast<NoteListModel *>(m_view->model());
+    if (model && model->hasPinnedNote() && model->isFirstPinnedNote(index)
+        && dynamic_cast<NoteListView *>(m_view)->isPinnedNotesCollapsed()) {
         bufferPainter.fillRect(bufferRect, QBrush(m_defaultColor));
-    } else if((option.state & QStyle::State_Selected) == QStyle::State_Selected){
-        if(qApp->applicationState() == Qt::ApplicationActive){
-            if(m_isActive){
+    } else if ((option.state & QStyle::State_Selected) == QStyle::State_Selected) {
+        if (qApp->applicationState() == Qt::ApplicationActive) {
+            if (m_isActive) {
                 bufferPainter.fillRect(bufferRect, QBrush(m_ActiveColor));
-            }else{
+            } else {
                 bufferPainter.fillRect(bufferRect, QBrush(m_notActiveColor));
             }
-        }else if(qApp->applicationState() == Qt::ApplicationInactive){
+        } else if (qApp->applicationState() == Qt::ApplicationInactive) {
             bufferPainter.fillRect(bufferRect, QBrush(m_applicationInactiveColor));
         }
-    } else if((option.state & QStyle::State_MouseOver) == QStyle::State_MouseOver){
-        if (dynamic_cast<NoteListView*>(m_view)->isDragging()) {
+    } else if ((option.state & QStyle::State_MouseOver) == QStyle::State_MouseOver) {
+        if (dynamic_cast<NoteListView *>(m_view)->isDragging()) {
             if (isPinned) {
                 auto rect = bufferRect;
                 rect.setTop(rect.bottom() - 5);
@@ -350,9 +357,10 @@ void NoteListDelegate::paintBackground(QPainter *painter, const QStyleOptionView
             bufferPainter.fillRect(bufferRect, QBrush(m_defaultColor));
         }
     }
-    if (dynamic_cast<NoteListView*>(m_view)->isDragging() && !isPinned
-            && !dynamic_cast<NoteListView*>(m_view)->isDraggingInsidePinned()) {
-        if (model && model->isFirstUnpinnedNote(index) && (index.row() == (model->rowCount() - 1))) {
+    if (dynamic_cast<NoteListView *>(m_view)->isDragging() && !isPinned
+        && !dynamic_cast<NoteListView *>(m_view)->isDraggingInsidePinned()) {
+        if (model && model->isFirstUnpinnedNote(index)
+            && (index.row() == (model->rowCount() - 1))) {
             auto rect = bufferRect;
             rect.setHeight(4);
             bufferPainter.fillRect(rect, QBrush("#d6d5d5"));
@@ -401,10 +409,10 @@ void NoteListDelegate::paintBackground(QPainter *painter, const QStyleOptionView
     int rowHeight;
     if (m_animatedIndexes.contains(index)) {
         if (m_state != NoteListState::MoveIn) {
-            double rowRate = m_timeLine->currentFrame()/(m_maxFrame * 1.0);
+            double rowRate = m_timeLine->currentFrame() / (m_maxFrame * 1.0);
             rowHeight = bufferSize.height() * rowRate;
         } else {
-            double rowRate = 1.0 - m_timeLine->currentFrame()/(m_maxFrame * 1.0);
+            double rowRate = 1.0 - m_timeLine->currentFrame() / (m_maxFrame * 1.0);
             rowHeight = bufferSize.height() * rowRate;
         }
     } else {
@@ -414,63 +422,75 @@ void NoteListDelegate::paintBackground(QPainter *painter, const QStyleOptionView
 
     if (m_animatedIndexes.contains(index)) {
         if (m_state == NoteListState::MoveIn) {
-            if (model && model->hasPinnedNote() &&
-                    (model->isFirstPinnedNote(index) || model->isFirstUnpinnedNote(index))) {
-                painter->drawPixmap(
-                            QRect {option.rect.x(), option.rect.y() + bufferSize.height() - rowHeight + 25, option.rect.width(), rowHeight},
-                            buffer,
-                            QRect {0, bufferSize.height() - rowHeight, option.rect.width(), rowHeight});
+            if (model && model->hasPinnedNote()
+                && (model->isFirstPinnedNote(index) || model->isFirstUnpinnedNote(index))) {
+                painter->drawPixmap(QRect{ option.rect.x(),
+                                           option.rect.y() + bufferSize.height() - rowHeight + 25,
+                                           option.rect.width(), rowHeight },
+                                    buffer,
+                                    QRect{ 0, bufferSize.height() - rowHeight, option.rect.width(),
+                                           rowHeight });
             } else {
-                painter->drawPixmap(
-                            QRect {option.rect.x(), option.rect.y() + bufferSize.height() - rowHeight, option.rect.width(), rowHeight},
-                            buffer,
-                            QRect {0, bufferSize.height() - rowHeight, option.rect.width(), rowHeight});
+                painter->drawPixmap(QRect{ option.rect.x(),
+                                           option.rect.y() + bufferSize.height() - rowHeight,
+                                           option.rect.width(), rowHeight },
+                                    buffer,
+                                    QRect{ 0, bufferSize.height() - rowHeight, option.rect.width(),
+                                           rowHeight });
             }
         } else {
-            if (model && model->hasPinnedNote() &&
-                    (model->isFirstPinnedNote(index) || model->isFirstUnpinnedNote(index))) {
-                painter->drawPixmap(QRect {option.rect.x(), option.rect.y() + 25, option.rect.width(), option.rect.height()},
+            if (model && model->hasPinnedNote()
+                && (model->isFirstPinnedNote(index) || model->isFirstUnpinnedNote(index))) {
+                painter->drawPixmap(QRect{ option.rect.x(), option.rect.y() + 25,
+                                           option.rect.width(), option.rect.height() },
                                     buffer,
-                                    QRect {0, bufferSize.height() - rowHeight, option.rect.width(), rowHeight});
+                                    QRect{ 0, bufferSize.height() - rowHeight, option.rect.width(),
+                                           rowHeight });
             } else {
                 painter->drawPixmap(option.rect, buffer,
-                                    QRect {0, bufferSize.height() - rowHeight, option.rect.width(), rowHeight});
+                                    QRect{ 0, bufferSize.height() - rowHeight, option.rect.width(),
+                                           rowHeight });
             }
         }
     } else {
-        painter->drawPixmap(option.rect, buffer,
-                            QRect {0, bufferSize.height() - rowHeight, option.rect.width(), rowHeight});
+        painter->drawPixmap(
+                option.rect, buffer,
+                QRect{ 0, bufferSize.height() - rowHeight, option.rect.width(), rowHeight });
     }
 }
 
-void NoteListDelegate::paintLabels(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const
+void NoteListDelegate::paintLabels(QPainter *painter, const QStyleOptionViewItem &option,
+                                   const QModelIndex &index) const
 {
     if (m_animatedIndexes.contains(index)) {
         auto bufferSize = bufferSizeHint(option, index);
-        QPixmap buffer {bufferSize};
+        QPixmap buffer{ bufferSize };
         buffer.fill(Qt::transparent);
-        QPainter bufferPainter{&buffer};
+        QPainter bufferPainter{ &buffer };
         bufferPainter.setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform);
-        QString title{index.data(NoteListModel::NoteFullTitle).toString()};
-        QFont titleFont = (option.state & QStyle::State_Selected) == QStyle::State_Selected ? m_titleSelectedFont : m_titleFont;
+        QString title{ index.data(NoteListModel::NoteFullTitle).toString() };
+        QFont titleFont = (option.state & QStyle::State_Selected) == QStyle::State_Selected
+                ? m_titleSelectedFont
+                : m_titleFont;
         QFontMetrics fmTitle(titleFont);
         QRect fmRectTitle = fmTitle.boundingRect(title);
 
-        QString date = parseDateTime(index.data(NoteListModel::NoteLastModificationDateTime).toDateTime());
+        QString date =
+                parseDateTime(index.data(NoteListModel::NoteLastModificationDateTime).toDateTime());
         QFontMetrics fmDate(m_dateFont);
         QRect fmRectDate = fmDate.boundingRect(date);
 
-        QString parentName{index.data(NoteListModel::NoteParentName).toString()};
+        QString parentName{ index.data(NoteListModel::NoteParentName).toString() };
         QFontMetrics fmParentName(titleFont);
         QRect fmRectParentName = fmParentName.boundingRect(parentName);
 
-        QString content{index.data(NoteListModel::NoteContent).toString()};
+        QString content{ index.data(NoteListModel::NoteContent).toString() };
         content = NoteEditorLogic::getSecondLine(content);
         QFontMetrics fmContent(titleFont);
         QRect fmRectContent = fmContent.boundingRect(content);
-        double rowPosX = 0; //option.rect.x();
-        double rowPosY = 0; //option.rect.y();
-        auto model = dynamic_cast<NoteListModel*>(m_view->model());
+        double rowPosX = 0; // option.rect.x();
+        double rowPosY = 0; // option.rect.y();
+        auto model = dynamic_cast<NoteListModel *>(m_view->model());
         if (m_view->isPinnedNotesCollapsed()) {
             auto isPinned = index.data(NoteListModel::NoteIsPinned).value<bool>();
             if (isPinned) {
@@ -493,7 +513,7 @@ void NoteListDelegate::paintLabels(QPainter* painter, const QStyleOptionViewItem
 
         int fifthYOffset = 0;
         if (model && model->hasPinnedNote() && !m_view->isPinnedNotesCollapsed()
-                && model->isFirstUnpinnedNote(index)) {
+            && model->isFirstUnpinnedNote(index)) {
             fifthYOffset = NoteListConstant::lastPinnedToUnpinnedHeader;
         }
 
@@ -504,12 +524,14 @@ void NoteListDelegate::paintLabels(QPainter* painter, const QStyleOptionViewItem
         double titleRectHeight = fmRectTitle.height() + NoteListConstant::topOffsetY + yOffsets;
 
         double dateRectPosX = rowPosX + NoteListConstant::leftOffsetX;
-        double dateRectPosY = rowPosY + fmRectTitle.height() + NoteListConstant::topOffsetY + yOffsets;
+        double dateRectPosY =
+                rowPosY + fmRectTitle.height() + NoteListConstant::topOffsetY + yOffsets;
         double dateRectWidth = rowWidth - 2.0 * NoteListConstant::leftOffsetX;
         double dateRectHeight = fmRectDate.height() + NoteListConstant::titleDateSpace;
 
         double contentRectPosX = rowPosX + NoteListConstant::leftOffsetX;
-        double contentRectPosY = rowPosY + fmRectTitle.height() + fmRectDate.height() + NoteListConstant::topOffsetY + yOffsets;
+        double contentRectPosY = rowPosY + fmRectTitle.height() + fmRectDate.height()
+                + NoteListConstant::topOffsetY + yOffsets;
         double contentRectWidth = rowWidth - 2.0 * NoteListConstant::leftOffsetX;
         double contentRectHeight = fmRectContent.height() + NoteListConstant::dateDescSpace;
 
@@ -520,12 +542,14 @@ void NoteListDelegate::paintLabels(QPainter* painter, const QStyleOptionViewItem
 
         if (m_isInAllNotes) {
             folderNameRectPosX = rowPosX + NoteListConstant::leftOffsetX + 20;
-            folderNameRectPosY = rowPosY + fmRectContent.height() + fmRectTitle.height() + fmRectDate.height() + NoteListConstant::topOffsetY + yOffsets;
+            folderNameRectPosY = rowPosY + fmRectContent.height() + fmRectTitle.height()
+                    + fmRectDate.height() + NoteListConstant::topOffsetY + yOffsets;
             folderNameRectWidth = rowWidth - 2.0 * NoteListConstant::leftOffsetX;
             folderNameRectHeight = fmRectParentName.height() + NoteListConstant::descFolderSpace;
         }
 
-        auto drawStr = [&bufferPainter](double posX, double posY, double width, double height, QColor color, const QFont &font, const QString &str){
+        auto drawStr = [&bufferPainter](double posX, double posY, double width, double height,
+                                        QColor color, const QFont &font, const QString &str) {
             QRectF rect(posX, posY, width, height);
             bufferPainter.setPen(color);
             bufferPainter.setFont(font);
@@ -534,23 +558,28 @@ void NoteListDelegate::paintLabels(QPainter* painter, const QStyleOptionViewItem
         // draw title & date
         title = fmTitle.elidedText(title, Qt::ElideRight, int(titleRectWidth));
         content = fmContent.elidedText(content, Qt::ElideRight, int(titleRectWidth));
-        drawStr(titleRectPosX, titleRectPosY, titleRectWidth, titleRectHeight, m_titleColor, titleFont, title);
-        drawStr(dateRectPosX, dateRectPosY, dateRectWidth, dateRectHeight, m_dateColor, m_dateFont, date);
+        drawStr(titleRectPosX, titleRectPosY, titleRectWidth, titleRectHeight, m_titleColor,
+                titleFont, title);
+        drawStr(dateRectPosX, dateRectPosY, dateRectWidth, dateRectHeight, m_dateColor, m_dateFont,
+                date);
         if (m_isInAllNotes) {
             bufferPainter.drawImage(QRect(rowPosX + NoteListConstant::leftOffsetX,
                                           folderNameRectPosY + NoteListConstant::descFolderSpace,
-                                          16, 16), m_folderIcon);
-            drawStr(folderNameRectPosX, folderNameRectPosY, folderNameRectWidth, folderNameRectHeight, m_contentColor, titleFont, parentName);
+                                          16, 16),
+                                    m_folderIcon);
+            drawStr(folderNameRectPosX, folderNameRectPosY, folderNameRectWidth,
+                    folderNameRectHeight, m_contentColor, titleFont, parentName);
         }
-        drawStr(contentRectPosX, contentRectPosY, contentRectWidth, contentRectHeight, m_contentColor, titleFont, content);
+        drawStr(contentRectPosX, contentRectPosY, contentRectWidth, contentRectHeight,
+                m_contentColor, titleFont, content);
         painter->setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform);
         int rowHeight;
         if (m_animatedIndexes.contains(index)) {
             if (m_state != NoteListState::MoveIn) {
-                double rowRate = m_timeLine->currentFrame()/(m_maxFrame * 1.0);
+                double rowRate = m_timeLine->currentFrame() / (m_maxFrame * 1.0);
                 rowHeight = bufferSize.height() * rowRate;
             } else {
-                double rowRate = 1.0 - m_timeLine->currentFrame()/(m_maxFrame * 1.0);
+                double rowRate = 1.0 - m_timeLine->currentFrame() / (m_maxFrame * 1.0);
                 rowHeight = bufferSize.height() * rowRate;
             }
         } else {
@@ -558,25 +587,34 @@ void NoteListDelegate::paintLabels(QPainter* painter, const QStyleOptionViewItem
         }
 
         if (m_state == NoteListState::MoveIn) {
-            if (model && model->hasPinnedNote() && (model->isFirstPinnedNote(index) || model->isFirstUnpinnedNote(index))) {
-                painter->drawPixmap(
-                            QRect {option.rect.x(), option.rect.y() + bufferSize.height() - rowHeight + 25, option.rect.width(), rowHeight},
-                            buffer,
-                            QRect {0, bufferSize.height() - rowHeight, option.rect.width(), rowHeight});
+            if (model && model->hasPinnedNote()
+                && (model->isFirstPinnedNote(index) || model->isFirstUnpinnedNote(index))) {
+                painter->drawPixmap(QRect{ option.rect.x(),
+                                           option.rect.y() + bufferSize.height() - rowHeight + 25,
+                                           option.rect.width(), rowHeight },
+                                    buffer,
+                                    QRect{ 0, bufferSize.height() - rowHeight, option.rect.width(),
+                                           rowHeight });
             } else {
-                painter->drawPixmap(
-                            QRect {option.rect.x(), option.rect.y() + bufferSize.height() - rowHeight, option.rect.width(), rowHeight},
-                            buffer,
-                            QRect {0, bufferSize.height() - rowHeight, option.rect.width(), rowHeight});
+                painter->drawPixmap(QRect{ option.rect.x(),
+                                           option.rect.y() + bufferSize.height() - rowHeight,
+                                           option.rect.width(), rowHeight },
+                                    buffer,
+                                    QRect{ 0, bufferSize.height() - rowHeight, option.rect.width(),
+                                           rowHeight });
             }
         } else {
-            if (model && model->hasPinnedNote() && (model->isFirstPinnedNote(index) || model->isFirstUnpinnedNote(index))) {
-                painter->drawPixmap(QRect {option.rect.x(), option.rect.y() + 25, option.rect.width(), rowHeight},
+            if (model && model->hasPinnedNote()
+                && (model->isFirstPinnedNote(index) || model->isFirstUnpinnedNote(index))) {
+                painter->drawPixmap(QRect{ option.rect.x(), option.rect.y() + 25,
+                                           option.rect.width(), rowHeight },
                                     buffer,
-                                    QRect {0, bufferSize.height() - rowHeight, option.rect.width(), rowHeight});
+                                    QRect{ 0, bufferSize.height() - rowHeight, option.rect.width(),
+                                           rowHeight });
             } else {
                 painter->drawPixmap(option.rect, buffer,
-                                    QRect {0, bufferSize.height() - rowHeight, option.rect.width(), rowHeight});
+                                    QRect{ 0, bufferSize.height() - rowHeight, option.rect.width(),
+                                           rowHeight });
             }
         }
         if (model && model->hasPinnedNote()) {
@@ -584,19 +622,18 @@ void NoteListDelegate::paintLabels(QPainter* painter, const QStyleOptionViewItem
                 QRect headerRect(option.rect.x() + NoteListConstant::leftOffsetX, option.rect.y(),
                                  option.rect.width() - NoteListConstant::leftOffsetX, 25);
                 if (m_view->isPinnedNotesCollapsed()) {
-                    painter->drawImage(QRect(headerRect.right() - 25,
-                                             headerRect.y() + 2,
-                                             20, 20), m_pinnedCollapseIcon);
+                    painter->drawImage(QRect(headerRect.right() - 25, headerRect.y() + 2, 20, 20),
+                                       m_pinnedCollapseIcon);
                 } else {
-                    painter->drawImage(QRect(headerRect.right() - 25,
-                                             headerRect.y() + 2,
-                                             20, 20), m_pinnedExpandIcon);
+                    painter->drawImage(QRect(headerRect.right() - 25, headerRect.y() + 2, 20, 20),
+                                       m_pinnedExpandIcon);
                 }
                 painter->setPen(m_contentColor);
                 painter->setFont(m_headerFont);
                 painter->drawText(headerRect, Qt::AlignLeft | Qt::AlignVCenter, "Pinned");
             } else if (model->hasPinnedNote() && model->isFirstUnpinnedNote(index)) {
-                QRect headerRect(option.rect.x() + NoteListConstant::leftOffsetX, option.rect.y() + fifthYOffset,
+                QRect headerRect(option.rect.x() + NoteListConstant::leftOffsetX,
+                                 option.rect.y() + fifthYOffset,
                                  option.rect.width() - NoteListConstant::leftOffsetX, 25);
                 painter->setPen(m_contentColor);
                 painter->setFont(m_headerFont);
@@ -604,30 +641,32 @@ void NoteListDelegate::paintLabels(QPainter* painter, const QStyleOptionViewItem
             }
         }
     } else {
-        QString title{index.data(NoteListModel::NoteFullTitle).toString()};
-        QFont titleFont = m_view->selectionModel()->isSelected(index) ? m_titleSelectedFont : m_titleFont;
+        QString title{ index.data(NoteListModel::NoteFullTitle).toString() };
+        QFont titleFont =
+                m_view->selectionModel()->isSelected(index) ? m_titleSelectedFont : m_titleFont;
         QFontMetrics fmTitle(titleFont);
         QRect fmRectTitle = fmTitle.boundingRect(title);
 
-        QString date = parseDateTime(index.data(NoteListModel::NoteLastModificationDateTime).toDateTime());
+        QString date =
+                parseDateTime(index.data(NoteListModel::NoteLastModificationDateTime).toDateTime());
         QFontMetrics fmDate(m_dateFont);
         QRect fmRectDate = fmDate.boundingRect(date);
 
-        QString parentName{index.data(NoteListModel::NoteParentName).toString()};
+        QString parentName{ index.data(NoteListModel::NoteParentName).toString() };
         QFontMetrics fmParentName(titleFont);
         QRect fmRectParentName = fmParentName.boundingRect(parentName);
 
-        QString content{index.data(NoteListModel::NoteContent).toString()};
+        QString content{ index.data(NoteListModel::NoteContent).toString() };
         content = NoteEditorLogic::getSecondLine(content);
         QFontMetrics fmContent(titleFont);
         QRect fmRectContent = fmContent.boundingRect(content);
 
         double rowPosX = option.rect.x();
         double rowPosY = option.rect.y();
-        auto model = dynamic_cast<NoteListModel*>(m_view->model());
+        auto model = dynamic_cast<NoteListModel *>(m_view->model());
         int fifthYOffset = 0;
         if (model && model->hasPinnedNote() && !m_view->isPinnedNotesCollapsed()
-                && model->isFirstUnpinnedNote(index)) {
+            && model->isFirstUnpinnedNote(index)) {
             fifthYOffset = NoteListConstant::lastPinnedToUnpinnedHeader;
         }
         if (model) {
@@ -635,13 +674,11 @@ void NoteListDelegate::paintLabels(QPainter* painter, const QStyleOptionViewItem
                 QRect headerRect(rowPosX + NoteListConstant::leftOffsetX, rowPosY,
                                  option.rect.width() - NoteListConstant::leftOffsetX, 25);
                 if (m_view->isPinnedNotesCollapsed()) {
-                    painter->drawImage(QRect(headerRect.right() - 25,
-                                             headerRect.y() + 2,
-                                             20, 20), m_pinnedCollapseIcon);
+                    painter->drawImage(QRect(headerRect.right() - 25, headerRect.y() + 2, 20, 20),
+                                       m_pinnedCollapseIcon);
                 } else {
-                    painter->drawImage(QRect(headerRect.right() - 25,
-                                             headerRect.y() + 2,
-                                             20, 20), m_pinnedExpandIcon);
+                    painter->drawImage(QRect(headerRect.right() - 25, headerRect.y() + 2, 20, 20),
+                                       m_pinnedExpandIcon);
                 }
                 painter->setPen(m_contentColor);
                 painter->setFont(m_headerFont);
@@ -685,12 +722,14 @@ void NoteListDelegate::paintLabels(QPainter* painter, const QStyleOptionViewItem
         double titleRectHeight = fmRectTitle.height() + NoteListConstant::topOffsetY + yOffsets;
 
         double dateRectPosX = rowPosX + NoteListConstant::leftOffsetX;
-        double dateRectPosY = rowPosY + fmRectTitle.height() + NoteListConstant::topOffsetY + yOffsets;
+        double dateRectPosY =
+                rowPosY + fmRectTitle.height() + NoteListConstant::topOffsetY + yOffsets;
         double dateRectWidth = rowWidth - 2.0 * NoteListConstant::leftOffsetX;
         double dateRectHeight = fmRectDate.height() + NoteListConstant::titleDateSpace;
 
         double contentRectPosX = rowPosX + NoteListConstant::leftOffsetX;
-        double contentRectPosY = rowPosY + fmRectTitle.height() + fmRectDate.height() + NoteListConstant::topOffsetY + yOffsets;
+        double contentRectPosY = rowPosY + fmRectTitle.height() + fmRectDate.height()
+                + NoteListConstant::topOffsetY + yOffsets;
         double contentRectWidth = rowWidth - 2.0 * NoteListConstant::leftOffsetX;
         double contentRectHeight = fmRectContent.height() + NoteListConstant::dateDescSpace;
 
@@ -701,11 +740,13 @@ void NoteListDelegate::paintLabels(QPainter* painter, const QStyleOptionViewItem
 
         if (isInAllNotes()) {
             folderNameRectPosX = rowPosX + NoteListConstant::leftOffsetX + 20;
-            folderNameRectPosY = rowPosY + fmRectContent.height() + fmRectTitle.height() + fmRectDate.height() + NoteListConstant::topOffsetY + yOffsets;
+            folderNameRectPosY = rowPosY + fmRectContent.height() + fmRectTitle.height()
+                    + fmRectDate.height() + NoteListConstant::topOffsetY + yOffsets;
             folderNameRectWidth = rowWidth - 2.0 * NoteListConstant::leftOffsetX;
             folderNameRectHeight = fmRectParentName.height() + NoteListConstant::descFolderSpace;
         }
-        auto drawStr = [painter](double posX, double posY, double width, double height, QColor color, const QFont &font, const QString &str){
+        auto drawStr = [painter](double posX, double posY, double width, double height,
+                                 QColor color, const QFont &font, const QString &str) {
             QRectF rect(posX, posY, width, height);
             painter->setPen(color);
             painter->setFont(font);
@@ -715,19 +756,24 @@ void NoteListDelegate::paintLabels(QPainter* painter, const QStyleOptionViewItem
         // draw title & date
         title = fmTitle.elidedText(title, Qt::ElideRight, int(titleRectWidth));
         content = fmContent.elidedText(content, Qt::ElideRight, int(titleRectWidth));
-        drawStr(titleRectPosX, titleRectPosY, titleRectWidth, titleRectHeight, m_titleColor, titleFont, title);
-        drawStr(dateRectPosX, dateRectPosY, dateRectWidth, dateRectHeight, m_dateColor, m_dateFont, date);
+        drawStr(titleRectPosX, titleRectPosY, titleRectWidth, titleRectHeight, m_titleColor,
+                titleFont, title);
+        drawStr(dateRectPosX, dateRectPosY, dateRectWidth, dateRectHeight, m_dateColor, m_dateFont,
+                date);
         if (isInAllNotes()) {
             painter->drawImage(QRect(rowPosX + NoteListConstant::leftOffsetX,
-                                     folderNameRectPosY + NoteListConstant::descFolderSpace,
-                                     16, 16), m_folderIcon);
-            drawStr(folderNameRectPosX, folderNameRectPosY, folderNameRectWidth, folderNameRectHeight, m_contentColor, titleFont, parentName);
+                                     folderNameRectPosY + NoteListConstant::descFolderSpace, 16,
+                                     16),
+                               m_folderIcon);
+            drawStr(folderNameRectPosX, folderNameRectPosY, folderNameRectWidth,
+                    folderNameRectHeight, m_contentColor, titleFont, parentName);
         }
-        drawStr(contentRectPosX, contentRectPosY, contentRectWidth, contentRectHeight, m_contentColor, titleFont, content);
+        drawStr(contentRectPosX, contentRectPosY, contentRectWidth, contentRectHeight,
+                m_contentColor, titleFont, content);
     }
 }
 
-void NoteListDelegate::paintSeparator(QPainter*painter, QRect rect, const QModelIndex&index) const
+void NoteListDelegate::paintSeparator(QPainter *painter, QRect rect, const QModelIndex &index) const
 {
     Q_UNUSED(index);
     painter->setPen(QPen(m_separatorColor));
@@ -736,16 +782,16 @@ void NoteListDelegate::paintSeparator(QPainter*painter, QRect rect, const QModel
     int posX2 = rect.x() + rect.width() - leftOffsetX - 1;
     int posY = rect.y() + rect.height() - 1;
 
-    painter->drawLine(QPoint(posX1, posY),
-                      QPoint(posX2, posY));
+    painter->drawLine(QPoint(posX1, posY), QPoint(posX2, posY));
 }
 
-void NoteListDelegate::paintTagList(int top, QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
+void NoteListDelegate::paintTagList(int top, QPainter *painter, const QStyleOptionViewItem &option,
+                                    const QModelIndex &index) const
 {
     auto tagIds = index.data(NoteListModel::NoteTagsList).value<QSet<int>>();
     int left = option.rect.x() + 10;
 
-    for (const auto& id : qAsConst(tagIds)) {
+    for (const auto &id : qAsConst(tagIds)) {
         if (left >= option.rect.width()) {
             break;
         }
@@ -763,7 +809,7 @@ void NoteListDelegate::paintTagList(int top, QPainter *painter, const QStyleOpti
         path.addRoundedRect(rect, 10, 10);
         if (m_theme == Theme::Dark) {
             painter->fillPath(path, QColor(76, 85, 97));
-        } else if((option.state & QStyle::State_Selected) == QStyle::State_Selected) {
+        } else if ((option.state & QStyle::State_Selected) == QStyle::State_Selected) {
             painter->fillPath(path, QColor(218, 235, 248));
         } else {
             painter->fillPath(path, QColor(227, 234, 243));
@@ -782,21 +828,22 @@ void NoteListDelegate::paintTagList(int top, QPainter *painter, const QStyleOpti
     }
 }
 
-bool NoteListDelegate::shouldPaintSeparator(const QModelIndex &index, const NoteListModel &model) const
+bool NoteListDelegate::shouldPaintSeparator(const QModelIndex &index,
+                                            const NoteListModel &model) const
 {
     if (index.row() == model.rowCount() - 1) {
         return false;
     }
-    const auto& selectedIndexes = m_view->selectedIndex();
+    const auto &selectedIndexes = m_view->selectedIndex();
     bool isCurrentSelected = selectedIndexes.contains(index);
     bool isNextRowSelected = false;
-    for (const auto& selected : selectedIndexes) {
+    for (const auto &selected : selectedIndexes) {
         if (index.row() == selected.row() - 1) {
             isNextRowSelected = true;
         }
     }
-    if (!isCurrentSelected &&
-            ((index.row() == m_hoveredIndex.row() - 1) || index.row() == m_hoveredIndex.row())) {
+    if (!isCurrentSelected
+        && ((index.row() == m_hoveredIndex.row() - 1) || index.row() == m_hoveredIndex.row())) {
         return false;
     }
     if (isCurrentSelected == isNextRowSelected) {
@@ -820,12 +867,11 @@ QString NoteListDelegate::parseDateTime(const QDateTime &dateTime) const
 
     auto currDateTime = QDateTime::currentDateTime();
 
-    if(dateTime.date() == currDateTime.date()){
-        return usLocale.toString(dateTime.time(),"h:mm A");
-    }else if(dateTime.daysTo(currDateTime) == 1){
+    if (dateTime.date() == currDateTime.date()) {
+        return usLocale.toString(dateTime.time(), "h:mm A");
+    } else if (dateTime.daysTo(currDateTime) == 1) {
         return "Yesterday";
-    }else if(dateTime.daysTo(currDateTime) >= 2 &&
-             dateTime.daysTo(currDateTime) <= 7){
+    } else if (dateTime.daysTo(currDateTime) >= 2 && dateTime.daysTo(currDateTime) <= 7) {
         return usLocale.toString(dateTime.date(), "dddd");
     }
 
@@ -836,8 +882,8 @@ void NoteListDelegate::setStateI(NoteListState NewState, const QModelIndexList &
 {
     m_animatedIndexes = indexes;
 
-    auto startAnimation = [this](QTimeLine::Direction diretion, int duration){
-        for (const auto& index : qAsConst(m_animatedIndexes)) {
+    auto startAnimation = [this](QTimeLine::Direction diretion, int duration) {
+        for (const auto &index : qAsConst(m_animatedIndexes)) {
             m_view->closePersistentEditorC(index);
         }
         m_timeLine->setDirection(diretion);
@@ -845,7 +891,7 @@ void NoteListDelegate::setStateI(NoteListState NewState, const QModelIndexList &
         m_timeLine->start();
     };
 
-    switch ( NewState ){
+    switch (NewState) {
     case NoteListState::Insert:
         startAnimation(QTimeLine::Forward, m_maxFrame);
         break;
@@ -903,12 +949,13 @@ void NoteListDelegate::editorDestroyed(int id, const QModelIndex &index)
     emit sizeHintChanged(index);
 }
 
-QWidget *NoteListDelegate::createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const
+QWidget *NoteListDelegate::createEditor(QWidget *parent, const QStyleOptionViewItem &option,
+                                        const QModelIndex &index) const
 {
     if (!index.isValid()) {
         return nullptr;
     }
-    auto model = dynamic_cast<NoteListModel*>(m_view->model());
+    auto model = dynamic_cast<NoteListModel *>(m_view->model());
     if (m_view->isPinnedNotesCollapsed()) {
         auto isPinned = index.data(NoteListModel::NoteIsPinned).value<bool>();
         if (isPinned) {
@@ -923,12 +970,9 @@ QWidget *NoteListDelegate::createEditor(QWidget *parent, const QStyleOptionViewI
     }
     auto w = new NoteListDelegateEditor(this, m_view, option, index, m_tagPool, parent);
     w->setTheme(m_theme);
-    connect(this, &NoteListDelegate::themeChanged,
-            w, &NoteListDelegateEditor::setTheme);
-    connect(w, &NoteListDelegateEditor::updateSizeHint,
-            this, &NoteListDelegate::updateSizeMap);
-    connect(w, &NoteListDelegateEditor::nearDestroyed,
-            this, &NoteListDelegate::editorDestroyed);
+    connect(this, &NoteListDelegate::themeChanged, w, &NoteListDelegateEditor::setTheme);
+    connect(w, &NoteListDelegateEditor::updateSizeHint, this, &NoteListDelegate::updateSizeMap);
+    connect(w, &NoteListDelegateEditor::nearDestroyed, this, &NoteListDelegate::editorDestroyed);
     w->recalculateSize();
     return w;
 }
@@ -951,9 +995,8 @@ void NoteListDelegate::setHoveredIndex(const QModelIndex &hoveredIndex)
 void NoteListDelegate::setTheme(Theme theme)
 {
     m_theme = theme;
-    switch(m_theme){
-    case Theme::Light:
-    {
+    switch (m_theme) {
+    case Theme::Light: {
         m_titleColor = QColor(26, 26, 26);
         m_dateColor = QColor(26, 26, 26);
         m_defaultColor = QColor(247, 247, 247);
@@ -962,8 +1005,7 @@ void NoteListDelegate::setTheme(Theme theme)
         m_hoverColor = QColor(207, 207, 207);
         break;
     }
-    case Theme::Dark:
-    {
+    case Theme::Dark: {
         m_titleColor = QColor(204, 204, 204);
         m_dateColor = QColor(204, 204, 204);
         m_defaultColor = QColor(30, 30, 30);
@@ -972,8 +1014,7 @@ void NoteListDelegate::setTheme(Theme theme)
         m_hoverColor = QColor(15, 45, 90);
         break;
     }
-    case Theme::Sepia:
-    {
+    case Theme::Sepia: {
         m_titleColor = QColor(26, 26, 26);
         m_dateColor = QColor(26, 26, 26);
         m_defaultColor = QColor(251, 240, 217);

--- a/src/notelistdelegate.h
+++ b/src/notelistdelegate.h
@@ -8,22 +8,16 @@
 
 class TagPool;
 class NoteListModel;
-enum class NoteListState{
-    Normal,
-    Insert,
-    Remove,
-    MoveOut,
-    MoveIn
-};
+enum class NoteListState { Normal, Insert, Remove, MoveOut, MoveIn };
 
 class NoteListDelegate : public QStyledItemDelegate
 {
     Q_OBJECT
 
 public:
-    NoteListDelegate(NoteListView* view, TagPool *tagPool, QObject *parent = Q_NULLPTR);
+    NoteListDelegate(NoteListView *view, TagPool *tagPool, QObject *parent = Q_NULLPTR);
 
-    void setState(NoteListState NewState , QModelIndexList indexes);
+    void setState(NoteListState NewState, QModelIndexList indexes);
     void setAnimationDuration(const int duration);
 
     void paint(QPainter *painter, const QStyleOptionViewItem &option,
@@ -32,8 +26,7 @@ public:
     QSize sizeHint(const QStyleOptionViewItem &option,
                    const QModelIndex &index) const Q_DECL_OVERRIDE;
 
-    QSize bufferSizeHint(const QStyleOptionViewItem &option,
-                   const QModelIndex &index) const;
+    QSize bufferSizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const;
 
     QTimeLine::State animationState();
 
@@ -47,29 +40,33 @@ public:
     void clearSizeMap();
 
 public slots:
-    void updateSizeMap(int id, QSize sz, const QModelIndex& index);
-    void editorDestroyed(int id, const QModelIndex& index);
+    void updateSizeMap(int id, QSize sz, const QModelIndex &index);
+    void editorDestroyed(int id, const QModelIndex &index);
 
     // QAbstractItemDelegate interface
 public:
-    virtual QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+    virtual QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option,
+                                  const QModelIndex &index) const override;
     const QModelIndex &hoveredIndex() const;
-    bool shouldPaintSeparator(const QModelIndex& index, const NoteListModel& model) const;
+    bool shouldPaintSeparator(const QModelIndex &index, const NoteListModel &model) const;
 
 signals:
     void themeChanged(Theme theme);
     void animationFinished(NoteListState animationState);
 
 private:
-    void paintBackground(QPainter* painter, const QStyleOptionViewItem &option, const QModelIndex &index)const;
-    void paintLabels(QPainter* painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
+    void paintBackground(QPainter *painter, const QStyleOptionViewItem &option,
+                         const QModelIndex &index) const;
+    void paintLabels(QPainter *painter, const QStyleOptionViewItem &option,
+                     const QModelIndex &index) const;
     void paintSeparator(QPainter *painter, QRect rect, const QModelIndex &index) const;
-    void paintTagList(int top, QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
-    QString parseDateTime(const QDateTime& dateTime) const;
-    void setStateI(NoteListState NewState , const QModelIndexList &indexes);
+    void paintTagList(int top, QPainter *painter, const QStyleOptionViewItem &option,
+                      const QModelIndex &index) const;
+    QString parseDateTime(const QDateTime &dateTime) const;
+    void setStateI(NoteListState NewState, const QModelIndexList &indexes);
 
-    NoteListView* m_view;
-    TagPool* m_tagPool;
+    NoteListView *m_view;
+    TagPool *m_tagPool;
     QString m_displayFont;
     QFont m_titleFont;
     QFont m_titleSelectedFont;
@@ -96,7 +93,7 @@ private:
     Theme m_theme;
     QTimeLine *m_timeLine;
     QModelIndexList m_animatedIndexes;
-    QModelIndex m_hoveredIndex;    
+    QModelIndex m_hoveredIndex;
     QMap<int, QSize> szMap;
     QQueue<QPair<QSet<int>, NoteListState>> animationQueue;
 };

--- a/src/notelistdelegateeditor.cpp
+++ b/src/notelistdelegateeditor.cpp
@@ -18,37 +18,38 @@
 #include "taglistmodel.h"
 #include "taglistdelegate.h"
 
-NoteListDelegateEditor::NoteListDelegateEditor(const NoteListDelegate *delegate,
-                                               NoteListView *view,
+NoteListDelegateEditor::NoteListDelegateEditor(const NoteListDelegate *delegate, NoteListView *view,
                                                const QStyleOptionViewItem &option,
-                                               const QModelIndex &index,
-                                               TagPool *tagPool,
+                                               const QModelIndex &index, TagPool *tagPool,
                                                QWidget *parent)
     : QWidget(parent),
       m_delegate(delegate),
       m_option(option),
       m_id(index.data(NoteListModel::NoteID).toInt()),
       m_view(view),
-      m_tagPool{tagPool},
-      #ifdef __APPLE__
-      m_displayFont(QFont(QStringLiteral("SF Pro Text")).exactMatch() ? QStringLiteral("SF Pro Text") : QStringLiteral("Roboto")),
-      #elif _WIN32
-      m_displayFont(QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI") : QStringLiteral("Roboto")),
-      #else
+      m_tagPool{ tagPool },
+#ifdef __APPLE__
+      m_displayFont(QFont(QStringLiteral("SF Pro Text")).exactMatch()
+                            ? QStringLiteral("SF Pro Text")
+                            : QStringLiteral("Roboto")),
+#elif _WIN32
+      m_displayFont(QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI")
+                                                                   : QStringLiteral("Roboto")),
+#else
       m_displayFont(QStringLiteral("Roboto")),
-      #endif
+#endif
 
-      #ifdef __APPLE__
+#ifdef __APPLE__
       m_titleFont(m_displayFont, 13, QFont::DemiBold),
       m_titleSelectedFont(m_displayFont, 13, QFont::DemiBold),
       m_dateFont(m_displayFont, 13),
       m_headerFont(m_displayFont, 10, QFont::DemiBold),
-      #else
+#else
       m_titleFont(m_displayFont, 10, QFont::DemiBold),
       m_titleSelectedFont(m_displayFont, 10),
       m_dateFont(m_displayFont, 10),
       m_headerFont(m_displayFont, 10, QFont::DemiBold),
-      #endif
+#endif
       m_titleColor(26, 26, 26),
       m_dateColor(26, 26, 26),
       m_contentColor(142, 146, 150),
@@ -78,11 +79,11 @@ NoteListDelegateEditor::NoteListDelegateEditor(const NoteListDelegate *delegate,
     m_tagListModel->setModelData(index.data(NoteListModel::NoteTagsList).value<QSet<int>>());
     if (m_delegate->isInAllNotes()) {
         int y = 90;
-        auto model = dynamic_cast<NoteListModel*>(m_view->model());
+        auto model = dynamic_cast<NoteListModel *>(m_view->model());
         if (model) {
             auto m_index = model->getNoteIndex(m_id);
-            if (model->hasPinnedNote() &&
-                    (model->isFirstPinnedNote(m_index) || model->isFirstUnpinnedNote(m_index))) {
+            if (model->hasPinnedNote()
+                && (model->isFirstPinnedNote(m_index) || model->isFirstUnpinnedNote(m_index))) {
                 y += 25;
             }
         }
@@ -92,7 +93,7 @@ NoteListDelegateEditor::NoteListDelegateEditor(const NoteListDelegate *delegate,
         }
         int fifthYOffset = 0;
         if (model && model->hasPinnedNote() && !m_view->isPinnedNotesCollapsed()
-                && model->isFirstUnpinnedNote(index)) {
+            && model->isFirstUnpinnedNote(index)) {
             fifthYOffset = NoteListConstant::lastPinnedToUnpinnedHeader;
         }
         int yOffsets = fouthYOffset + fifthYOffset;
@@ -101,11 +102,11 @@ NoteListDelegateEditor::NoteListDelegateEditor(const NoteListDelegate *delegate,
         m_tagListView->setGeometry(10, y - 5, rect().width() - 15, m_tagListView->height());
     } else {
         int y = 70;
-        auto model = dynamic_cast<NoteListModel*>(m_view->model());
+        auto model = dynamic_cast<NoteListModel *>(m_view->model());
         if (model) {
             auto m_index = model->getNoteIndex(m_id);
-            if (model->hasPinnedNote() &&
-                    (model->isFirstPinnedNote(m_index) || model->isFirstUnpinnedNote(m_index))) {
+            if (model->hasPinnedNote()
+                && (model->isFirstPinnedNote(m_index) || model->isFirstUnpinnedNote(m_index))) {
                 y += 25;
             }
         }
@@ -115,7 +116,7 @@ NoteListDelegateEditor::NoteListDelegateEditor(const NoteListDelegate *delegate,
         }
         int fifthYOffset = 0;
         if (model && model->hasPinnedNote() && !m_view->isPinnedNotesCollapsed()
-                && model->isFirstUnpinnedNote(index)) {
+            && model->isFirstUnpinnedNote(index)) {
             fifthYOffset = NoteListConstant::lastPinnedToUnpinnedHeader;
         }
         int yOffsets = fouthYOffset + fifthYOffset;
@@ -123,14 +124,13 @@ NoteListDelegateEditor::NoteListDelegateEditor(const NoteListDelegate *delegate,
         y += yOffsets;
         m_tagListView->setGeometry(10, y - 5, rect().width() - 15, m_tagListView->height());
     }
-    connect(m_tagListView->verticalScrollBar(), &QScrollBar::valueChanged,
-            this, [this] {
-        auto m_index = dynamic_cast<NoteListModel*>(m_view->model())->getNoteIndex(m_id);
-        dynamic_cast<NoteListModel*>(m_view->model())
+    connect(m_tagListView->verticalScrollBar(), &QScrollBar::valueChanged, this, [this] {
+        auto m_index = dynamic_cast<NoteListModel *>(m_view->model())->getNoteIndex(m_id);
+        dynamic_cast<NoteListModel *>(m_view->model())
                 ->setData(m_index, getScrollBarPos(), NoteListModel::NoteTagListScrollbarPos);
     });
     QTimer::singleShot(0, this, [this] {
-        auto index = dynamic_cast<NoteListModel*>(m_view->model())->getNoteIndex(m_id);
+        auto index = dynamic_cast<NoteListModel *>(m_view->model())->getNoteIndex(m_id);
         setScrollBarPos(index.data(NoteListModel::NoteTagListScrollbarPos).toInt());
     });
     m_view->setEditorWidget(m_id, this);
@@ -143,39 +143,40 @@ NoteListDelegateEditor::~NoteListDelegateEditor()
     m_view->unsetEditorWidget(m_id, nullptr);
 }
 
-void NoteListDelegateEditor::paintBackground(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
+void NoteListDelegateEditor::paintBackground(QPainter *painter, const QStyleOptionViewItem &option,
+                                             const QModelIndex &index) const
 {
     auto bufferSize = rect().size();
-    QPixmap buffer{bufferSize};
+    QPixmap buffer{ bufferSize };
     buffer.fill(Qt::transparent);
-    QPainter bufferPainter{&buffer};
+    QPainter bufferPainter{ &buffer };
     bufferPainter.setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform);
     QRect bufferRect = buffer.rect();
-    auto model = dynamic_cast<NoteListModel*>(m_view->model());
-    if (model && model->hasPinnedNote() &&
-            (model->isFirstPinnedNote(index) || model->isFirstUnpinnedNote(index))) {
+    auto model = dynamic_cast<NoteListModel *>(m_view->model());
+    if (model && model->hasPinnedNote()
+        && (model->isFirstPinnedNote(index) || model->isFirstUnpinnedNote(index))) {
         int fifthYOffset = 0;
         if (model && model->hasPinnedNote() && !m_view->isPinnedNotesCollapsed()
-                && model->isFirstUnpinnedNote(index)) {
+            && model->isFirstUnpinnedNote(index)) {
             fifthYOffset = NoteListConstant::lastPinnedToUnpinnedHeader;
         }
         bufferRect.setY(bufferRect.y() + 25 + fifthYOffset);
     }
     auto isPinned = index.data(NoteListModel::NoteIsPinned).toBool();
-    if(m_view->selectionModel()->isSelected(index)){
-        if(qApp->applicationState() == Qt::ApplicationActive){
-            if(m_isActive){
+    if (m_view->selectionModel()->isSelected(index)) {
+        if (qApp->applicationState() == Qt::ApplicationActive) {
+            if (m_isActive) {
                 bufferPainter.fillRect(bufferRect, QBrush(m_ActiveColor));
                 m_tagListView->setBackground(m_ActiveColor);
-            }else{
+            } else {
                 bufferPainter.fillRect(bufferRect, QBrush(m_notActiveColor));
                 m_tagListView->setBackground(m_notActiveColor);
             }
-        }else if(qApp->applicationState() == Qt::ApplicationInactive){
+        } else if (qApp->applicationState() == Qt::ApplicationInactive) {
             bufferPainter.fillRect(bufferRect, QBrush(m_applicationInactiveColor));
             m_tagListView->setBackground(m_applicationInactiveColor);
         }
-    }else if (underMouseC()){
+    } else if (underMouseC()) {
         if (m_view->isDragging()) {
             if (isPinned) {
                 auto rect = bufferRect;
@@ -189,15 +190,16 @@ void NoteListDelegateEditor::paintBackground(QPainter *painter, const QStyleOpti
     } else {
         auto isPinned = index.data(NoteListModel::NoteIsPinned).value<bool>();
         if (m_view->isPinnedNotesCollapsed() && !isPinned) {
-                bufferPainter.fillRect(bufferRect, QBrush(m_defaultColor));
-                m_tagListView->setBackground(m_defaultColor);
+            bufferPainter.fillRect(bufferRect, QBrush(m_defaultColor));
+            m_tagListView->setBackground(m_defaultColor);
         } else {
             bufferPainter.fillRect(bufferRect, QBrush(m_defaultColor));
             m_tagListView->setBackground(m_defaultColor);
         }
     }
     if (m_view->isDragging() && !isPinned && !m_view->isDraggingInsidePinned()) {
-        if (model && model->isFirstUnpinnedNote(index) && (index.row() == (model->rowCount() - 1))) {
+        if (model && model->isFirstUnpinnedNote(index)
+            && (index.row() == (model->rowCount() - 1))) {
             auto rect = bufferRect;
             rect.setHeight(4);
             bufferPainter.fillRect(rect, QBrush("#d6d5d5"));
@@ -245,27 +247,30 @@ void NoteListDelegateEditor::paintBackground(QPainter *painter, const QStyleOpti
 
     auto rowHeight = rect().height();
     painter->drawPixmap(rect(), buffer,
-                        QRect {0, bufferSize.height() - rowHeight, rect().width(), rowHeight});
+                        QRect{ 0, bufferSize.height() - rowHeight, rect().width(), rowHeight });
 }
 
-void NoteListDelegateEditor::paintLabels(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const
+void NoteListDelegateEditor::paintLabels(QPainter *painter, const QStyleOptionViewItem &option,
+                                         const QModelIndex &index) const
 {
     Q_UNUSED(option);
 
-    QString title{index.data(NoteListModel::NoteFullTitle).toString()};
-    QFont titleFont = m_view->selectionModel()->isSelected(index) ? m_titleSelectedFont : m_titleFont;
+    QString title{ index.data(NoteListModel::NoteFullTitle).toString() };
+    QFont titleFont =
+            m_view->selectionModel()->isSelected(index) ? m_titleSelectedFont : m_titleFont;
     QFontMetrics fmTitle(titleFont);
     QRect fmRectTitle = fmTitle.boundingRect(title);
 
-    QString date = parseDateTime(index.data(NoteListModel::NoteLastModificationDateTime).toDateTime());
+    QString date =
+            parseDateTime(index.data(NoteListModel::NoteLastModificationDateTime).toDateTime());
     QFontMetrics fmDate(m_dateFont);
     QRect fmRectDate = fmDate.boundingRect(date);
 
-    QString parentName{index.data(NoteListModel::NoteParentName).toString()};
+    QString parentName{ index.data(NoteListModel::NoteParentName).toString() };
     QFontMetrics fmParentName(titleFont);
     QRect fmRectParentName = fmParentName.boundingRect(parentName);
 
-    QString content{index.data(NoteListModel::NoteContent).toString()};
+    QString content{ index.data(NoteListModel::NoteContent).toString() };
     content = NoteEditorLogic::getSecondLine(content);
     QFontMetrics fmContent(titleFont);
     QRect fmRectContent = fmContent.boundingRect(content);
@@ -273,10 +278,10 @@ void NoteListDelegateEditor::paintLabels(QPainter* painter, const QStyleOptionVi
     double rowPosX = rect().x();
     double rowPosY = rect().y();
     double rowWidth = rect().width();
-    auto model = dynamic_cast<NoteListModel*>(m_view->model());
+    auto model = dynamic_cast<NoteListModel *>(m_view->model());
     int fifthYOffset = 0;
     if (model && model->hasPinnedNote() && !m_view->isPinnedNotesCollapsed()
-            && model->isFirstUnpinnedNote(index)) {
+        && model->isFirstUnpinnedNote(index)) {
         fifthYOffset = NoteListConstant::lastPinnedToUnpinnedHeader;
     }
     if (model && model->hasPinnedNote()) {
@@ -284,13 +289,11 @@ void NoteListDelegateEditor::paintLabels(QPainter* painter, const QStyleOptionVi
             QRect headerRect(rowPosX + NoteListConstant::leftOffsetX, rowPosY,
                              rowWidth - NoteListConstant::leftOffsetX, 25);
             if (m_view->isPinnedNotesCollapsed()) {
-                painter->drawImage(QRect(headerRect.right() - 25,
-                                              headerRect.y() + 2,
-                                              20, 20), m_pinnedCollapseIcon);
+                painter->drawImage(QRect(headerRect.right() - 25, headerRect.y() + 2, 20, 20),
+                                   m_pinnedCollapseIcon);
             } else {
-                painter->drawImage(QRect(headerRect.right() - 25,
-                                              headerRect.y() + 2,
-                                              20, 20), m_pinnedExpandIcon);
+                painter->drawImage(QRect(headerRect.right() - 25, headerRect.y() + 2, 20, 20),
+                                   m_pinnedExpandIcon);
             }
             painter->setPen(m_contentColor);
             painter->setFont(m_headerFont);
@@ -337,7 +340,8 @@ void NoteListDelegateEditor::paintLabels(QPainter* painter, const QStyleOptionVi
     double dateRectHeight = fmRectDate.height() + NoteListConstant::titleDateSpace;
 
     double contentRectPosX = rowPosX + NoteListConstant::leftOffsetX;
-    double contentRectPosY = rowPosY + fmRectTitle.height() + fmRectDate.height() + NoteListConstant::topOffsetY + yOffsets;
+    double contentRectPosY = rowPosY + fmRectTitle.height() + fmRectDate.height()
+            + NoteListConstant::topOffsetY + yOffsets;
     double contentRectWidth = rowWidth - 2.0 * NoteListConstant::leftOffsetX;
     double contentRectHeight = fmRectContent.height() + NoteListConstant::dateDescSpace;
 
@@ -348,12 +352,13 @@ void NoteListDelegateEditor::paintLabels(QPainter* painter, const QStyleOptionVi
 
     if (m_delegate->isInAllNotes()) {
         folderNameRectPosX = rowPosX + NoteListConstant::leftOffsetX + 20;
-        folderNameRectPosY = rowPosY + fmRectContent.height() + fmRectTitle.height() + fmRectDate.height()
-                + NoteListConstant::topOffsetY + yOffsets;
+        folderNameRectPosY = rowPosY + fmRectContent.height() + fmRectTitle.height()
+                + fmRectDate.height() + NoteListConstant::topOffsetY + yOffsets;
         folderNameRectWidth = rowWidth - 2.0 * NoteListConstant::leftOffsetX;
         folderNameRectHeight = fmRectParentName.height() + NoteListConstant::descFolderSpace;
     }
-    auto drawStr = [painter](double posX, double posY, double width, double height, QColor color, const QFont &font, const QString &str){
+    auto drawStr = [painter](double posX, double posY, double width, double height, QColor color,
+                             const QFont &font, const QString &str) {
         QRectF rect(posX, posY, width, height);
         painter->setPen(color);
         painter->setFont(font);
@@ -363,18 +368,23 @@ void NoteListDelegateEditor::paintLabels(QPainter* painter, const QStyleOptionVi
     // draw title & date
     title = fmTitle.elidedText(title, Qt::ElideRight, int(titleRectWidth));
     content = fmContent.elidedText(content, Qt::ElideRight, int(titleRectWidth));
-    drawStr(titleRectPosX, titleRectPosY, titleRectWidth, titleRectHeight, m_titleColor, titleFont, title);
-    drawStr(dateRectPosX, dateRectPosY, dateRectWidth, dateRectHeight, m_dateColor, m_dateFont, date);
+    drawStr(titleRectPosX, titleRectPosY, titleRectWidth, titleRectHeight, m_titleColor, titleFont,
+            title);
+    drawStr(dateRectPosX, dateRectPosY, dateRectWidth, dateRectHeight, m_dateColor, m_dateFont,
+            date);
     if (m_delegate->isInAllNotes()) {
         painter->drawImage(QRect(rowPosX + NoteListConstant::leftOffsetX,
-                                 folderNameRectPosY + NoteListConstant::descFolderSpace,
-                                 16, 16), m_folderIcon);
-        drawStr(folderNameRectPosX, folderNameRectPosY, folderNameRectWidth, folderNameRectHeight, m_contentColor, titleFont, parentName);
+                                 folderNameRectPosY + NoteListConstant::descFolderSpace, 16, 16),
+                           m_folderIcon);
+        drawStr(folderNameRectPosX, folderNameRectPosY, folderNameRectWidth, folderNameRectHeight,
+                m_contentColor, titleFont, parentName);
     }
-    drawStr(contentRectPosX, contentRectPosY, contentRectWidth, contentRectHeight, m_contentColor, titleFont, content);
+    drawStr(contentRectPosX, contentRectPosY, contentRectWidth, contentRectHeight, m_contentColor,
+            titleFont, content);
 }
 
-void NoteListDelegateEditor::paintSeparator(QPainter*painter, const QStyleOptionViewItem& option, const QModelIndex&index) const
+void NoteListDelegateEditor::paintSeparator(QPainter *painter, const QStyleOptionViewItem &option,
+                                            const QModelIndex &index) const
 {
     Q_UNUSED(index)
     Q_UNUSED(option);
@@ -385,8 +395,7 @@ void NoteListDelegateEditor::paintSeparator(QPainter*painter, const QStyleOption
     int posX2 = rect().x() + rect().width() - leftOffsetX - 1;
     int posY = rect().y() + rect().height() - 1;
 
-    painter->drawLine(QPoint(posX1, posY),
-                      QPoint(posX2, posY));
+    painter->drawLine(QPoint(posX1, posY), QPoint(posX2, posY));
 }
 
 QString NoteListDelegateEditor::parseDateTime(const QDateTime &dateTime) const
@@ -395,12 +404,11 @@ QString NoteListDelegateEditor::parseDateTime(const QDateTime &dateTime) const
 
     auto currDateTime = QDateTime::currentDateTime();
 
-    if(dateTime.date() == currDateTime.date()){
-        return usLocale.toString(dateTime.time(),"h:mm A");
-    }else if(dateTime.daysTo(currDateTime) == 1){
+    if (dateTime.date() == currDateTime.date()) {
+        return usLocale.toString(dateTime.time(), "h:mm A");
+    } else if (dateTime.daysTo(currDateTime) == 1) {
         return "Yesterday";
-    }else if(dateTime.daysTo(currDateTime) >= 2 &&
-             dateTime.daysTo(currDateTime) <= 7){
+    } else if (dateTime.daysTo(currDateTime) >= 2 && dateTime.daysTo(currDateTime) <= 7) {
         return usLocale.toString(dateTime.date(), "dddd");
     }
 
@@ -414,13 +422,13 @@ bool NoteListDelegateEditor::underMouseC() const
 
 QPixmap NoteListDelegateEditor::renderToPixmap()
 {
-    QPixmap result{rect().size()};
+    QPixmap result{ rect().size() };
     result.fill(Qt::yellow);
     QPainter painter(&result);
     painter.setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform);
     QStyleOptionViewItem opt = m_option;
     opt.rect.setWidth(m_option.rect.width() - m_rowRightOffset);
-    auto m_index = dynamic_cast<NoteListModel*>(m_view->model())->getNoteIndex(m_id);
+    auto m_index = dynamic_cast<NoteListModel *>(m_view->model())->getNoteIndex(m_id);
     paintBackground(&painter, opt, m_index);
     paintLabels(&painter, m_option, m_index);
     return result;
@@ -432,7 +440,7 @@ void NoteListDelegateEditor::paintEvent(QPaintEvent *event)
     painter.setRenderHint(QPainter::Antialiasing);
     QStyleOptionViewItem opt = m_option;
     opt.rect.setWidth(m_option.rect.width() - m_rowRightOffset);
-    auto m_index = dynamic_cast<NoteListModel*>(m_view->model())->getNoteIndex(m_id);
+    auto m_index = dynamic_cast<NoteListModel *>(m_view->model())->getNoteIndex(m_id);
     paintBackground(&painter, opt, m_index);
     paintLabels(&painter, m_option, m_index);
     QWidget::paintEvent(event);
@@ -443,11 +451,11 @@ void NoteListDelegateEditor::resizeEvent(QResizeEvent *event)
     QWidget::resizeEvent(event);
     if (m_delegate->isInAllNotes()) {
         int y = 90;
-        auto model = dynamic_cast<NoteListModel*>(m_view->model());
+        auto model = dynamic_cast<NoteListModel *>(m_view->model());
         if (model) {
             auto m_index = model->getNoteIndex(m_id);
-            if (model->hasPinnedNote() &&
-                    (model->isFirstPinnedNote(m_index) || model->isFirstUnpinnedNote(m_index))) {
+            if (model->hasPinnedNote()
+                && (model->isFirstPinnedNote(m_index) || model->isFirstUnpinnedNote(m_index))) {
                 y += 25;
             }
             int fouthYOffset = 0;
@@ -456,7 +464,7 @@ void NoteListDelegateEditor::resizeEvent(QResizeEvent *event)
             }
             int fifthYOffset = 0;
             if (model && model->hasPinnedNote() && !m_view->isPinnedNotesCollapsed()
-                    && model->isFirstUnpinnedNote(m_index)) {
+                && model->isFirstUnpinnedNote(m_index)) {
                 fifthYOffset = NoteListConstant::lastPinnedToUnpinnedHeader;
             }
             int yOffsets = fouthYOffset + fifthYOffset;
@@ -466,11 +474,11 @@ void NoteListDelegateEditor::resizeEvent(QResizeEvent *event)
         m_tagListView->setGeometry(10, y - 5, rect().width() - 15, m_tagListView->height());
     } else {
         int y = 70;
-        auto model = dynamic_cast<NoteListModel*>(m_view->model());
+        auto model = dynamic_cast<NoteListModel *>(m_view->model());
         if (model) {
             auto m_index = model->getNoteIndex(m_id);
-            if (model->hasPinnedNote() &&
-                    (model->isFirstPinnedNote(m_index) || model->isFirstUnpinnedNote(m_index))) {
+            if (model->hasPinnedNote()
+                && (model->isFirstPinnedNote(m_index) || model->isFirstUnpinnedNote(m_index))) {
                 y += 25;
             }
             int fouthYOffset = 0;
@@ -479,7 +487,7 @@ void NoteListDelegateEditor::resizeEvent(QResizeEvent *event)
             }
             int fifthYOffset = 0;
             if (model && model->hasPinnedNote() && !m_view->isPinnedNotesCollapsed()
-                    && model->isFirstUnpinnedNote(m_index)) {
+                && model->isFirstUnpinnedNote(m_index)) {
                 fifthYOffset = NoteListConstant::lastPinnedToUnpinnedHeader;
             }
             int yOffsets = fouthYOffset + fifthYOffset;
@@ -521,11 +529,12 @@ void NoteListDelegateEditor::leaveEvent(QEvent *event)
 
 void NoteListDelegateEditor::dropEvent(QDropEvent *event)
 {
-    auto model = dynamic_cast<NoteListModel*>(m_view->model());
+    auto model = dynamic_cast<NoteListModel *>(m_view->model());
     if (model) {
         auto index = model->getNoteIndex(m_id);
         if (index.isValid()) {
-            model->dropMimeData(event->mimeData(), event->proposedAction(), index.row(), 0, QModelIndex());
+            model->dropMimeData(event->mimeData(), event->proposedAction(), index.row(), 0,
+                                QModelIndex());
         }
     }
 }
@@ -545,11 +554,11 @@ void NoteListDelegateEditor::recalculateSize()
     }
     result.setHeight(result.height() + m_tagListView->height() + 2);
     result.setWidth(rect().width());
-    auto model = dynamic_cast<NoteListModel*>(m_view->model());
+    auto model = dynamic_cast<NoteListModel *>(m_view->model());
     if (model) {
         auto m_index = model->getNoteIndex(m_id);
-        if (model->hasPinnedNote() &&
-                (model->isFirstPinnedNote(m_index) || model->isFirstUnpinnedNote(m_index))) {
+        if (model->hasPinnedNote()
+            && (model->isFirstPinnedNote(m_index) || model->isFirstUnpinnedNote(m_index))) {
             result.setHeight(result.height() + 25);
         }
         if (model->hasPinnedNote() && m_view->isPinnedNotesCollapsed()) {
@@ -579,7 +588,7 @@ void NoteListDelegateEditor::recalculateSize()
 
         int fifthYOffset = 0;
         if (model && model->hasPinnedNote() && !m_view->isPinnedNotesCollapsed()
-                && model->isFirstUnpinnedNote(m_index)) {
+            && model->isFirstUnpinnedNote(m_index)) {
             fifthYOffset = NoteListConstant::lastPinnedToUnpinnedHeader;
         }
 
@@ -607,9 +616,8 @@ void NoteListDelegateEditor::setRowRightOffset(int rowRightOffset)
 void NoteListDelegateEditor::setTheme(Theme theme)
 {
     m_theme = theme;
-    switch(m_theme){
-    case Theme::Light:
-    {
+    switch (m_theme) {
+    case Theme::Light: {
         m_titleColor = QColor(26, 26, 26);
         m_dateColor = QColor(26, 26, 26);
         m_defaultColor = QColor(247, 247, 247);
@@ -618,8 +626,7 @@ void NoteListDelegateEditor::setTheme(Theme theme)
         m_hoverColor = QColor(207, 207, 207);
         break;
     }
-    case Theme::Dark:
-    {
+    case Theme::Dark: {
         m_titleColor = QColor(204, 204, 204);
         m_dateColor = QColor(204, 204, 204);
         m_defaultColor = QColor(30, 30, 30);
@@ -628,8 +635,7 @@ void NoteListDelegateEditor::setTheme(Theme theme)
         m_hoverColor = QColor(15, 45, 90);
         break;
     }
-    case Theme::Sepia:
-    {
+    case Theme::Sepia: {
         m_titleColor = QColor(26, 26, 26);
         m_dateColor = QColor(26, 26, 26);
         m_defaultColor = QColor(251, 240, 217);

--- a/src/notelistdelegateeditor.h
+++ b/src/notelistdelegateeditor.h
@@ -10,29 +10,31 @@ class TagListModel;
 class TagListView;
 class TagListDelegate;
 class NoteListModel;
-struct NoteListConstant {
+struct NoteListConstant
+{
     static constexpr int leftOffsetX = 10;
-    static constexpr int topOffsetY = 5;   // space on top of title
-    static constexpr int titleDateSpace = 1;  // space between title and date
-    static constexpr int dateDescSpace = 4;  // space between date and description
-    static constexpr int descFolderSpace = 9;  // space between description and folder name
+    static constexpr int topOffsetY = 5; // space on top of title
+    static constexpr int titleDateSpace = 1; // space between title and date
+    static constexpr int dateDescSpace = 4; // space between date and description
+    static constexpr int descFolderSpace = 9; // space between description and folder name
     static constexpr int lastElSepSpace = 10; // space between the last element and the seperator
-    static constexpr int nextNoteOffset = 0; // space between the seperator and the next note underneath it
-    static constexpr int pinnedHeaderToNoteSpace = 0; // space between Pinned label to the pinned list
-    static constexpr int unpinnedHeaderToNoteSpace = 0; // space between Notes label and the normal notes list
-    static constexpr int lastPinnedToUnpinnedHeader = 10; // space between the last pinned note to Notes label
+    static constexpr int nextNoteOffset =
+            0; // space between the seperator and the next note underneath it
+    static constexpr int pinnedHeaderToNoteSpace =
+            0; // space between Pinned label to the pinned list
+    static constexpr int unpinnedHeaderToNoteSpace =
+            0; // space between Notes label and the normal notes list
+    static constexpr int lastPinnedToUnpinnedHeader =
+            10; // space between the last pinned note to Notes label
 };
 
 class NoteListDelegateEditor : public QWidget
 {
     Q_OBJECT
 public:
-    explicit NoteListDelegateEditor(const NoteListDelegate* delegate,
-                                    NoteListView *view,
-                                    const QStyleOptionViewItem &option,
-                                    const QModelIndex &index,
-                                    TagPool *tagPool,
-                                    QWidget *parent = nullptr);
+    explicit NoteListDelegateEditor(const NoteListDelegate *delegate, NoteListView *view,
+                                    const QStyleOptionViewItem &option, const QModelIndex &index,
+                                    TagPool *tagPool, QWidget *parent = nullptr);
     ~NoteListDelegateEditor();
 
     void setRowRightOffset(int rowRightOffset);
@@ -46,21 +48,24 @@ public:
 public slots:
     void setTheme(Theme theme);
 signals:
-    void updateSizeHint(int id, const QSize& sz, const QModelIndex& index);
-    void nearDestroyed(int id, const QModelIndex& index);
+    void updateSizeHint(int id, const QSize &sz, const QModelIndex &index);
+    void nearDestroyed(int id, const QModelIndex &index);
 
 private:
-    void paintBackground(QPainter* painter, const QStyleOptionViewItem &option, const QModelIndex &index)const;
-    void paintLabels(QPainter* painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
-    void paintSeparator(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
-    QString parseDateTime(const QDateTime& dateTime) const;
+    void paintBackground(QPainter *painter, const QStyleOptionViewItem &option,
+                         const QModelIndex &index) const;
+    void paintLabels(QPainter *painter, const QStyleOptionViewItem &option,
+                     const QModelIndex &index) const;
+    void paintSeparator(QPainter *painter, const QStyleOptionViewItem &option,
+                        const QModelIndex &index) const;
+    QString parseDateTime(const QDateTime &dateTime) const;
 
-    const NoteListDelegate* m_delegate;
+    const NoteListDelegate *m_delegate;
     QStyleOptionViewItem m_option;
     int m_id;
     NoteListView *m_view;
 
-    TagPool* m_tagPool;
+    TagPool *m_tagPool;
     QString m_displayFont;
     QFont m_titleFont;
     QFont m_titleSelectedFont;
@@ -85,9 +90,9 @@ private:
     bool m_containsMouse;
     QModelIndex m_animatedIndex;
 
-    TagListView* m_tagListView;
-    TagListModel* m_tagListModel;
-    TagListDelegate* m_tagListDelegate;
+    TagListView *m_tagListView;
+    TagListModel *m_tagListModel;
+    TagListDelegate *m_tagListDelegate;
     // QWidget interface
 protected:
     virtual void paintEvent(QPaintEvent *event) override;

--- a/src/notelistmodel.cpp
+++ b/src/notelistmodel.cpp
@@ -4,24 +4,18 @@
 #include <QTimer>
 #include <QMimeData>
 
-NoteListModel::NoteListModel(QObject *parent)
-    : QAbstractListModel(parent)
-{
-}
+NoteListModel::NoteListModel(QObject *parent) : QAbstractListModel(parent) { }
 
-NoteListModel::~NoteListModel()
-{
+NoteListModel::~NoteListModel() { }
 
-}
-
-QModelIndex NoteListModel::addNote(const NodeData& note)
+QModelIndex NoteListModel::addNote(const NodeData &note)
 {
     if (!note.isPinnedNote()) {
         const int rowCnt = rowCount();
         beginInsertRows(QModelIndex(), rowCnt, rowCnt);
         m_noteList << note;
         endInsertRows();
-        emit rowsInsertedC({createIndex(rowCnt, 0)});
+        emit rowsInsertedC({ createIndex(rowCnt, 0) });
         emit rowCountChanged();
         return createIndex(rowCnt, 0);
     } else {
@@ -29,7 +23,7 @@ QModelIndex NoteListModel::addNote(const NodeData& note)
         beginInsertRows(QModelIndex(), rowCnt, rowCnt);
         m_pinnedList << note;
         endInsertRows();
-        emit rowsInsertedC({createIndex(rowCnt, 0)});
+        emit rowsInsertedC({ createIndex(rowCnt, 0) });
         emit rowCountChanged();
         return createIndex(rowCnt, 0);
     }
@@ -46,7 +40,7 @@ QModelIndex NoteListModel::insertNote(const NodeData &note, int row)
         beginInsertRows(QModelIndex(), row, row);
         m_pinnedList.insert(row, note);
         endInsertRows();
-        emit rowsInsertedC({createIndex(row, 0)});
+        emit rowsInsertedC({ createIndex(row, 0) });
         emit rowCountChanged();
         return createIndex(row, 0);
     } else {
@@ -58,13 +52,13 @@ QModelIndex NoteListModel::insertNote(const NodeData &note, int row)
         beginInsertRows(QModelIndex(), row, row);
         m_noteList.insert(row - m_pinnedList.size(), note);
         endInsertRows();
-        emit rowsInsertedC({createIndex(row, 0)});
+        emit rowsInsertedC({ createIndex(row, 0) });
         emit rowCountChanged();
         return createIndex(row, 0);
     }
 }
 
-const NodeData& NoteListModel::getNote(const QModelIndex& index) const
+const NodeData &NoteListModel::getNote(const QModelIndex &index) const
 {
     auto row = index.row();
     if (row < m_pinnedList.size()) {
@@ -91,14 +85,15 @@ QModelIndex NoteListModel::getNoteIndex(int id) const
     return QModelIndex{};
 }
 
-void NoteListModel::setListNote(const QVector<NodeData> &notes, const ListViewInfo& inf)
+void NoteListModel::setListNote(const QVector<NodeData> &notes, const ListViewInfo &inf)
 {
     beginResetModel();
     m_pinnedList.clear();
     m_noteList.clear();
     m_listViewInfo = inf;
-    if ((!m_listViewInfo.isInTag) && (m_listViewInfo.parentFolderId != SpecialNodeID::TrashFolder)) {
-        for (const auto& note : qAsConst(notes)) {
+    if ((!m_listViewInfo.isInTag)
+        && (m_listViewInfo.parentFolderId != SpecialNodeID::TrashFolder)) {
+        for (const auto &note : qAsConst(notes)) {
             if (note.isPinnedNote()) {
                 m_pinnedList.append(note);
             } else {
@@ -118,21 +113,20 @@ void NoteListModel::removeNotes(const QModelIndexList &noteIndexes)
     emit requestRemoveNotes(noteIndexes);
 }
 
-
-bool NoteListModel::moveRow(const QModelIndex &sourceParent, int sourceRow, const QModelIndex &destinationParent, int destinationChild)
+bool NoteListModel::moveRow(const QModelIndex &sourceParent, int sourceRow,
+                            const QModelIndex &destinationParent, int destinationChild)
 {
-    if(sourceRow < 0
-            || sourceRow >= rowCount()
-            || destinationChild <0
-            || destinationChild >= rowCount()) {
+    if (sourceRow < 0 || sourceRow >= rowCount() || destinationChild < 0
+        || destinationChild >= rowCount()) {
         return false;
     }
     if (sourceRow < m_pinnedList.size() && destinationChild < m_pinnedList.size()) {
-        if (beginMoveRows(sourceParent,sourceRow,sourceRow,destinationParent,destinationChild)) {
+        if (beginMoveRows(sourceParent, sourceRow, sourceRow, destinationParent,
+                          destinationChild)) {
             m_pinnedList.move(sourceRow, destinationChild);
             endMoveRows();
-            emit rowsAboutToBeMovedC({createIndex(sourceRow, 0)});
-            emit rowsMovedC({createIndex(destinationChild, 0)});
+            emit rowsAboutToBeMovedC({ createIndex(sourceRow, 0) });
+            emit rowsMovedC({ createIndex(destinationChild, 0) });
             emit rowCountChanged();
             return true;
         }
@@ -140,11 +134,12 @@ bool NoteListModel::moveRow(const QModelIndex &sourceParent, int sourceRow, cons
     if (sourceRow >= m_pinnedList.size() && destinationChild >= m_pinnedList.size()) {
         sourceRow = sourceRow - m_pinnedList.size();
         destinationChild = destinationChild - m_pinnedList.size();
-        if (beginMoveRows(sourceParent,sourceRow,sourceRow,destinationParent,destinationChild)) {
+        if (beginMoveRows(sourceParent, sourceRow, sourceRow, destinationParent,
+                          destinationChild)) {
             m_noteList.move(sourceRow, destinationChild);
             endMoveRows();
-            emit rowsAboutToBeMovedC({createIndex(sourceRow, 0)});
-            emit rowsMovedC({createIndex(destinationChild + 1, 0)});
+            emit rowsAboutToBeMovedC({ createIndex(sourceRow, 0) });
+            emit rowsMovedC({ createIndex(destinationChild + 1, 0) });
             emit rowCountChanged();
             return true;
         }
@@ -169,7 +164,7 @@ QVariant NoteListModel::data(const QModelIndex &index, int role) const
     if (role < NoteID || role > NoteIsPinned) {
         return QVariant();
     }
-    auto getRef = [this] (int row) -> const NodeData& {
+    auto getRef = [this](int row) -> const NodeData & {
         if (row < m_pinnedList.size()) {
             return m_pinnedList[row];
         } else {
@@ -177,31 +172,31 @@ QVariant NoteListModel::data(const QModelIndex &index, int role) const
             return m_noteList[row];
         }
     };
-    const NodeData& note = getRef(index.row());
-    if(role == NoteID){
+    const NodeData &note = getRef(index.row());
+    if (role == NoteID) {
         return note.id();
-    }else if(role == NoteFullTitle){
+    } else if (role == NoteFullTitle) {
         auto text = note.fullTitle().trimmed();
         if (text.startsWith("#")) {
             text.remove(0, 1);
             text = text.trimmed();
         }
         return text;
-    }else if(role == NoteCreationDateTime){
+    } else if (role == NoteCreationDateTime) {
         return note.creationDateTime();
-    }else if(role == NoteLastModificationDateTime){
+    } else if (role == NoteLastModificationDateTime) {
         return note.lastModificationdateTime();
-    }else if(role == NoteDeletionDateTime){
+    } else if (role == NoteDeletionDateTime) {
         return note.deletionDateTime();
-    }else if(role == NoteContent){
+    } else if (role == NoteContent) {
         return note.content();
-    }else if(role == NoteScrollbarPos){
+    } else if (role == NoteScrollbarPos) {
         return note.scrollBarPosition();
-    }else if(role == NoteTagsList){
+    } else if (role == NoteTagsList) {
         return QVariant::fromValue(note.tagIds());
-    }else if(role == NoteIsTemp){
+    } else if (role == NoteIsTemp) {
         return note.isTempNote();
-    }else if(role == NoteParentName){
+    } else if (role == NoteParentName) {
         return note.parentName();
     } else if (role == NoteTagListScrollbarPos) {
         return note.tagListScrollBarPos();
@@ -218,7 +213,7 @@ bool NoteListModel::setData(const QModelIndex &index, const QVariant &value, int
         return false;
     }
 
-    auto getRef = [this] (int row) -> NodeData& {
+    auto getRef = [this](int row) -> NodeData & {
         if (row < m_pinnedList.size()) {
             return m_pinnedList[row];
         } else {
@@ -226,26 +221,26 @@ bool NoteListModel::setData(const QModelIndex &index, const QVariant &value, int
             return m_noteList[row];
         }
     };
-    NodeData& note = getRef(index.row());
-    if(role == NoteID){
+    NodeData &note = getRef(index.row());
+    if (role == NoteID) {
         note.setId(value.toInt());
-    }else if(role == NoteFullTitle){
+    } else if (role == NoteFullTitle) {
         note.setFullTitle(value.toString());
-    }else if(role == NoteCreationDateTime){
+    } else if (role == NoteCreationDateTime) {
         note.setCreationDateTime(value.toDateTime());
-    }else if(role == NoteLastModificationDateTime){
+    } else if (role == NoteLastModificationDateTime) {
         note.setLastModificationDateTime(value.toDateTime());
-    }else if(role == NoteDeletionDateTime){
+    } else if (role == NoteDeletionDateTime) {
         note.setDeletionDateTime(value.toDateTime());
-    }else if(role == NoteContent){
+    } else if (role == NoteContent) {
         note.setContent(value.toString());
-    }else if(role == NoteScrollbarPos){
+    } else if (role == NoteScrollbarPos) {
         note.setScrollBarPosition(value.toInt());
-    }else if(role == NoteTagsList) {
+    } else if (role == NoteTagsList) {
         note.setTagIds(value.value<QSet<int>>());
-    }else if(role == NoteIsTemp) {
+    } else if (role == NoteIsTemp) {
         note.setIsTempNote(value.toBool());
-    }else if(role == NoteParentName) {
+    } else if (role == NoteParentName) {
         note.setParentName(value.toString());
     } else if (role == NoteTagListScrollbarPos) {
         note.setTagListScrollBarPos(value.toInt());
@@ -253,9 +248,7 @@ bool NoteListModel::setData(const QModelIndex &index, const QVariant &value, int
         return false;
     }
 
-    emit dataChanged(this->index(index.row()),
-                     this->index(index.row()),
-                     QVector<int>(1,role));
+    emit dataChanged(this->index(index.row()), this->index(index.row()), QVector<int>(1, role));
     return true;
 }
 
@@ -265,7 +258,8 @@ Qt::ItemFlags NoteListModel::flags(const QModelIndex &index) const
         return Qt::ItemIsEnabled | Qt::ItemIsDropEnabled;
     }
 
-    return QAbstractListModel::flags(index) | Qt::ItemIsEditable | Qt::ItemIsDragEnabled | Qt::ItemIsDropEnabled;
+    return QAbstractListModel::flags(index) | Qt::ItemIsEditable | Qt::ItemIsDragEnabled
+            | Qt::ItemIsDropEnabled;
 }
 
 int NoteListModel::rowCount(const QModelIndex &parent) const
@@ -279,24 +273,27 @@ void NoteListModel::sort(int column, Qt::SortOrder order)
     Q_UNUSED(column)
     Q_UNUSED(order)
     if (m_listViewInfo.parentFolderId == SpecialNodeID::TrashFolder) {
-        std::stable_sort(m_noteList.begin(), m_noteList.end(), [](const NodeData& lhs, const NodeData& rhs){
-            return lhs.deletionDateTime() > rhs.deletionDateTime();
-        });
+        std::stable_sort(m_noteList.begin(), m_noteList.end(),
+                         [](const NodeData &lhs, const NodeData &rhs) {
+                             return lhs.deletionDateTime() > rhs.deletionDateTime();
+                         });
     } else {
-        std::stable_sort(m_pinnedList.begin(), m_pinnedList.end(), [this](const NodeData& lhs, const NodeData& rhs) {
-            if (isInAllNote()) {
-                return lhs.relativePosAN() < rhs.relativePosAN();
-            } else {
-                return lhs.relativePosition() < rhs.relativePosition();
-            }
-        });
+        std::stable_sort(m_pinnedList.begin(), m_pinnedList.end(),
+                         [this](const NodeData &lhs, const NodeData &rhs) {
+                             if (isInAllNote()) {
+                                 return lhs.relativePosAN() < rhs.relativePosAN();
+                             } else {
+                                 return lhs.relativePosition() < rhs.relativePosition();
+                             }
+                         });
 
-        std::stable_sort(m_noteList.begin(), m_noteList.end(), [](const NodeData& lhs, const NodeData& rhs){
-            return lhs.lastModificationdateTime() > rhs.lastModificationdateTime();
-        });
+        std::stable_sort(m_noteList.begin(), m_noteList.end(),
+                         [](const NodeData &lhs, const NodeData &rhs) {
+                             return lhs.lastModificationdateTime() > rhs.lastModificationdateTime();
+                         });
     }
 
-    emit dataChanged(index(0), index(rowCount()-1));
+    emit dataChanged(index(0), index(rowCount() - 1));
 }
 
 void NoteListModel::setNoteData(const QModelIndex &index, const NodeData &note)
@@ -311,8 +308,7 @@ void NoteListModel::setNoteData(const QModelIndex &index, const NodeData &note)
         row = row - m_pinnedList.size();
         m_noteList[row] = note;
     }
-    emit dataChanged(this->index(index.row()),
-                     this->index(index.row()));
+    emit dataChanged(this->index(index.row()), this->index(index.row()));
 }
 
 void NoteListModel::updatePinnedRelativePosition()
@@ -328,7 +324,8 @@ void NoteListModel::updatePinnedRelativePosition()
 
 bool NoteListModel::isInAllNote() const
 {
-    return (!m_listViewInfo.isInTag) && (m_listViewInfo.parentFolderId == SpecialNodeID::RootFolder);
+    return (!m_listViewInfo.isInTag)
+            && (m_listViewInfo.parentFolderId == SpecialNodeID::RootFolder);
 }
 
 bool NoteListModel::removeRows(int row, int count, const QModelIndex &parent)
@@ -371,7 +368,7 @@ QMimeData *NoteListModel::mimeData(const QModelIndexList &indexes) const
         return nullptr;
     }
     QStringList d;
-    for (const auto& index : indexes) {
+    for (const auto &index : indexes) {
         auto id = index.data(NoteListModel::NoteID).toInt();
         d.append(QString::number(id));
     }
@@ -383,13 +380,11 @@ QMimeData *NoteListModel::mimeData(const QModelIndexList &indexes) const
     return mimeData;
 }
 
-bool NoteListModel::dropMimeData(const QMimeData *mime,
-                                 Qt::DropAction action,
-                                 int row, int column,
+bool NoteListModel::dropMimeData(const QMimeData *mime, Qt::DropAction action, int row, int column,
                                  const QModelIndex &parent)
 {
     Q_UNUSED(column);
-    auto getRef = [this] (int row) -> NodeData& {
+    auto getRef = [this](int row) -> NodeData & {
         if (row < m_pinnedList.size()) {
             return m_pinnedList[row];
         } else {
@@ -398,8 +393,7 @@ bool NoteListModel::dropMimeData(const QMimeData *mime,
         }
     };
 
-    if (!(mime->hasFormat(NOTE_MIME) &&
-          action == Qt::MoveAction)) {
+    if (!(mime->hasFormat(NOTE_MIME) && action == Qt::MoveAction)) {
         return false;
     }
     if (row == -1) {
@@ -417,26 +411,25 @@ bool NoteListModel::dropMimeData(const QMimeData *mime,
     } else {
         toPinned = true;
     }
-    auto idl = QString::fromUtf8(mime->data(NOTE_MIME))
-            .split(QStringLiteral(PATH_SEPERATOR));
+    auto idl = QString::fromUtf8(mime->data(NOTE_MIME)).split(QStringLiteral(PATH_SEPERATOR));
     QSet<int> movedIds;
     QModelIndexList idxe;
-    for (const auto& id_s : qAsConst(idl)) {
+    for (const auto &id_s : qAsConst(idl)) {
         auto nodeId = id_s.toInt();
         idxe.append(getNoteIndex(nodeId));
     }
     emit rowsAboutToBeMovedC(idxe);
     beginResetModel();
     if (toPinned) {
-        for (const auto& index : qAsConst(idxe)) {
-            auto& note = getRef(index.row());
+        for (const auto &index : qAsConst(idxe)) {
+            auto &note = getRef(index.row());
             if (!note.isPinnedNote()) {
                 note.setIsPinnedNote(true);
                 emit requestUpdatePinned(note.id(), true);
                 m_pinnedList.prepend(m_noteList.takeAt(index.row() - m_pinnedList.size()));
             }
         }
-        for (const auto& id_s : qAsConst(idl)) {
+        for (const auto &id_s : qAsConst(idl)) {
             auto nodeId = id_s.toInt();
             for (int i = 0; i < m_pinnedList.size(); ++i) {
                 if (m_pinnedList[i].id() == nodeId) {
@@ -447,8 +440,8 @@ bool NoteListModel::dropMimeData(const QMimeData *mime,
             movedIds.insert(nodeId);
         }
     } else {
-        for (const auto& index : qAsConst(idxe)) {
-            auto& note = getRef(index.row());
+        for (const auto &index : qAsConst(idxe)) {
+            auto &note = getRef(index.row());
             movedIds.insert(note.id());
             if (!note.isPinnedNote()) {
                 continue;
@@ -458,16 +451,18 @@ bool NoteListModel::dropMimeData(const QMimeData *mime,
             int destinationChild = 0;
             if (m_listViewInfo.parentFolderId == SpecialNodeID::TrashFolder) {
                 auto lastMod = index.data(NoteDeletionDateTime).toDateTime();
-                for (destinationChild = 0; destinationChild < m_noteList.size(); ++destinationChild) {
-                    const auto& note = m_noteList[destinationChild];
+                for (destinationChild = 0; destinationChild < m_noteList.size();
+                     ++destinationChild) {
+                    const auto &note = m_noteList[destinationChild];
                     if (note.deletionDateTime() <= lastMod) {
                         break;
                     }
                 }
             } else {
                 auto lastMod = index.data(NoteLastModificationDateTime).toDateTime();
-                for (destinationChild = 0; destinationChild < m_noteList.size(); ++destinationChild) {
-                    const auto& note = m_noteList[destinationChild];
+                for (destinationChild = 0; destinationChild < m_noteList.size();
+                     ++destinationChild) {
+                    const auto &note = m_noteList[destinationChild];
                     if (note.lastModificationdateTime() <= lastMod) {
                         break;
                     }
@@ -479,7 +474,7 @@ bool NoteListModel::dropMimeData(const QMimeData *mime,
 
     endResetModel();
     QModelIndexList destinations;
-    for (const auto& id : movedIds) {
+    for (const auto &id : movedIds) {
         auto index = getNoteIndex(id);
         if (!index.isValid()) {
             continue;
@@ -504,7 +499,7 @@ QModelIndex NoteListModel::getFirstUnpinnedNote() const
 bool NoteListModel::hasPinnedNote() const
 {
     if ((!m_listViewInfo.isInTag)
-            && (m_listViewInfo.parentFolderId == SpecialNodeID::TrashFolder)) {
+        && (m_listViewInfo.parentFolderId == SpecialNodeID::TrashFolder)) {
         // Trash don't have pinned note
         return false;
     }
@@ -513,7 +508,7 @@ bool NoteListModel::hasPinnedNote() const
 
 void NoteListModel::setNotesIsPinned(const QModelIndexList &indexes, bool isPinned)
 {
-    auto getRef = [this] (int row) -> NodeData& {
+    auto getRef = [this](int row) -> NodeData & {
         if (row < m_pinnedList.size()) {
             return m_pinnedList[row];
         } else {
@@ -524,9 +519,9 @@ void NoteListModel::setNotesIsPinned(const QModelIndexList &indexes, bool isPinn
     emit requestCloseNoteEditor(indexes);
     QSet<int> needMovingIds;
     QModelIndexList needMovingIndexes;
-    for (const auto& index : indexes) {
+    for (const auto &index : indexes) {
         if (index.isValid()) {
-            NodeData& note = getRef(index.row());
+            NodeData &note = getRef(index.row());
             if (note.isPinnedNote() != isPinned) {
                 needMovingIds.insert(note.id());
                 needMovingIndexes.append(index);
@@ -540,7 +535,7 @@ void NoteListModel::setNotesIsPinned(const QModelIndexList &indexes, bool isPinn
         emit rowsAboutToBeMovedC(needMovingIndexes);
         int moved = 0;
         beginResetModel();
-        for (const auto& id : qAsConst(needMovingIds)) {
+        for (const auto &id : qAsConst(needMovingIds)) {
             auto index = getNoteIndex(id);
             if (!index.isValid()) {
                 continue;
@@ -550,11 +545,11 @@ void NoteListModel::setNotesIsPinned(const QModelIndexList &indexes, bool isPinn
                 continue;
             }
             m_pinnedList.prepend(m_noteList.takeAt(sourceRow - m_pinnedList.size()));
-            ++ moved;
+            ++moved;
         }
         endResetModel();
         QModelIndexList destinations;
-        for (const auto& id : needMovingIds) {
+        for (const auto &id : needMovingIds) {
             auto index = getNoteIndex(id);
             if (!index.isValid()) {
                 continue;
@@ -568,7 +563,7 @@ void NoteListModel::setNotesIsPinned(const QModelIndexList &indexes, bool isPinn
     } else {
         emit rowsAboutToBeMovedC(needMovingIndexes);
         beginResetModel();
-        for (const auto& id : qAsConst(needMovingIds)) {
+        for (const auto &id : qAsConst(needMovingIds)) {
             auto index = getNoteIndex(id);
             if (!index.isValid()) {
                 continue;
@@ -576,16 +571,18 @@ void NoteListModel::setNotesIsPinned(const QModelIndexList &indexes, bool isPinn
             int destinationChild = 0;
             if (m_listViewInfo.parentFolderId == SpecialNodeID::TrashFolder) {
                 auto lastMod = index.data(NoteDeletionDateTime).toDateTime();
-                for (destinationChild = 0; destinationChild < m_noteList.size(); ++destinationChild) {
-                    const auto& note = m_noteList[destinationChild];
+                for (destinationChild = 0; destinationChild < m_noteList.size();
+                     ++destinationChild) {
+                    const auto &note = m_noteList[destinationChild];
                     if (note.deletionDateTime() <= lastMod) {
                         break;
                     }
                 }
             } else {
                 auto lastMod = index.data(NoteLastModificationDateTime).toDateTime();
-                for (destinationChild = 0; destinationChild < m_noteList.size(); ++destinationChild) {
-                    const auto& note = m_noteList[destinationChild];
+                for (destinationChild = 0; destinationChild < m_noteList.size();
+                     ++destinationChild) {
+                    const auto &note = m_noteList[destinationChild];
                     if (note.lastModificationdateTime() <= lastMod) {
                         break;
                     }
@@ -595,7 +592,7 @@ void NoteListModel::setNotesIsPinned(const QModelIndexList &indexes, bool isPinn
         }
         endResetModel();
         QModelIndexList destinations;
-        for (const auto& id : needMovingIds) {
+        for (const auto &id : needMovingIds) {
             auto index = getNoteIndex(id);
             if (!index.isValid()) {
                 continue;
@@ -608,7 +605,6 @@ void NoteListModel::setNotesIsPinned(const QModelIndexList &indexes, bool isPinn
         updatePinnedRelativePosition();
     }
 }
-
 
 bool NoteListModel::noteIsHaveTag(const QModelIndex &index) const
 {
@@ -634,7 +630,7 @@ bool NoteListModel::isFirstPinnedNote(const QModelIndex &index) const
     if (index.row() > 0) {
         return false;
     }
-    auto getRef = [this] (int row) -> const NodeData& {
+    auto getRef = [this](int row) -> const NodeData & {
         if (row < m_pinnedList.size()) {
             return m_pinnedList[row];
         } else {
@@ -642,7 +638,7 @@ bool NoteListModel::isFirstPinnedNote(const QModelIndex &index) const
             return m_noteList[row];
         }
     };
-    const NodeData& note = getRef(index.row());
+    const NodeData &note = getRef(index.row());
     if (index.row() == 0 && note.isPinnedNote()) {
         return true;
     }
@@ -654,7 +650,7 @@ bool NoteListModel::isFirstUnpinnedNote(const QModelIndex &index) const
     if (!index.isValid()) {
         return false;
     }
-    auto getRef = [this] (int row) -> const NodeData& {
+    auto getRef = [this](int row) -> const NodeData & {
         if (row < m_pinnedList.size()) {
             return m_pinnedList[row];
         } else {
@@ -662,7 +658,7 @@ bool NoteListModel::isFirstUnpinnedNote(const QModelIndex &index) const
             return m_noteList[row];
         }
     };
-    const NodeData& note = getRef(index.row());
+    const NodeData &note = getRef(index.row());
     if ((index.row() - m_pinnedList.size()) == 0 && !note.isPinnedNote()) {
         return true;
     }

--- a/src/notelistmodel.h
+++ b/src/notelistmodel.h
@@ -9,7 +9,7 @@ class NoteListModel : public QAbstractListModel
 {
     Q_OBJECT
 public:
-    enum NoteRoles{
+    enum NoteRoles {
         NoteID = Qt::UserRole + 1,
         NoteFullTitle,
         NoteCreationDateTime,
@@ -27,30 +27,30 @@ public:
     explicit NoteListModel(QObject *parent = Q_NULLPTR);
     ~NoteListModel();
 
-    QModelIndex addNote(const NodeData& note);
-    QModelIndex insertNote(const NodeData& note, int row);
-    const NodeData &getNote(const QModelIndex& index) const;
+    QModelIndex addNote(const NodeData &note);
+    QModelIndex insertNote(const NodeData &note, int row);
+    const NodeData &getNote(const QModelIndex &index) const;
     QModelIndex getNoteIndex(int id) const;
-    void setListNote(const QVector<NodeData> &notes, const ListViewInfo& inf);
+    void setListNote(const QVector<NodeData> &notes, const ListViewInfo &inf);
     void removeNotes(const QModelIndexList &noteIndexes);
-    bool moveRow(const QModelIndex& sourceParent,
-                 int sourceRow,
-                 const QModelIndex& destinationParent,
-                 int destinationChild);
+    bool moveRow(const QModelIndex &sourceParent, int sourceRow,
+                 const QModelIndex &destinationParent, int destinationChild);
 
     void clearNotes();
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const Q_DECL_OVERRIDE;
-    bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) Q_DECL_OVERRIDE;
+    bool setData(const QModelIndex &index, const QVariant &value,
+                 int role = Qt::EditRole) Q_DECL_OVERRIDE;
     Qt::ItemFlags flags(const QModelIndex &index) const Q_DECL_OVERRIDE;
     int rowCount(const QModelIndex &parent = QModelIndex()) const Q_DECL_OVERRIDE;
     void sort(int column, Qt::SortOrder order) Q_DECL_OVERRIDE;
-    void setNoteData(const QModelIndex& index, const NodeData& note);
+    void setNoteData(const QModelIndex &index, const NodeData &note);
 
     virtual Qt::DropActions supportedDropActions() const override;
     virtual Qt::DropActions supportedDragActions() const override;
     virtual QStringList mimeTypes() const override;
     virtual QMimeData *mimeData(const QModelIndexList &indexes) const override;
-    virtual bool dropMimeData(const QMimeData *mime, Qt::DropAction action, int row, int column, const QModelIndex &parent) override;
+    virtual bool dropMimeData(const QMimeData *mime, Qt::DropAction action, int row, int column,
+                              const QModelIndex &parent) override;
 
     bool noteIsHaveTag(const QModelIndex &index) const;
     bool isFirstPinnedNote(const QModelIndex &index) const;
@@ -58,7 +58,7 @@ public:
     QModelIndex getFirstPinnedNote() const;
     QModelIndex getFirstUnpinnedNote() const;
     bool hasPinnedNote() const;
-    void setNotesIsPinned(const QModelIndexList& indexes, bool isPinned);
+    void setNotesIsPinned(const QModelIndexList &indexes, bool isPinned);
 
 private:
     QVector<NodeData> m_noteList;
@@ -73,12 +73,12 @@ signals:
     void requestUpdatePinnedRelPos(int noteId, int pos);
     void requestUpdatePinnedRelPosAN(int noteId, int pos);
     void requestRemoveNotes(QModelIndexList index);
-    void rowsInsertedC(const QModelIndexList& rows);
-    void rowsAboutToBeMovedC(const QModelIndexList& source);
-    void rowsMovedC(const QModelIndexList& dest);
-    void requestCloseNoteEditor(const QModelIndexList& indexes);
-    void requestOpenNoteEditor(const QModelIndexList& indexes);
-    void selectNotes(const QModelIndexList& indexes);
+    void rowsInsertedC(const QModelIndexList &rows);
+    void rowsAboutToBeMovedC(const QModelIndexList &source);
+    void rowsMovedC(const QModelIndexList &dest);
+    void requestCloseNoteEditor(const QModelIndexList &indexes);
+    void requestOpenNoteEditor(const QModelIndexList &indexes);
+    void selectNotes(const QModelIndexList &indexes);
 
     // QAbstractItemModel interface
 public:

--- a/src/notelistview.cpp
+++ b/src/notelistview.cpp
@@ -22,7 +22,7 @@
 #include "notelistdelegateeditor.h"
 
 NoteListView::NoteListView(QWidget *parent)
-    : QListView( parent ),
+    : QListView(parent),
       m_isScrollBarHidden(true),
       m_animationEnabled(true),
       m_isMousePressed(false),
@@ -31,19 +31,18 @@ NoteListView::NoteListView(QWidget *parent)
       m_currentBackgroundColor(247, 247, 247),
       m_tagPool(nullptr),
       m_dbManager(nullptr),
-      m_currentFolderId{SpecialNodeID::InvalidNodeId},
-      m_isInTrash{false},
-      m_isDragging{false},
-      m_isDraggingPinnedNotes{false},
-      m_isPinnedNotesCollapsed{false},
-      m_isDraggingInsidePinned{false}
+      m_currentFolderId{ SpecialNodeID::InvalidNodeId },
+      m_isInTrash{ false },
+      m_isDragging{ false },
+      m_isDraggingPinnedNotes{ false },
+      m_isPinnedNotesCollapsed{ false },
+      m_isDraggingInsidePinned{ false }
 {
     setAttribute(Qt::WA_MacShowFocusRect, false);
 
     QTimer::singleShot(0, this, SLOT(init()));
     setContextMenuPolicy(Qt::CustomContextMenu);
-    connect(this, &QWidget::customContextMenuRequested,
-            this, &NoteListView::onCustomContextMenu);
+    connect(this, &QWidget::customContextMenuRequested, this, &NoteListView::onCustomContextMenu);
     contextMenu = new QMenu(this);
 
     deleteNoteAction = new QAction(tr("Delete Note"), this);
@@ -68,9 +67,7 @@ NoteListView::NoteListView(QWidget *parent)
     });
 
     newNoteAction = new QAction(tr("New Note"), this);
-    connect(newNoteAction, &QAction::triggered, this, [this] {
-        emit newNoteRequested();
-    });
+    connect(newNoteAction, &QAction::triggered, this, [this] { emit newNoteRequested(); });
 
     m_dragPixmap.load("qrc:/images/notes_icon.icns");
     setDragEnabled(true);
@@ -84,10 +81,10 @@ NoteListView::~NoteListView()
     closeAllEditor();
 }
 
-void NoteListView::animateAddedRow(const QModelIndexList& indexes)
+void NoteListView::animateAddedRow(const QModelIndexList &indexes)
 {
-    NoteListDelegate* delegate = dynamic_cast<NoteListDelegate*>(itemDelegate());
-    if(delegate != Q_NULLPTR){
+    NoteListDelegate *delegate = dynamic_cast<NoteListDelegate *>(itemDelegate());
+    if (delegate != Q_NULLPTR) {
         delegate->setState(NoteListState::Insert, indexes);
     }
 }
@@ -129,9 +126,9 @@ void NoteListView::onRemoveRowRequested(const QModelIndexList &indexes)
         for (const auto index : qAsConst(indexes)) {
             m_needRemovedNotes.push_back(index.data(NoteListModel::NoteID).toInt());
         }
-        NoteListDelegate* delegate = dynamic_cast<NoteListDelegate*>(itemDelegate());
+        NoteListDelegate *delegate = dynamic_cast<NoteListDelegate *>(itemDelegate());
         if (delegate) {
-            if (m_animationEnabled){
+            if (m_animationEnabled) {
                 delegate->setState(NoteListState::Remove, indexes);
             } else {
                 delegate->setState(NoteListState::Normal, indexes);
@@ -158,7 +155,7 @@ void NoteListView::setCurrentFolderId(int newCurrentFolderId)
 void NoteListView::openPersistentEditorC(const QModelIndex &index)
 {
     if (index.isValid()) {
-        auto isHaveTag = dynamic_cast<NoteListModel*>(model())->noteIsHaveTag(index);
+        auto isHaveTag = dynamic_cast<NoteListModel *>(model())->noteIsHaveTag(index);
         if (isHaveTag) {
             auto id = index.data(NoteListModel::NoteID).toInt();
             m_openedEditor[id] = {};
@@ -194,8 +191,8 @@ void NoteListView::unsetEditorWidget(int noteId, QWidget *w)
 
 void NoteListView::closeAllEditor()
 {
-    for (const auto& id : m_openedEditor.keys()) {
-        auto index = dynamic_cast<NoteListModel*>(model())->getNoteIndex(id);
+    for (const auto &id : m_openedEditor.keys()) {
+        auto index = dynamic_cast<NoteListModel *>(model())->getNoteIndex(id);
         closePersistentEditor(index);
     }
     m_openedEditor.clear();
@@ -216,23 +213,23 @@ void NoteListView::setTagPool(TagPool *newTagPool)
     m_tagPool = newTagPool;
 }
 
-void NoteListView::rowsAboutToBeMoved(const QModelIndexList& source)
+void NoteListView::rowsAboutToBeMoved(const QModelIndexList &source)
 {
-    NoteListDelegate* delegate = dynamic_cast<NoteListDelegate*>(itemDelegate());
-    if(delegate){
-        if(m_animationEnabled){
+    NoteListDelegate *delegate = dynamic_cast<NoteListDelegate *>(itemDelegate());
+    if (delegate) {
+        if (m_animationEnabled) {
             delegate->setState(NoteListState::MoveOut, source);
-        }else{
+        } else {
             delegate->setState(NoteListState::Normal, source);
         }
     }
 }
 
-void NoteListView::rowsMoved(const QModelIndexList& dest)
+void NoteListView::rowsMoved(const QModelIndexList &dest)
 {
-    NoteListDelegate* delegate = dynamic_cast<NoteListDelegate*>(itemDelegate());
+    NoteListDelegate *delegate = dynamic_cast<NoteListDelegate *>(itemDelegate());
     if (delegate) {
-        if (m_animationEnabled){
+        if (m_animationEnabled) {
             delegate->setState(NoteListState::Insert, dest);
         } else {
             delegate->setState(NoteListState::Normal, dest);
@@ -260,22 +257,22 @@ bool NoteListView::isDraggingInsidePinned() const
     return m_isDraggingInsidePinned;
 }
 
-void NoteListView::mouseMoveEvent(QMouseEvent* event)
+void NoteListView::mouseMoveEvent(QMouseEvent *event)
 {
-    if(!m_isMousePressed) {
+    if (!m_isMousePressed) {
         QListView::mouseMoveEvent(event);
         return;
     }
     if (event->buttons() & Qt::LeftButton) {
         if ((event->pos() - m_dragStartPosition).manhattanLength()
-                >= QApplication::startDragDistance()) {
+            >= QApplication::startDragDistance()) {
             startDrag(Qt::MoveAction);
         }
     }
     //    QListView::mouseMoveEvent(event);
 }
 
-void NoteListView::mousePressEvent(QMouseEvent* e)
+void NoteListView::mousePressEvent(QMouseEvent *e)
 {
     Q_D(NoteListView);
     m_isMousePressed = true;
@@ -284,7 +281,7 @@ void NoteListView::mousePressEvent(QMouseEvent* e)
         emit noteListViewClicked();
         return;
     }
-    auto model = dynamic_cast<NoteListModel*>(this->model());
+    auto model = dynamic_cast<NoteListModel *>(this->model());
     if (model && model->isFirstPinnedNote(index)) {
         auto rect = visualRect(index);
         auto iconRect = QRect(rect.right() - 25, rect.y() + 2, 20, 20);
@@ -312,7 +309,7 @@ void NoteListView::mousePressEvent(QMouseEvent* e)
                 emit notePressed(selectedIndexes);
             } else {
                 setCurrentIndexC(index);
-                emit notePressed({index});
+                emit notePressed({ index });
             }
             m_mousePressHandled = true;
         }
@@ -320,14 +317,14 @@ void NoteListView::mousePressEvent(QMouseEvent* e)
         auto oldIndexes = selectionModel()->selectedIndexes();
         if (!oldIndexes.contains(index)) {
             setCurrentIndexC(index);
-            emit notePressed({index});
+            emit notePressed({ index });
         }
     }
     QPoint offset = d->offset();
     d->pressedPosition = e->pos() + offset;
 }
 
-void NoteListView::mouseReleaseEvent(QMouseEvent*e)
+void NoteListView::mouseReleaseEvent(QMouseEvent *e)
 {
     m_isMousePressed = false;
     auto index = indexAt(e->pos());
@@ -348,24 +345,24 @@ void NoteListView::mouseReleaseEvent(QMouseEvent*e)
             emit notePressed(selectedIndexes);
         } else {
             setCurrentIndexC(index);
-            emit notePressed({index});
+            emit notePressed({ index });
         }
     }
     m_mousePressHandled = false;
     QListView::mouseReleaseEvent(e);
 }
 
-bool NoteListView::viewportEvent(QEvent*e)
+bool NoteListView::viewportEvent(QEvent *e)
 {
-    if(model() != Q_NULLPTR){
+    if (model() != Q_NULLPTR) {
         switch (e->type()) {
-        case QEvent::Leave:{
+        case QEvent::Leave: {
             QPoint pt = mapFromGlobal(QCursor::pos());
             QModelIndex index = indexAt(QPoint(10, pt.y()));
-            if(index.row() > 0){
-                index = model()->index(index.row()-1, 0);
-                NoteListDelegate* delegate = dynamic_cast<NoteListDelegate*>(itemDelegate());
-                if(delegate != Q_NULLPTR){
+            if (index.row() > 0) {
+                index = model()->index(index.row() - 1, 0);
+                NoteListDelegate *delegate = dynamic_cast<NoteListDelegate *>(itemDelegate());
+                if (delegate != Q_NULLPTR) {
                     delegate->setHoveredIndex(QModelIndex());
                     viewport()->update(visualRect(index));
                 }
@@ -415,7 +412,7 @@ void NoteListView::dragMoveEvent(QDragMoveEvent *event)
 void NoteListView::scrollContentsBy(int dx, int dy)
 {
     QListView::scrollContentsBy(dx, dy);
-    auto m_listModel = dynamic_cast<NoteListModel*>(model());
+    auto m_listModel = dynamic_cast<NoteListModel *>(model());
     if (!m_listModel) {
         return;
     }
@@ -465,14 +462,15 @@ void NoteListView::startDrag(Qt::DropActions supportedActions)
             if (!wl.empty()) {
                 pixmap = wl.first()->grab();
             } else {
-                qDebug() << __FUNCTION__ << "Dragging row" << current.row() << "is in opened editor list but editor widget is null";
+                qDebug() << __FUNCTION__ << "Dragging row" << current.row()
+                         << "is in opened editor list but editor widget is null";
             }
         } else {
             pixmap = d->renderToPixmap(indexes, &rect);
         }
-        auto model = dynamic_cast<NoteListModel*>(this->model());
-        if (model && model->hasPinnedNote() &&
-                (model->isFirstPinnedNote(current) || model->isFirstUnpinnedNote(current))) {
+        auto model = dynamic_cast<NoteListModel *>(this->model());
+        if (model && model->hasPinnedNote()
+            && (model->isFirstPinnedNote(current) || model->isFirstUnpinnedNote(current))) {
             QRect r(0, 25, rect.width(), rect.height() - 25);
             pixmap = pixmap.copy(r);
             rect.setHeight(rect.height() - 25);
@@ -480,12 +478,16 @@ void NoteListView::startDrag(Qt::DropActions supportedActions)
         rect.adjust(horizontalOffset(), verticalOffset(), 0, 0);
     } else {
         pixmap.load(":/images/notes_icon.ico");
-        pixmap = pixmap.scaled(pixmap.width() / 3, pixmap.height() / 3,
-                               Qt::KeepAspectRatio, Qt::SmoothTransformation);
+        pixmap = pixmap.scaled(pixmap.width() / 3, pixmap.height() / 3, Qt::KeepAspectRatio,
+                               Qt::SmoothTransformation);
 #ifdef __APPLE__
-        QFont m_displayFont(QFont(QStringLiteral("SF Pro Text")).exactMatch() ? QStringLiteral("SF Pro Text") : QStringLiteral("Roboto"));
+        QFont m_displayFont(QFont(QStringLiteral("SF Pro Text")).exactMatch()
+                                    ? QStringLiteral("SF Pro Text")
+                                    : QStringLiteral("Roboto"));
 #elif _WIN32
-        QFont m_displayFont(QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI") : QStringLiteral("Roboto"));
+        QFont m_displayFont(QFont(QStringLiteral("Segoe UI")).exactMatch()
+                                    ? QStringLiteral("Segoe UI")
+                                    : QStringLiteral("Roboto"));
 #else
         QFont m_displayFont(QStringLiteral("Roboto"));
 #endif
@@ -501,14 +503,13 @@ void NoteListView::startDrag(Qt::DropActions supportedActions)
         painter.setPen(Qt::red);
         painter.drawPixmap(0, 0, pixmap);
         painter.setFont(m_displayFont);
-        painter.drawText(nameRect, Qt::AlignRight | Qt::AlignBottom,
-                         sz);
+        painter.drawText(nameRect, Qt::AlignRight | Qt::AlignBottom, sz);
         painter.end();
         std::swap(pixmap, px);
         rect = px.rect();
     }
     m_isDraggingPinnedNotes = false;
-    for (const auto& index : qAsConst(indexes)) {
+    for (const auto &index : qAsConst(indexes)) {
         if (index.data(NoteListModel::NoteIsPinned).toBool()) {
             m_isDraggingPinnedNotes = true;
             break;
@@ -520,13 +521,13 @@ void NoteListView::startDrag(Qt::DropActions supportedActions)
     if (indexes.size() == 1) {
         drag->setHotSpot(d->pressedPosition - rect.topLeft());
     } else {
-        drag->setHotSpot({0, 0});
+        drag->setHotSpot({ 0, 0 });
     }
     auto openedEditors = m_openedEditor.keys();
     m_isDragging = true;
     Qt::DropAction dropAction = drag->exec(Qt::MoveAction);
     /// Delete later, if there is no drop event.
-    if(dropAction == Qt::IgnoreAction){
+    if (dropAction == Qt::IgnoreAction) {
         drag->deleteLater();
         data->deleteLater();
     }
@@ -538,8 +539,8 @@ void NoteListView::startDrag(Qt::DropActions supportedActions)
     d->dropIndicatorRect = QRect();
     d->dropIndicatorPosition = OnItem;
     closeAllEditor();
-    for (const auto& id : qAsConst(openedEditors)) {
-        auto index = dynamic_cast<NoteListModel*>(model())->getNoteIndex(id);
+    for (const auto &id : qAsConst(openedEditors)) {
+        auto index = dynamic_cast<NoteListModel *>(model())->getNoteIndex(id);
         openPersistentEditorC(index);
     }
     scrollContentsBy(0, 0);
@@ -547,8 +548,8 @@ void NoteListView::startDrag(Qt::DropActions supportedActions)
 
 void NoteListView::setCurrentRowActive(bool isActive)
 {
-    NoteListDelegate* delegate = dynamic_cast<NoteListDelegate*>(itemDelegate());
-    if(delegate == Q_NULLPTR)
+    NoteListDelegate *delegate = dynamic_cast<NoteListDelegate *>(itemDelegate());
+    if (delegate == Q_NULLPTR)
         return;
 
     delegate->setActive(isActive);
@@ -564,66 +565,65 @@ void NoteListView::setupSignalsSlots()
 {
     // remove/add separator
     // current selectected row changed
-    connect(selectionModel(), &QItemSelectionModel::currentRowChanged, this, [this]
-            (const QModelIndex & current, const QModelIndex & previous){
+    connect(selectionModel(), &QItemSelectionModel::currentRowChanged, this,
+            [this](const QModelIndex &current, const QModelIndex &previous) {
+                if (model() != Q_NULLPTR) {
+                    if (current.row() < previous.row()) {
+                        if (current.row() > 0) {
+                            QModelIndex prevIndex = model()->index(current.row() - 1, 0);
+                            viewport()->update(visualRect(prevIndex));
+                        }
+                    }
 
-        if(model() != Q_NULLPTR){
-            if(current.row() < previous.row()){
-                if(current.row() > 0){
-                    QModelIndex prevIndex = model()->index(current.row()-1, 0);
-                    viewport()->update(visualRect(prevIndex));
+                    if (current.row() > 1) {
+                        QModelIndex prevPrevIndex = model()->index(current.row() - 2, 0);
+                        viewport()->update(visualRect(prevPrevIndex));
+                    }
                 }
-            }
-
-            if(current.row() > 1){
-                QModelIndex prevPrevIndex = model()->index(current.row()-2, 0);
-                viewport()->update(visualRect(prevPrevIndex));
-            }
-        }
-    });
+            });
 
     // row was entered
-    connect(this, &NoteListView::entered, this, [this](const QModelIndex &index){
-        if(model() != Q_NULLPTR){
-            if(index.row() > 1){
-                QModelIndex prevPrevIndex = model()->index(index.row()-2, 0);
+    connect(this, &NoteListView::entered, this, [this](const QModelIndex &index) {
+        if (model() != Q_NULLPTR) {
+            if (index.row() > 1) {
+                QModelIndex prevPrevIndex = model()->index(index.row() - 2, 0);
                 viewport()->update(visualRect(prevPrevIndex));
 
-                QModelIndex prevIndex = model()->index(index.row()-1, 0);
+                QModelIndex prevIndex = model()->index(index.row() - 1, 0);
                 viewport()->update(visualRect(prevIndex));
 
-            }else if(index.row() > 0){
-                QModelIndex prevIndex = model()->index(index.row()-1, 0);
+            } else if (index.row() > 0) {
+                QModelIndex prevIndex = model()->index(index.row() - 1, 0);
                 viewport()->update(visualRect(prevIndex));
             }
 
-            NoteListDelegate* delegate = dynamic_cast<NoteListDelegate *>(itemDelegate());
-            if(delegate != Q_NULLPTR)
+            NoteListDelegate *delegate = dynamic_cast<NoteListDelegate *>(itemDelegate());
+            if (delegate != Q_NULLPTR)
                 delegate->setHoveredIndex(index);
         }
     });
 
     // viewport was entered
-    connect(this, &NoteListView::viewportEntered, this, [this](){
-        if(model() != Q_NULLPTR && model()->rowCount() > 1){
-            NoteListDelegate* delegate = dynamic_cast<NoteListDelegate *>(itemDelegate());
-            if(delegate != Q_NULLPTR)
+    connect(this, &NoteListView::viewportEntered, this, [this]() {
+        if (model() != Q_NULLPTR && model()->rowCount() > 1) {
+            NoteListDelegate *delegate = dynamic_cast<NoteListDelegate *>(itemDelegate());
+            if (delegate != Q_NULLPTR)
                 delegate->setHoveredIndex(QModelIndex());
 
-            QModelIndex lastIndex = model()->index(model()->rowCount()-2, 0);
+            QModelIndex lastIndex = model()->index(model()->rowCount() - 2, 0);
             viewport()->update(visualRect(lastIndex));
         }
     });
 
     // remove/add offset right side
-    connect(this->verticalScrollBar(), &QScrollBar::rangeChanged, this, [this](int min, int max){
+    connect(this->verticalScrollBar(), &QScrollBar::rangeChanged, this, [this](int min, int max) {
         Q_UNUSED(min)
 
-        NoteListDelegate* delegate = dynamic_cast<NoteListDelegate*>(itemDelegate());
-        if(delegate != Q_NULLPTR){
-            if(max > 0){
+        NoteListDelegate *delegate = dynamic_cast<NoteListDelegate *>(itemDelegate());
+        if (delegate != Q_NULLPTR) {
+            if (max > 0) {
                 delegate->setRowRightOffset(2);
-            }else{
+            } else {
                 delegate->setRowRightOffset(0);
             }
             viewport()->update();
@@ -637,26 +637,30 @@ void NoteListView::setupSignalsSlots()
 void NoteListView::setupStyleSheet()
 {
 #if defined(Q_OS_LINUX) || defined(Q_OS_WINDOWS) || defined(Q_OS_WIN)
-    QString ss = QString("QListView {background-color: %1;} "
-                         "QScrollBar::handle:vertical:hover { background: rgba(40, 40, 40, 0.5); }"
-                         "QScrollBar::handle:vertical:pressed { background: rgba(40, 40, 40, 0.5); }"
-                         "QScrollBar::handle:vertical { border-radius: 4px; background: rgba(100, 100, 100, 0.5); min-height: 20px; }"
-                         "QScrollBar::vertical {border-radius: 6px; width: 10px; color: rgba(255, 255, 255,0);}"
-                         "QScrollBar {margin-right: 2px; background: transparent;}"
-                         "QScrollBar::add-line:vertical { width:0px; height: 0px; subcontrol-position: bottom; subcontrol-origin: margin; }"
-                         "QScrollBar::sub-line:vertical { width:0px; height: 0px; subcontrol-position: top; subcontrol-origin: margin; }"
-                         ).arg(m_currentBackgroundColor.name());
+    QString ss =
+            QString("QListView {background-color: %1;} "
+                    "QScrollBar::handle:vertical:hover { background: rgba(40, 40, 40, 0.5); }"
+                    "QScrollBar::handle:vertical:pressed { background: rgba(40, 40, 40, 0.5); }"
+                    "QScrollBar::handle:vertical { border-radius: 4px; background: rgba(100, 100, "
+                    "100, 0.5); min-height: 20px; }"
+                    "QScrollBar::vertical {border-radius: 6px; width: 10px; color: rgba(255, 255, "
+                    "255,0);}"
+                    "QScrollBar {margin-right: 2px; background: transparent;}"
+                    "QScrollBar::add-line:vertical { width:0px; height: 0px; subcontrol-position: "
+                    "bottom; subcontrol-origin: margin; }"
+                    "QScrollBar::sub-line:vertical { width:0px; height: 0px; subcontrol-position: "
+                    "top; subcontrol-origin: margin; }")
+                    .arg(m_currentBackgroundColor.name());
 #else
-    QString ss = QString("QListView {background-color: %1;} "
-                         ).arg(m_currentBackgroundColor.name());
+    QString ss = QString("QListView {background-color: %1;} ").arg(m_currentBackgroundColor.name());
 #endif
     setStyleSheet(ss);
 }
 
 void NoteListView::addNotesToTag(QSet<int> notesId, int tagId)
 {
-    for (const auto& id: qAsConst(notesId)) {
-        auto model = dynamic_cast<NoteListModel*>(this->model());
+    for (const auto &id : qAsConst(notesId)) {
+        auto model = dynamic_cast<NoteListModel *>(this->model());
         if (model) {
             auto index = model->getNoteIndex(id);
             if (index.isValid()) {
@@ -668,8 +672,8 @@ void NoteListView::addNotesToTag(QSet<int> notesId, int tagId)
 
 void NoteListView::removeNotesFromTag(QSet<int> notesId, int tagId)
 {
-    for (const auto& id: qAsConst(notesId)) {
-        auto model = dynamic_cast<NoteListModel*>(this->model());
+    for (const auto &id : qAsConst(notesId)) {
+        auto model = dynamic_cast<NoteListModel *>(this->model());
         if (model) {
             auto index = model->getNoteIndex(id);
             if (index.isValid()) {
@@ -679,11 +683,12 @@ void NoteListView::removeNotesFromTag(QSet<int> notesId, int tagId)
     }
 }
 
-void NoteListView::selectionChanged(const QItemSelection &selected, const QItemSelection &deselected)
+void NoteListView::selectionChanged(const QItemSelection &selected,
+                                    const QItemSelection &deselected)
 {
     QListView::selectionChanged(selected, deselected);
     QSet<int> ids;
-    for (const auto& index : selectedIndexes()) {
+    for (const auto &index : selectedIndexes()) {
         ids.insert(index.data(NoteListModel::NoteID).toInt());
     }
     emit saveSelectedNote(ids);
@@ -694,19 +699,16 @@ void NoteListView::selectionChanged(const QItemSelection &selected, const QItemS
  */
 void NoteListView::setTheme(Theme theme)
 {
-    switch(theme){
-    case Theme::Light:
-    {
+    switch (theme) {
+    case Theme::Light: {
         m_currentBackgroundColor = QColor(247, 247, 247);
         break;
     }
-    case Theme::Dark:
-    {
+    case Theme::Dark: {
         m_currentBackgroundColor = QColor(30, 30, 30);
         break;
     }
-    case Theme::Sepia:
-    {
+    case Theme::Sepia: {
         m_currentBackgroundColor = QColor(251, 240, 217);
         break;
     }
@@ -725,7 +727,7 @@ void NoteListView::onCustomContextMenu(QPoint point)
             indexList = selectionModel()->selectedIndexes();
         }
         QSet<int> notes;
-        for (const auto& idx : qAsConst(indexList)) {
+        for (const auto &idx : qAsConst(indexList)) {
             notes.insert(idx.data(NoteListModel::NoteID).toInt());
         }
         contextMenu->clear();
@@ -735,23 +737,22 @@ void NoteListView::onCustomContextMenu(QPoint point)
                 delete action;
             }
             m_noteTagActions.clear();
-            auto createTagIcon = [](const QString& color) -> QIcon{
-                QPixmap pix{32, 32};
+            auto createTagIcon = [](const QString &color) -> QIcon {
+                QPixmap pix{ 32, 32 };
                 pix.fill(Qt::transparent);
-                QPainter painter{&pix};
+                QPainter painter{ &pix };
                 painter.setRenderHint(QPainter::Antialiasing);
-                auto iconRect = QRect((pix.width() - 30) / 2,
-                                      (pix.height() - 30) / 2, 30, 30);
+                auto iconRect = QRect((pix.width() - 30) / 2, (pix.height() - 30) / 2, 30, 30);
                 painter.setBrush(QColor(color));
                 painter.setPen(QColor(color));
                 painter.drawEllipse(iconRect);
-                return QIcon{pix};
+                return QIcon{ pix };
             };
             QSet<int> tagInNote;
             const auto tagIds = m_tagPool->tagIds();
-            for (const auto& id : tagIds) {
+            for (const auto &id : tagIds) {
                 bool all = true;
-                for (const auto& index : qAsConst(indexList)) {
+                for (const auto &index : qAsConst(indexList)) {
                     auto tags = index.data(NoteListModel::NoteTagsList).value<QSet<int>>();
                     if (!tags.contains(id)) {
                         all = false;
@@ -765,9 +766,8 @@ void NoteListView::onCustomContextMenu(QPoint point)
             for (auto id : qAsConst(tagInNote)) {
                 auto tag = m_tagPool->getTag(id);
                 auto tagAction = new QAction(QString("Remove tag ") + tag.name(), this);
-                connect(tagAction, &QAction::triggered, this, [this, id, notes] {
-                    removeNotesFromTag(notes, id);
-                });
+                connect(tagAction, &QAction::triggered, this,
+                        [this, id, notes] { removeNotesFromTag(notes, id); });
                 tagAction->setIcon(createTagIcon(tag.color()));
                 tagsMenu->addAction(tagAction);
                 m_noteTagActions.append(tagAction);
@@ -779,9 +779,8 @@ void NoteListView::onCustomContextMenu(QPoint point)
                 }
                 auto tag = m_tagPool->getTag(id);
                 auto tagAction = new QAction(QString("Assign tag ") + tag.name(), this);
-                connect(tagAction, &QAction::triggered, this, [this, id, notes] {
-                    addNotesToTag(notes, id);
-                });
+                connect(tagAction, &QAction::triggered, this,
+                        [this, id, notes] { addNotesToTag(notes, id); });
                 tagAction->setIcon(createTagIcon(tag.color()));
                 tagsMenu->addAction(tagAction);
                 m_noteTagActions.append(tagAction);
@@ -801,16 +800,15 @@ void NoteListView::onCustomContextMenu(QPoint point)
             deleteNoteAction->setText(tr("Delete Note"));
         }
         contextMenu->addAction(deleteNoteAction);
-        if ((!m_listViewInfo.isInTag) && (m_listViewInfo.parentFolderId != SpecialNodeID::TrashFolder)) {
+        if ((!m_listViewInfo.isInTag)
+            && (m_listViewInfo.parentFolderId != SpecialNodeID::TrashFolder)) {
             contextMenu->addSeparator();
             if (notes.size() > 1) {
                 pinNoteAction->setText(tr("Pin Notes"));
                 unpinNoteAction->setText(tr("Unpin Notes"));
-                enum class ShowAction {
-                    NotInit, ShowPin, ShowBoth, ShowUnpin
-                };
+                enum class ShowAction { NotInit, ShowPin, ShowBoth, ShowUnpin };
                 ShowAction a = ShowAction::NotInit;
-                for (const auto& idx : qAsConst(indexList)) {
+                for (const auto &idx : qAsConst(indexList)) {
                     if (idx.data(NoteListModel::NoteIsPinned).toBool()) {
                         if (a == ShowAction::ShowPin) {
                             a = ShowAction::ShowBoth;
@@ -858,16 +856,15 @@ void NoteListView::onCustomContextMenu(QPoint point)
             auto m = contextMenu->addMenu("Move to");
             FolderListType folders;
             QMetaObject::invokeMethod(m_dbManager, "getFolderList", Qt::BlockingQueuedConnection,
-                                      Q_RETURN_ARG(FolderListType, folders)
-                                      );
-            for (const auto& id: folders.keys()) {
+                                      Q_RETURN_ARG(FolderListType, folders));
+            for (const auto &id : folders.keys()) {
                 if (id == m_currentFolderId) {
                     continue;
                 }
                 auto action = new QAction(folders[id], this);
                 connect(action, &QAction::triggered, this, [this, id] {
                     auto indexes = selectedIndexes();
-                    for (const auto& index: qAsConst(indexes)) {
+                    for (const auto &index : qAsConst(indexes)) {
                         if (index.isValid()) {
                             emit moveNoteRequested(index.data(NoteListModel::NoteID).toInt(), id);
                         }
@@ -886,7 +883,7 @@ void NoteListView::onCustomContextMenu(QPoint point)
 void NoteListView::onAnimationFinished(NoteListState state)
 {
     if (state == NoteListState::Remove) {
-        auto model = dynamic_cast<NoteListModel*>(this->model());
+        auto model = dynamic_cast<NoteListModel *>(this->model());
         if (model) {
             for (const auto id : qAsConst(m_needRemovedNotes)) {
                 auto index = model->getNoteIndex(id);
@@ -934,7 +931,6 @@ QPixmap NoteListViewPrivate::renderToPixmap(const QModelIndexList &indexes, QRec
 #else
         delegateForIndex(current)->paint(&painter, option, current);
 #endif
-
     }
     return pixmap;
 }
@@ -949,5 +945,4 @@ QStyleOptionViewItem NoteListViewPrivate::viewOptionsV1() const
 #else
     return q->viewOptions();
 #endif
-
 }

--- a/src/notelistview.h
+++ b/src/notelistview.h
@@ -15,29 +15,29 @@ class NoteListView : public QListView
     Q_OBJECT
 
 public:
-    explicit NoteListView(QWidget* parent = Q_NULLPTR);
+    explicit NoteListView(QWidget *parent = Q_NULLPTR);
     ~NoteListView();
 
     void animateAddedRow(const QModelIndexList &indexes);
     void setAnimationEnabled(bool isEnabled);
     void setCurrentRowActive(bool isActive);
-    void setTheme(Theme theme);    
+    void setTheme(Theme theme);
     void setTagPool(TagPool *newTagPool);
     void setIsInTrash(bool newIsInTrash);
     void setDbManager(DBManager *newDbManager);
 
     void setCurrentFolderId(int newCurrentFolderId);
-    void openPersistentEditorC(const QModelIndex& index);
-    void closePersistentEditorC(const QModelIndex& index);
-    void setEditorWidget(int noteId, QWidget* w);
-    void unsetEditorWidget(int noteId, QWidget* w);
-    void closeAllEditor();    
+    void openPersistentEditorC(const QModelIndex &index);
+    void closePersistentEditorC(const QModelIndex &index);
+    void setEditorWidget(int noteId, QWidget *w);
+    void unsetEditorWidget(int noteId, QWidget *w);
+    void closeAllEditor();
     void setListViewInfo(const ListViewInfo &newListViewInfo);
     bool isDragging() const;
 
     bool isPinnedNotesCollapsed() const;
     void setIsPinnedNotesCollapsed(bool newIsPinnedNotesCollapsed);
-    void setCurrentIndexC(const QModelIndex& index);
+    void setCurrentIndexC(const QModelIndex &index);
     QModelIndexList selectedIndex() const;
     bool isDraggingInsidePinned() const;
 
@@ -47,10 +47,10 @@ public slots:
     void onAnimationFinished(NoteListState state);
 
 protected:
-    void mouseMoveEvent(QMouseEvent* event) Q_DECL_OVERRIDE;
-    void mousePressEvent(QMouseEvent* e) Q_DECL_OVERRIDE;
-    void mouseReleaseEvent(QMouseEvent* e) Q_DECL_OVERRIDE;
-    bool viewportEvent(QEvent* e) Q_DECL_OVERRIDE;
+    void mouseMoveEvent(QMouseEvent *event) Q_DECL_OVERRIDE;
+    void mousePressEvent(QMouseEvent *e) Q_DECL_OVERRIDE;
+    void mouseReleaseEvent(QMouseEvent *e) Q_DECL_OVERRIDE;
+    bool viewportEvent(QEvent *e) Q_DECL_OVERRIDE;
     virtual void dragEnterEvent(QDragEnterEvent *event) override;
     virtual void dragMoveEvent(QDragMoveEvent *event) override;
 
@@ -62,22 +62,22 @@ protected:
 public slots:
     void rowsAboutToBeMoved(const QModelIndexList &source);
     void rowsMoved(const QModelIndexList &dest);
-    void onRowsInserted(const QModelIndexList& rows);
+    void onRowsInserted(const QModelIndexList &rows);
 
 private slots:
     void init();
 
 signals:
-    void addTagRequested(const QModelIndex& index, int tadId);
-    void removeTagRequested(const QModelIndex& index, int tadId);
-    void deleteNoteRequested(const QModelIndexList& index);
-    void restoreNoteRequested(const QModelIndexList& indexes);
+    void addTagRequested(const QModelIndex &index, int tadId);
+    void removeTagRequested(const QModelIndex &index, int tadId);
+    void deleteNoteRequested(const QModelIndexList &index);
+    void restoreNoteRequested(const QModelIndexList &indexes);
     void newNoteRequested();
     void moveNoteRequested(int noteId, int folderId);
-    void setPinnedNoteRequested(const QModelIndexList& indexes, bool isPinned);
-    void saveSelectedNote(const QSet<int>& noteId);
+    void setPinnedNoteRequested(const QModelIndexList &indexes, bool isPinned);
+    void saveSelectedNote(const QSet<int> &noteId);
     void pinnedCollapseChanged();
-    void notePressed(const QModelIndexList& selected);
+    void notePressed(const QModelIndexList &selected);
     void noteListViewClicked();
 
 private:
@@ -87,21 +87,21 @@ private:
     bool m_mousePressHandled;
     int m_rowHeight;
     QColor m_currentBackgroundColor;
-    QMenu* contextMenu;
-    QAction* deleteNoteAction;
-    QAction* restoreNoteAction;
-    QAction* pinNoteAction;
-    QAction* unpinNoteAction;
-    QAction* newNoteAction;
-    TagPool* m_tagPool;
-    DBManager* m_dbManager;
+    QMenu *contextMenu;
+    QAction *deleteNoteAction;
+    QAction *restoreNoteAction;
+    QAction *pinNoteAction;
+    QAction *unpinNoteAction;
+    QAction *newNoteAction;
+    TagPool *m_tagPool;
+    DBManager *m_dbManager;
     int m_currentFolderId;
-    QVector<QAction*> m_noteTagActions;
-    QVector<QAction*> m_folderActions;
+    QVector<QAction *> m_noteTagActions;
+    QVector<QAction *> m_folderActions;
     bool m_isInTrash;
     QPoint m_dragStartPosition;
     QPixmap m_dragPixmap;
-    QMap<int, QVector<QWidget*>> m_openedEditor;
+    QMap<int, QVector<QWidget *>> m_openedEditor;
     QVector<int> m_needRemovedNotes;
     ListViewInfo m_listViewInfo;
     bool m_isDragging;
@@ -113,12 +113,14 @@ private:
 
     void addNotesToTag(QSet<int> notesId, int tagId);
     void removeNotesFromTag(QSet<int> notesId, int tagId);
+
 private:
     Q_DECLARE_PRIVATE(NoteListView)
 
     // QAbstractItemView interface
 protected slots:
-    void selectionChanged(const QItemSelection &selected, const QItemSelection &deselected) override;
+    void selectionChanged(const QItemSelection &selected,
+                          const QItemSelection &deselected) override;
 };
 
 #endif // NOTELISTVIEW_H

--- a/src/notelistview_p.h
+++ b/src/notelistview_p.h
@@ -8,8 +8,8 @@ class NoteListViewPrivate : public QAbstractItemViewPrivate
     Q_DECLARE_PUBLIC(NoteListView)
 
 public:
-    NoteListViewPrivate(): QAbstractItemViewPrivate() {};
-    virtual ~NoteListViewPrivate() {}
+    NoteListViewPrivate() : QAbstractItemViewPrivate(){};
+    virtual ~NoteListViewPrivate() { }
     QPixmap renderToPixmap(const QModelIndexList &indexes, QRect *r) const;
     QStyleOptionViewItem viewOptionsV1() const;
 };

--- a/src/pushbuttontype.cpp
+++ b/src/pushbuttontype.cpp
@@ -1,10 +1,7 @@
 #include "pushbuttontype.h"
 #include <QEvent>
 
-PushButtonType::PushButtonType(QWidget *parent) : QPushButton(parent)
-{
-
-}
+PushButtonType::PushButtonType(QWidget *parent) : QPushButton(parent) { }
 
 bool PushButtonType::event(QEvent *event)
 {
@@ -22,7 +19,7 @@ bool PushButtonType::event(QEvent *event)
         setIcon(hoveredIcon);
     }
 
-    if (event->type() == QEvent::Leave){
+    if (event->type() == QEvent::Leave) {
         setIcon(normalIcon);
     }
     return QPushButton::event(event);

--- a/src/singleinstance.cpp
+++ b/src/singleinstance.cpp
@@ -1,11 +1,8 @@
 #include "singleinstance.h"
 
-
-SingleInstance::SingleInstance(QObject *parent)
-    : QObject(parent)
+SingleInstance::SingleInstance(QObject *parent) : QObject(parent)
 {
-    connect(&m_server, &QLocalServer::newConnection,
-            [this](){emit newInstance();});
+    connect(&m_server, &QLocalServer::newConnection, [this]() { emit newInstance(); });
 }
 
 void SingleInstance::listen(const QString &name)

--- a/src/singleinstance.h
+++ b/src/singleinstance.h
@@ -18,7 +18,7 @@ signals:
     void newInstance();
 
 private:
-    QLocalSocket* m_socket;
+    QLocalSocket *m_socket;
     QLocalServer m_server;
 };
 

--- a/src/splitterstyle.cpp
+++ b/src/splitterstyle.cpp
@@ -1,15 +1,11 @@
 #include "splitterstyle.h"
 
-SplitterStyle::SplitterStyle()
-{
+SplitterStyle::SplitterStyle() { }
 
-}
-
-void SplitterStyle::drawControl(ControlElement element, const QStyleOption *opt, QPainter *p, const QWidget *w) const
+void SplitterStyle::drawControl(ControlElement element, const QStyleOption *opt, QPainter *p,
+                                const QWidget *w) const
 {
-    if(element != QStyle::CE_Splitter)
-    {
+    if (element != QStyle::CE_Splitter) {
         QProxyStyle::drawControl(element, opt, p, w);
     }
 }
-

--- a/src/splitterstyle.h
+++ b/src/splitterstyle.h
@@ -6,11 +6,12 @@
 class SplitterStyle : public QProxyStyle
 {
 public:
-	SplitterStyle();
+    SplitterStyle();
 
     // QStyle interface
 public:
-    virtual void drawControl(ControlElement element, const QStyleOption *opt, QPainter *p, const QWidget *w) const override;
+    virtual void drawControl(ControlElement element, const QStyleOption *opt, QPainter *p,
+                             const QWidget *w) const override;
 };
 
 #endif // SPLITTERSTYLE_H

--- a/src/styleeditorwindow.cpp
+++ b/src/styleeditorwindow.cpp
@@ -8,21 +8,24 @@
 /**
  * Initializes the window components and configures the StyleEditorWindow
  */
-StyleEditorWindow::StyleEditorWindow(QWidget *parent) :
-    QWidget(parent),
-    m_ui(new Ui::StyleEditorWindow),
-    m_currentlyClickedButton(Q_NULLPTR),
-    m_currentSelectedFontButton(Q_NULLPTR),
-    m_currentSelectedThemeButton(Q_NULLPTR),
-    m_isFullWidthClicked(false)
+StyleEditorWindow::StyleEditorWindow(QWidget *parent)
+    : QWidget(parent),
+      m_ui(new Ui::StyleEditorWindow),
+      m_currentlyClickedButton(Q_NULLPTR),
+      m_currentSelectedFontButton(Q_NULLPTR),
+      m_currentSelectedThemeButton(Q_NULLPTR),
+      m_isFullWidthClicked(false)
 {
     m_ui->setupUi(this);
     this->setWindowTitle(tr("Editor Settings"));
     this->setWindowFlags(Qt::Window | Qt::WindowStaysOnTopHint);
 
-    m_ui->serifButton->setToolTip("Change the text editor font to a serif font.\nClick again to try different fonts");
-    m_ui->sansSerifButton->setToolTip("Change the text editor font to a sans-serif font.\nClick again to try different fonts");
-    m_ui->monoButton->setToolTip("Change the text editor font to a monospace font.\nClick again to try different fonts");
+    m_ui->serifButton->setToolTip(
+            "Change the text editor font to a serif font.\nClick again to try different fonts");
+    m_ui->sansSerifButton->setToolTip("Change the text editor font to a sans-serif font.\nClick "
+                                      "again to try different fonts");
+    m_ui->monoButton->setToolTip(
+            "Change the text editor font to a monospace font.\nClick again to try different fonts");
     m_ui->decreaseButton->setToolTip("Decrease font size");
     m_ui->increaseButton->setToolTip("Increase font size");
     m_ui->fullWidthButton->setToolTip("Make text stretch to the full width of the text editor");
@@ -33,40 +36,76 @@ StyleEditorWindow::StyleEditorWindow(QWidget *parent) :
     m_ui->sepiaButton->setToolTip("Chaneg app theme to Sepia");
     m_ui->resetDefaultButton->setToolTip("Reset all to default settings");
 
-    connect(m_ui->serifButton, &QPushButton::clicked, this, [this]{emit StyleEditorWindow::changeFontType(FontTypeface::Serif); buttonClicked(m_ui->serifButton);});
-    connect(m_ui->sansSerifButton, &QPushButton::clicked, this, [this]{emit StyleEditorWindow::changeFontType(FontTypeface::SansSerif); buttonClicked(m_ui->sansSerifButton);});
-    connect(m_ui->monoButton, &QPushButton::clicked, this, [this]{emit StyleEditorWindow::changeFontType(FontTypeface::Mono); buttonClicked(m_ui->monoButton);});
-    connect(m_ui->decreaseButton, &QPushButton::clicked, this, [this]{emit StyleEditorWindow::changeFontSize(FontSizeAction::Decrease); buttonClicked(m_ui->decreaseButton);});
-    connect(m_ui->increaseButton, &QPushButton::clicked, this, [this]{emit StyleEditorWindow::changeFontSize(FontSizeAction::Increase); buttonClicked(m_ui->increaseButton);});
-    connect(m_ui->fullWidthButton, &QPushButton::clicked, this, [this]{emit StyleEditorWindow::changeEditorTextWidth(EditorTextWidth::FullWidth); buttonClicked(m_ui->fullWidthButton);});
-    connect(m_ui->increaseWidthButton, &QPushButton::clicked, this, [this]{emit StyleEditorWindow::changeEditorTextWidth(EditorTextWidth::Increase); buttonClicked(m_ui->increaseWidthButton);});
-    connect(m_ui->decreaseWidthButton, &QPushButton::clicked, this, [this]{emit StyleEditorWindow::changeEditorTextWidth(EditorTextWidth::Decrease); buttonClicked(m_ui->decreaseWidthButton);});
-    connect(m_ui->lightButton, &QPushButton::clicked, this, [this]{emit StyleEditorWindow::changeTheme(Theme::Light); buttonClicked(m_ui->lightButton);});
-    connect(m_ui->darkButton, &QPushButton::clicked, this, [this]{emit StyleEditorWindow::changeTheme(Theme::Dark); buttonClicked(m_ui->darkButton);});
-    connect(m_ui->sepiaButton, &QPushButton::clicked, this, [this]{emit StyleEditorWindow::changeTheme(Theme::Sepia); buttonClicked(m_ui->sepiaButton);});
-    connect(m_ui->resetDefaultButton, &QPushButton::clicked, this, [this]{emit StyleEditorWindow::resetEditorToDefaultSettings(); buttonClicked(m_ui->resetDefaultButton);});
+    connect(m_ui->serifButton, &QPushButton::clicked, this, [this] {
+        emit StyleEditorWindow::changeFontType(FontTypeface::Serif);
+        buttonClicked(m_ui->serifButton);
+    });
+    connect(m_ui->sansSerifButton, &QPushButton::clicked, this, [this] {
+        emit StyleEditorWindow::changeFontType(FontTypeface::SansSerif);
+        buttonClicked(m_ui->sansSerifButton);
+    });
+    connect(m_ui->monoButton, &QPushButton::clicked, this, [this] {
+        emit StyleEditorWindow::changeFontType(FontTypeface::Mono);
+        buttonClicked(m_ui->monoButton);
+    });
+    connect(m_ui->decreaseButton, &QPushButton::clicked, this, [this] {
+        emit StyleEditorWindow::changeFontSize(FontSizeAction::Decrease);
+        buttonClicked(m_ui->decreaseButton);
+    });
+    connect(m_ui->increaseButton, &QPushButton::clicked, this, [this] {
+        emit StyleEditorWindow::changeFontSize(FontSizeAction::Increase);
+        buttonClicked(m_ui->increaseButton);
+    });
+    connect(m_ui->fullWidthButton, &QPushButton::clicked, this, [this] {
+        emit StyleEditorWindow::changeEditorTextWidth(EditorTextWidth::FullWidth);
+        buttonClicked(m_ui->fullWidthButton);
+    });
+    connect(m_ui->increaseWidthButton, &QPushButton::clicked, this, [this] {
+        emit StyleEditorWindow::changeEditorTextWidth(EditorTextWidth::Increase);
+        buttonClicked(m_ui->increaseWidthButton);
+    });
+    connect(m_ui->decreaseWidthButton, &QPushButton::clicked, this, [this] {
+        emit StyleEditorWindow::changeEditorTextWidth(EditorTextWidth::Decrease);
+        buttonClicked(m_ui->decreaseWidthButton);
+    });
+    connect(m_ui->lightButton, &QPushButton::clicked, this, [this] {
+        emit StyleEditorWindow::changeTheme(Theme::Light);
+        buttonClicked(m_ui->lightButton);
+    });
+    connect(m_ui->darkButton, &QPushButton::clicked, this, [this] {
+        emit StyleEditorWindow::changeTheme(Theme::Dark);
+        buttonClicked(m_ui->darkButton);
+    });
+    connect(m_ui->sepiaButton, &QPushButton::clicked, this, [this] {
+        emit StyleEditorWindow::changeTheme(Theme::Sepia);
+        buttonClicked(m_ui->sepiaButton);
+    });
+    connect(m_ui->resetDefaultButton, &QPushButton::clicked, this, [this] {
+        emit StyleEditorWindow::resetEditorToDefaultSettings();
+        buttonClicked(m_ui->resetDefaultButton);
+    });
 
     QString ss = QString("QPushButton {background-color: white;} "
                          "QPushButton {border: none;}"
-                         "QPushButton {padding: 0px;}"
-                         );
+                         "QPushButton {padding: 0px;}");
 
     QString fontDisplayName;
 
 #ifdef __APPLE__
 
-    if(QFont(QStringLiteral("SF Pro Text")).exactMatch()) {
+    if (QFont(QStringLiteral("SF Pro Text")).exactMatch()) {
         fontDisplayName = QStringLiteral("SF Pro Text");
-    } else if(QFont(QStringLiteral("Helvetica Neue")).exactMatch()) {
+    } else if (QFont(QStringLiteral("Helvetica Neue")).exactMatch()) {
         fontDisplayName = QStringLiteral("Helvetica Neue");
-    } else if(QFont(QStringLiteral("Helvetica")).exactMatch()) {
+    } else if (QFont(QStringLiteral("Helvetica")).exactMatch()) {
         fontDisplayName = QStringLiteral("Helvetica");
     } else {
         fontDisplayName = QStringLiteral("Roboto");
     }
 
 #elif _WIN32
-    fontDisplayName = QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI") : QStringLiteral("Roboto");
+    fontDisplayName = QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI")
+                                                                     : QStringLiteral("Roboto");
 
 #else
 
@@ -91,22 +130,25 @@ StyleEditorWindow::StyleEditorWindow(QWidget *parent) :
     m_ui->sepiaButton->setFont(QFont(fontDisplayName, fontDisplaySize, QFont::Bold));
     m_ui->resetDefaultButton->setFont(QFont(fontDisplayName, fontDisplaySize, QFont::Bold));
 
-    QList<QPushButton*> listChildrenButtons = findChildren<QPushButton*>();
-    foreach(QPushButton* childButton, listChildrenButtons) {
-         childButton->setStyleSheet(ss);
-         childButton->installEventFilter(this);
+    QList<QPushButton *> listChildrenButtons = findChildren<QPushButton *>();
+    foreach (QPushButton *childButton, listChildrenButtons) {
+        childButton->setStyleSheet(ss);
+        childButton->installEventFilter(this);
     }
 
-    new QShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_S), this, SLOT(toggleWindowVisibility()));
+    new QShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_S), this,
+                  SLOT(toggleWindowVisibility()));
 
     m_ui->decreaseButton->setIcon(QIcon(QStringLiteral(":images/minus.png")));
     m_ui->increaseButton->setIcon(QIcon(QStringLiteral(":images/plus.png")));
     QIcon decreaseWidthIcon(QStringLiteral(":images/decrease-width.png"));
     QIcon increaseWidthIcon(QStringLiteral(":images/increase-width.png"));
     m_ui->decreaseWidthButton->setIcon(decreaseWidthIcon);
-    m_ui->decreaseWidthButton->setIconSize(decreaseWidthIcon.actualSize(m_ui->decreaseWidthButton->size()));
+    m_ui->decreaseWidthButton->setIconSize(
+            decreaseWidthIcon.actualSize(m_ui->decreaseWidthButton->size()));
     m_ui->increaseWidthButton->setIcon(increaseWidthIcon);
-    m_ui->increaseWidthButton->setIconSize(increaseWidthIcon.actualSize(m_ui->increaseWidthButton->size()));
+    m_ui->increaseWidthButton->setIconSize(
+            increaseWidthIcon.actualSize(m_ui->increaseWidthButton->size()));
 }
 
 StyleEditorWindow::~StyleEditorWindow()
@@ -121,31 +163,29 @@ StyleEditorWindow::~StyleEditorWindow()
  * (those who needs to keep show they are selected)
  * \param button
  */
-void StyleEditorWindow::buttonClicked(QPushButton* button)
+void StyleEditorWindow::buttonClicked(QPushButton *button)
 {
     m_currentlyClickedButton = button;
     bool shouldBeClicked = true;
 
-    if(button == m_ui->serifButton ||
-            button == m_ui->sansSerifButton ||
-            button == m_ui->monoButton) {
-        if(m_currentSelectedFontButton != Q_NULLPTR ){
+    if (button == m_ui->serifButton || button == m_ui->sansSerifButton
+        || button == m_ui->monoButton) {
+        if (m_currentSelectedFontButton != Q_NULLPTR) {
             m_currentSelectedFontButton->setStyleSheet(getStyleSheetForButton(ButtonState::Normal));
         }
         m_currentSelectedFontButton = button;
     }
 
-    if(button == m_ui->lightButton ||
-            button == m_ui->darkButton ||
-            button == m_ui->sepiaButton) {
-        if(m_currentSelectedThemeButton != Q_NULLPTR ){
-            m_currentSelectedThemeButton->setStyleSheet(getStyleSheetForButton(ButtonState::Normal));
+    if (button == m_ui->lightButton || button == m_ui->darkButton || button == m_ui->sepiaButton) {
+        if (m_currentSelectedThemeButton != Q_NULLPTR) {
+            m_currentSelectedThemeButton->setStyleSheet(
+                    getStyleSheetForButton(ButtonState::Normal));
         }
         m_currentSelectedThemeButton = button;
     }
 
-    if(button == m_ui->fullWidthButton) {
-        if(m_isFullWidthClicked) {
+    if (button == m_ui->fullWidthButton) {
+        if (m_isFullWidthClicked) {
             m_ui->fullWidthButton->setStyleSheet(getStyleSheetForButton(ButtonState::Hovered));
             m_isFullWidthClicked = false;
             shouldBeClicked = false;
@@ -155,17 +195,19 @@ void StyleEditorWindow::buttonClicked(QPushButton* button)
         }
     }
 
-    if(button == m_ui->increaseWidthButton ||
-              button == m_ui->decreaseWidthButton) {
+    if (button == m_ui->increaseWidthButton || button == m_ui->decreaseWidthButton) {
         m_ui->fullWidthButton->setStyleSheet(getStyleSheetForButton(ButtonState::Normal));
         m_isFullWidthClicked = false;
     }
 
-    if(shouldBeClicked)
+    if (shouldBeClicked)
         button->setStyleSheet(getStyleSheetForButton(ButtonState::Clicked));
 
-    if(button != m_currentSelectedFontButton && button != m_currentSelectedThemeButton && button != m_ui->fullWidthButton) {
-        QTimer::singleShot(200, this, [this]{m_currentlyClickedButton->setStyleSheet(getStyleSheetForButton(ButtonState::Normal));});
+    if (button != m_currentSelectedFontButton && button != m_currentSelectedThemeButton
+        && button != m_ui->fullWidthButton) {
+        QTimer::singleShot(200, this, [this] {
+            m_currentlyClickedButton->setStyleSheet(getStyleSheetForButton(ButtonState::Normal));
+        });
     }
 }
 
@@ -176,9 +218,10 @@ void StyleEditorWindow::buttonClicked(QPushButton* button)
  * \param selectedFontType
  * \param selectedFontName
  */
-void StyleEditorWindow::changeSelectedFont(FontTypeface selectedFontType, const QString &selectedFontName)
+void StyleEditorWindow::changeSelectedFont(FontTypeface selectedFontType,
+                                           const QString &selectedFontName)
 {
-    switch(selectedFontType) {
+    switch (selectedFontType) {
     case FontTypeface::Mono:
         m_selectedMonoFontFamilyName = selectedFontName;
         m_ui->monoButton->changeFont(selectedFontName, QStringLiteral("mono"), m_currentFontColor);
@@ -186,12 +229,14 @@ void StyleEditorWindow::changeSelectedFont(FontTypeface selectedFontType, const 
         break;
     case FontTypeface::Serif:
         m_selectedSerifFontFamilyName = selectedFontName;
-        m_ui->serifButton->changeFont(selectedFontName, QStringLiteral("serif"), m_currentFontColor);
+        m_ui->serifButton->changeFont(selectedFontName, QStringLiteral("serif"),
+                                      m_currentFontColor);
         m_ui->serifButton->repaint();
         break;
     case FontTypeface::SansSerif:
         m_selectedSansSerifFontFamilyName = selectedFontName;
-        m_ui->sansSerifButton->changeFont(selectedFontName, QStringLiteral("sansSerif"), m_currentFontColor);
+        m_ui->sansSerifButton->changeFont(selectedFontName, QStringLiteral("sansSerif"),
+                                          m_currentFontColor);
         m_ui->sansSerifButton->repaint();
         break;
     }
@@ -206,12 +251,12 @@ void StyleEditorWindow::changeSelectedFont(FontTypeface selectedFontType, const 
 QString StyleEditorWindow::getStyleSheetForButton(ButtonState buttonState)
 {
     QString ss = QStringLiteral("QPushButton{ "
-                 "  background-color: %1; "
-                 "  border: none;"
-                 "  padding: 0px;");
+                                "  background-color: %1; "
+                                "  border: none;"
+                                "  padding: 0px;");
 
     // Font color
-    if(m_currentTheme == Theme::Dark) {
+    if (m_currentTheme == Theme::Dark) {
         ss.append(QStringLiteral("color: rgb(204, 204, 204);"));
     } else {
         ss.append(QStringLiteral("color: rgb(26, 26, 26);"));
@@ -219,21 +264,21 @@ QString StyleEditorWindow::getStyleSheetForButton(ButtonState buttonState)
 
     ss.append("}");
 
-    switch(buttonState) {
+    switch (buttonState) {
     case ButtonState::Normal: {
         ss = ss.arg(m_currentThemeColor.name());
         break;
     }
     case ButtonState::Hovered: {
-        if(m_currentTheme == Theme::Dark) {
-            ss = ss.arg(QColor(43, 43,43).name());
+        if (m_currentTheme == Theme::Dark) {
+            ss = ss.arg(QColor(43, 43, 43).name());
         } else {
             ss = ss.arg(QColor(207, 207, 207).name());
         }
         break;
     }
     case ButtonState::Clicked: {
-        if(m_currentTheme == Theme::Dark) {
+        if (m_currentTheme == Theme::Dark) {
             ss = ss.arg(QColor(0, 59, 148).name());
         } else {
             ss = ss.arg(QColor(218, 233, 239).name());
@@ -253,9 +298,8 @@ QString StyleEditorWindow::getStyleSheetForButton(ButtonState buttonState)
  */
 bool StyleEditorWindow::isSelectedButton(QPushButton *button)
 {
-    if((button != m_currentSelectedFontButton &&
-        button != m_currentSelectedThemeButton) &&
-            !(button == m_ui->fullWidthButton && m_isFullWidthClicked)) {
+    if ((button != m_currentSelectedFontButton && button != m_currentSelectedThemeButton)
+        && !(button == m_ui->fullWidthButton && m_isFullWidthClicked)) {
         return false;
     }
 
@@ -278,39 +322,46 @@ void StyleEditorWindow::setTheme(Theme theme, QColor themeColor, QColor textColo
     m_currentThemeColor = themeColor;
     m_currentFontColor = textColor;
 
-    if(theme == Theme::Dark) {
+    if (theme == Theme::Dark) {
         m_ui->decreaseButton->setIcon(QIcon(QStringLiteral(":images/minus-dark.png")));
         m_ui->increaseButton->setIcon(QIcon(QStringLiteral(":images/plus-dark.png")));
         QIcon decreaseWidthIcon(QStringLiteral(":images/decrease-width-dark.png"));
         QIcon increaseWidthIcon(QStringLiteral(":images/increase-width-dark.png"));
         m_ui->decreaseWidthButton->setIcon(decreaseWidthIcon);
-        m_ui->decreaseWidthButton->setIconSize(decreaseWidthIcon.actualSize(m_ui->decreaseWidthButton->size()));
+        m_ui->decreaseWidthButton->setIconSize(
+                decreaseWidthIcon.actualSize(m_ui->decreaseWidthButton->size()));
         m_ui->increaseWidthButton->setIcon(increaseWidthIcon);
-        m_ui->increaseWidthButton->setIconSize(increaseWidthIcon.actualSize(m_ui->increaseWidthButton->size()));
+        m_ui->increaseWidthButton->setIconSize(
+                increaseWidthIcon.actualSize(m_ui->increaseWidthButton->size()));
     } else {
         m_ui->decreaseButton->setIcon(QIcon(QStringLiteral(":images/minus.png")));
         m_ui->increaseButton->setIcon(QIcon(QStringLiteral(":images/plus.png")));
         QIcon decreaseWidthIcon(QStringLiteral(":images/decrease-width.png"));
         QIcon increaseWidthIcon(QStringLiteral(":images/increase-width.png"));
         m_ui->decreaseWidthButton->setIcon(decreaseWidthIcon);
-        m_ui->decreaseWidthButton->setIconSize(decreaseWidthIcon.actualSize(m_ui->decreaseWidthButton->size()));
+        m_ui->decreaseWidthButton->setIconSize(
+                decreaseWidthIcon.actualSize(m_ui->decreaseWidthButton->size()));
         m_ui->increaseWidthButton->setIcon(increaseWidthIcon);
-        m_ui->increaseWidthButton->setIconSize(increaseWidthIcon.actualSize(m_ui->increaseWidthButton->size()));
+        m_ui->increaseWidthButton->setIconSize(
+                increaseWidthIcon.actualSize(m_ui->increaseWidthButton->size()));
     }
 
     m_ui->monoButton->setTheme(theme);
     m_ui->serifButton->setTheme(theme);
     m_ui->sansSerifButton->setTheme(theme);
-    m_ui->monoButton->changeFont(m_selectedMonoFontFamilyName, QStringLiteral("mono"), m_currentFontColor);
-    m_ui->serifButton->changeFont(m_selectedSerifFontFamilyName, QStringLiteral("serif"), m_currentFontColor);
-    m_ui->sansSerifButton->changeFont(m_selectedSansSerifFontFamilyName, QStringLiteral("sansSerif"), m_currentFontColor);
+    m_ui->monoButton->changeFont(m_selectedMonoFontFamilyName, QStringLiteral("mono"),
+                                 m_currentFontColor);
+    m_ui->serifButton->changeFont(m_selectedSerifFontFamilyName, QStringLiteral("serif"),
+                                  m_currentFontColor);
+    m_ui->sansSerifButton->changeFont(m_selectedSansSerifFontFamilyName,
+                                      QStringLiteral("sansSerif"), m_currentFontColor);
     m_ui->monoButton->repaint();
     m_ui->serifButton->repaint();
     m_ui->sansSerifButton->repaint();
 
-    QList<QPushButton*> listChildrenButtons = findChildren<QPushButton*>();
-    foreach(QPushButton* childButton, listChildrenButtons) {
-        if(!isSelectedButton(childButton)) {
+    QList<QPushButton *> listChildrenButtons = findChildren<QPushButton *>();
+    foreach (QPushButton *childButton, listChildrenButtons) {
+        if (!isSelectedButton(childButton)) {
             childButton->setStyleSheet(getStyleSheetForButton(ButtonState::Normal));
         } else {
             childButton->setStyleSheet(getStyleSheetForButton(ButtonState::Clicked));
@@ -326,13 +377,15 @@ void StyleEditorWindow::setTheme(Theme theme, QColor themeColor, QColor textColo
  * \param selectedFontTypeface
  * \param selectedTheme
  */
-void StyleEditorWindow::restoreSelectedOptions(bool isTextFullWidth, FontTypeface selectedFontTypeface, Theme selectedTheme)
+void StyleEditorWindow::restoreSelectedOptions(bool isTextFullWidth,
+                                               FontTypeface selectedFontTypeface,
+                                               Theme selectedTheme)
 {
-    if(isTextFullWidth){
+    if (isTextFullWidth) {
         buttonClicked(m_ui->fullWidthButton);
     }
 
-    switch(selectedFontTypeface) {
+    switch (selectedFontTypeface) {
     case FontTypeface::Mono:
         buttonClicked(m_ui->monoButton);
         break;
@@ -344,7 +397,7 @@ void StyleEditorWindow::restoreSelectedOptions(bool isTextFullWidth, FontTypefac
         break;
     }
 
-    switch(selectedTheme) {
+    switch (selectedTheme) {
     case Theme::Light: {
         buttonClicked(m_ui->lightButton);
         break;
@@ -362,7 +415,7 @@ void StyleEditorWindow::restoreSelectedOptions(bool isTextFullWidth, FontTypefac
 
 void StyleEditorWindow::toggleWindowVisibility()
 {
-    if(isVisible()) {
+    if (isVisible()) {
         hide();
     } else {
         show();
@@ -379,21 +432,21 @@ void StyleEditorWindow::toggleWindowVisibility()
 bool StyleEditorWindow::eventFilter(QObject *object, QEvent *event)
 {
     switch (event->type()) {
-    case QEvent::Enter:{
-        QList<QPushButton*> listChildrenButtons = findChildren<QPushButton*>();
-        foreach(QPushButton* childButton, listChildrenButtons) {
-             if((object == childButton && !isSelectedButton(childButton))) {
-                 childButton->setStyleSheet(getStyleSheetForButton(ButtonState::Hovered));
-             }
+    case QEvent::Enter: {
+        QList<QPushButton *> listChildrenButtons = findChildren<QPushButton *>();
+        foreach (QPushButton *childButton, listChildrenButtons) {
+            if ((object == childButton && !isSelectedButton(childButton))) {
+                childButton->setStyleSheet(getStyleSheetForButton(ButtonState::Hovered));
+            }
         }
         break;
     }
-    case QEvent::Leave:{
-        QList<QPushButton*> listChildrenButtons = findChildren<QPushButton*>();
-        foreach(QPushButton* childButton, listChildrenButtons) {
-             if(object == childButton && !isSelectedButton(childButton)) {
-                 childButton->setStyleSheet(getStyleSheetForButton(ButtonState::Normal));
-             }
+    case QEvent::Leave: {
+        QList<QPushButton *> listChildrenButtons = findChildren<QPushButton *>();
+        foreach (QPushButton *childButton, listChildrenButtons) {
+            if (object == childButton && !isSelectedButton(childButton)) {
+                childButton->setStyleSheet(getStyleSheetForButton(ButtonState::Normal));
+            }
         }
         break;
     }
@@ -402,6 +455,4 @@ bool StyleEditorWindow::eventFilter(QObject *object, QEvent *event)
     }
 
     return QObject::eventFilter(object, event);
-
 }
-

--- a/src/styleeditorwindow.h
+++ b/src/styleeditorwindow.h
@@ -1,58 +1,40 @@
 /*********************************************************************************************
-* Mozila License
-* Just a meantime project to see the ability of qt, the framework that my OS might be based on
-* And for those linux users that beleive in the power of notes
-*********************************************************************************************/
+ * Mozila License
+ * Just a meantime project to see the ability of qt, the framework that my OS might be based on
+ * And for those linux users that beleive in the power of notes
+ *********************************************************************************************/
 
 #ifndef STYLEEDITORWINDOW_H
 #define STYLEEDITORWINDOW_H
 
 #include <QWidget>
-#include<QPushButton>
+#include <QPushButton>
 
 namespace Ui {
 class StyleEditorWindow;
 }
 
-enum class FontTypeface {
-    Mono,
-    Serif,
-    SansSerif
-};
+enum class FontTypeface { Mono, Serif, SansSerif };
 
-enum class FontSizeAction {
-    Increase,
-    Decrease
-};
+enum class FontSizeAction { Increase, Decrease };
 
-enum class EditorTextWidth {
-    FullWidth,
-    Increase,
-    Decrease
-};
+enum class EditorTextWidth { FullWidth, Increase, Decrease };
 
-enum class Theme {
-    Light,
-    Dark,
-    Sepia
-};
+enum class Theme { Light, Dark, Sepia };
 
-enum class ButtonState {
-    Normal,
-    Hovered,
-    Clicked
-};
+enum class ButtonState { Normal, Hovered, Clicked };
 
 class StyleEditorWindow : public QWidget
 {
     Q_OBJECT
 
 public:
-    explicit StyleEditorWindow (QWidget *parent = 0);
+    explicit StyleEditorWindow(QWidget *parent = 0);
     ~StyleEditorWindow();
     void changeSelectedFont(FontTypeface selectedFontType, const QString &selectedFontName);
     void setTheme(Theme theme, QColor themeColor, QColor textColor);
-    void restoreSelectedOptions(bool isTextFullWidth, FontTypeface selectedFontTypeface, Theme selectedTheme);
+    void restoreSelectedOptions(bool isTextFullWidth, FontTypeface selectedFontTypeface,
+                                Theme selectedTheme);
 
 public slots:
     void toggleWindowVisibility();
@@ -71,7 +53,7 @@ protected:
 
 private:
     QString getStyleSheetForButton(ButtonState buttonState);
-    void buttonClicked(QPushButton* button);
+    void buttonClicked(QPushButton *button);
     bool isSelectedButton(QPushButton *button);
 
     Ui::StyleEditorWindow *m_ui;

--- a/src/tagdata.cpp
+++ b/src/tagdata.cpp
@@ -1,11 +1,8 @@
 #include "tagdata.h"
 
-TagData::TagData():
-    m_id{SpecialTagID::InvalidTagId},
-    m_relativePosition{-1},
-    m_childNotesCount{0}
+TagData::TagData()
+    : m_id{ SpecialTagID::InvalidTagId }, m_relativePosition{ -1 }, m_childNotesCount{ 0 }
 {
-
 }
 
 int TagData::id() const

--- a/src/tagdata.h
+++ b/src/tagdata.h
@@ -5,9 +5,9 @@
 #include <QMetaClassInfo>
 
 namespace SpecialTagID {
-    enum Value {
-        InvalidTagId = -1,
-    };
+enum Value {
+    InvalidTagId = -1,
+};
 }
 
 class TagData

--- a/src/taglistdelegate.cpp
+++ b/src/taglistdelegate.cpp
@@ -3,27 +3,30 @@
 #include <QPainter>
 #include <QPainterPath>
 
-TagListDelegate::TagListDelegate(QObject *parent) :
-    QStyledItemDelegate(parent),
-    #ifdef __APPLE__
-    m_displayFont(QFont(QStringLiteral("SF Pro Text")).exactMatch() ? QStringLiteral("SF Pro Text") : QStringLiteral("Roboto")),
-    #elif _WIN32
-    m_displayFont(QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI") : QStringLiteral("Roboto")),
-    #else
-    m_displayFont(QStringLiteral("Roboto")),
-    #endif
-    #ifdef __APPLE__
-	m_titleFont(m_displayFont, 13, QFont::DemiBold),
-    #else
-	m_titleFont(m_displayFont, 10, QFont::DemiBold),
-    #endif
-    m_titleColor(26, 26, 26),
-    m_theme(Theme::Light)
+TagListDelegate::TagListDelegate(QObject *parent)
+    : QStyledItemDelegate(parent),
+#ifdef __APPLE__
+      m_displayFont(QFont(QStringLiteral("SF Pro Text")).exactMatch()
+                            ? QStringLiteral("SF Pro Text")
+                            : QStringLiteral("Roboto")),
+#elif _WIN32
+      m_displayFont(QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI")
+                                                                   : QStringLiteral("Roboto")),
+#else
+      m_displayFont(QStringLiteral("Roboto")),
+#endif
+#ifdef __APPLE__
+      m_titleFont(m_displayFont, 13, QFont::DemiBold),
+#else
+      m_titleFont(m_displayFont, 10, QFont::DemiBold),
+#endif
+      m_titleColor(26, 26, 26),
+      m_theme(Theme::Light)
 {
-
 }
 
-void TagListDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
+void TagListDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option,
+                            const QModelIndex &index) const
 {
     painter->setRenderHint(QPainter::Antialiasing);
     auto name = index.data(TagListModel::NameRole).toString();
@@ -66,19 +69,16 @@ QSize TagListDelegate::sizeHint(const QStyleOptionViewItem &option, const QModel
 void TagListDelegate::setTheme(Theme newTheme)
 {
     m_theme = newTheme;
-    switch(m_theme){
-    case Theme::Light:
-    {
+    switch (m_theme) {
+    case Theme::Light: {
         m_titleColor = QColor(26, 26, 26);
         break;
     }
-    case Theme::Dark:
-    {
+    case Theme::Dark: {
         m_titleColor = QColor(204, 204, 204);
         break;
     }
-    case Theme::Sepia:
-    {
+    case Theme::Sepia: {
         m_titleColor = QColor(26, 26, 26);
         break;
     }

--- a/src/taglistdelegate.h
+++ b/src/taglistdelegate.h
@@ -12,8 +12,10 @@ public:
 
     // QAbstractItemDelegate interface
 public:
-    virtual void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
-    virtual QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+    virtual void paint(QPainter *painter, const QStyleOptionViewItem &option,
+                       const QModelIndex &index) const override;
+    virtual QSize sizeHint(const QStyleOptionViewItem &option,
+                           const QModelIndex &index) const override;
     void setTheme(Theme newTheme);
 
 private:
@@ -24,7 +26,5 @@ private:
     QColor m_titleColor;
     Theme m_theme;
 };
-
-
 
 #endif // TAGLISTDELEGATE_H

--- a/src/taglistmodel.cpp
+++ b/src/taglistmodel.cpp
@@ -3,12 +3,7 @@
 #include <QDebug>
 #include "nodepath.h"
 
-TagListModel::TagListModel(QObject *parent) :
-    QAbstractListModel(parent),
-    m_tagPool{nullptr}
-{
-
-}
+TagListModel::TagListModel(QObject *parent) : QAbstractListModel(parent), m_tagPool{ nullptr } { }
 
 void TagListModel::setTagPool(TagPool *tagPool)
 {
@@ -49,12 +44,14 @@ void TagListModel::addTag(int tagId)
     }
 }
 
-int TagListModel::rowCount(const QModelIndex & parent) const {
+int TagListModel::rowCount(const QModelIndex &parent) const
+{
     Q_UNUSED(parent);
     return m_data.count();
 }
 
-QVariant TagListModel::data(const QModelIndex & index, int role) const {
+QVariant TagListModel::data(const QModelIndex &index, int role) const
+{
     if (!index.isValid()) {
         return QVariant();
     }
@@ -72,7 +69,7 @@ QVariant TagListModel::data(const QModelIndex & index, int role) const {
 void TagListModel::updateTagData()
 {
     m_data.clear();
-    for (const auto& id : qAsConst(m_ids)) {
+    for (const auto &id : qAsConst(m_ids)) {
         if (m_tagPool->contains(id)) {
             m_data.append(m_tagPool->getTag(id));
         } else {

--- a/src/taglistmodel.h
+++ b/src/taglistmodel.h
@@ -10,19 +10,16 @@ class TagListModel : public QAbstractListModel
 {
     Q_OBJECT
 public:
-    enum TagListRoles {
-        IdRole = Qt::UserRole + 1,
-        NameRole,
-        ColorRole
-    };
+    enum TagListRoles { IdRole = Qt::UserRole + 1, NameRole, ColorRole };
     TagListModel(QObject *parent = nullptr);
-    void setTagPool(TagPool* tagPool);
+    void setTagPool(TagPool *tagPool);
     void setModelData(const QSet<int> &data);
     void addTag(int tagId);
-    int rowCount(const QModelIndex & parent = QModelIndex()) const;
-    QVariant data(const QModelIndex & index, int role = Qt::DisplayRole) const;
+    int rowCount(const QModelIndex &parent = QModelIndex()) const;
+    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
+
 private:
-    TagPool* m_tagPool;
+    TagPool *m_tagPool;
     QVector<TagData> m_data;
     QSet<int> m_ids;
 

--- a/src/taglistview.cpp
+++ b/src/taglistview.cpp
@@ -16,15 +16,15 @@ void TagListView::setBackground(const QColor &color)
     if (m_backgroundColor != color) {
         m_backgroundColor = color;
         QString ss = QStringLiteral(
-                    R"(QListView { background: %1; } )"
-                    R"(QScrollBar::handle:vertical:hover { background: rgb(170, 170, 171); } )"
-                    R"(QScrollBar::handle:vertical:pressed { background: rgb(149, 149, 149); } )"
-                    R"(QScrollBar::handle:vertical { border-radius: 4px; background: rgb(188, 188, 188); min-height: 20px; }  )"
-                    R"(QScrollBar::vertical {border-radius: 4px; width: 8px; color: rgba(255, 255, 255,0);} )"
-                    R"(QScrollBar {margin: 0; background: transparent;} )"
-                    R"(QScrollBar:hover { background-color: rgb(217, 217, 217);})"
-                    R"(QScrollBar::add-line:vertical { width:0px; height: 0px; subcontrol-position: bottom; subcontrol-origin: margin; }  )"
-                    R"(QScrollBar::sub-line:vertical { width:0px; height: 0px; subcontrol-position: top; subcontrol-origin: margin; })");
+                R"(QListView { background: %1; } )"
+                R"(QScrollBar::handle:vertical:hover { background: rgb(170, 170, 171); } )"
+                R"(QScrollBar::handle:vertical:pressed { background: rgb(149, 149, 149); } )"
+                R"(QScrollBar::handle:vertical { border-radius: 4px; background: rgb(188, 188, 188); min-height: 20px; }  )"
+                R"(QScrollBar::vertical {border-radius: 4px; width: 8px; color: rgba(255, 255, 255,0);} )"
+                R"(QScrollBar {margin: 0; background: transparent;} )"
+                R"(QScrollBar:hover { background-color: rgb(217, 217, 217);})"
+                R"(QScrollBar::add-line:vertical { width:0px; height: 0px; subcontrol-position: bottom; subcontrol-origin: margin; }  )"
+                R"(QScrollBar::sub-line:vertical { width:0px; height: 0px; subcontrol-position: top; subcontrol-origin: margin; })");
         setStyleSheet(ss.arg(m_backgroundColor.name()));
     }
 }
@@ -37,7 +37,7 @@ void TagListView::reset()
         sz.setHeight(0);
     } else {
         auto firstIndex = model()->index(0, 0);
-        auto lastIndex = model()->index(model()->rowCount() -1, 0);
+        auto lastIndex = model()->index(model()->rowCount() - 1, 0);
         auto fr = visualRect(firstIndex);
         fr.setBottom(visualRect(lastIndex).bottom());
         if (fr.height() < 80) {
@@ -74,4 +74,3 @@ void TagListView::mouseMoveEvent(QMouseEvent *event)
 {
     event->ignore();
 }
-

--- a/src/taglistview.h
+++ b/src/taglistview.h
@@ -8,7 +8,7 @@ class TagListView : public QListView
     Q_OBJECT
 public:
     explicit TagListView(QWidget *parent = nullptr);
-    void setBackground(const QColor& color);
+    void setBackground(const QColor &color);
 signals:
     // QAbstractItemView interface
 public slots:
@@ -21,6 +21,7 @@ protected:
     virtual void mouseReleaseEvent(QMouseEvent *event) override;
     virtual void mouseDoubleClickEvent(QMouseEvent *event) override;
     virtual void mouseMoveEvent(QMouseEvent *event) override;
+
 private:
     QColor m_backgroundColor;
 };

--- a/src/tagpool.cpp
+++ b/src/tagpool.cpp
@@ -1,26 +1,25 @@
 #include "tagpool.h"
 #include "dbmanager.h"
 
-TagPool::TagPool(DBManager *dbManager, QObject *parent) :
-    QObject(parent),
-    m_dbManager{dbManager}
+TagPool::TagPool(DBManager *dbManager, QObject *parent) : QObject(parent), m_dbManager{ dbManager }
 {
-    connect(m_dbManager, &DBManager::nodesTagTreeReceived,
-            this, [this] (const NodeTagTreeData& treeData) {
-        QMap<int, TagData> newPool;
-        for (const auto& tag: treeData.tagTreeData) {
-            newPool[tag.id()] = tag;
-        }
-        setTagPool(newPool);
-    }, Qt::QueuedConnection);
-    connect(m_dbManager, &DBManager::tagAdded,
-            this, &TagPool::onTagAdded, Qt::QueuedConnection);
-    connect(m_dbManager, &DBManager::tagRemoved,
-             this, &TagPool::onTagDeleted, Qt::QueuedConnection);
-    connect(m_dbManager, &DBManager::tagRenamed,
-             this, &TagPool::onTagRenamed, Qt::QueuedConnection);
-    connect(m_dbManager, &DBManager::tagColorChanged,
-             this, &TagPool::onTagColorChanged, Qt::QueuedConnection);
+    connect(
+            m_dbManager, &DBManager::nodesTagTreeReceived, this,
+            [this](const NodeTagTreeData &treeData) {
+                QMap<int, TagData> newPool;
+                for (const auto &tag : treeData.tagTreeData) {
+                    newPool[tag.id()] = tag;
+                }
+                setTagPool(newPool);
+            },
+            Qt::QueuedConnection);
+    connect(m_dbManager, &DBManager::tagAdded, this, &TagPool::onTagAdded, Qt::QueuedConnection);
+    connect(m_dbManager, &DBManager::tagRemoved, this, &TagPool::onTagDeleted,
+            Qt::QueuedConnection);
+    connect(m_dbManager, &DBManager::tagRenamed, this, &TagPool::onTagRenamed,
+            Qt::QueuedConnection);
+    connect(m_dbManager, &DBManager::tagColorChanged, this, &TagPool::onTagColorChanged,
+            Qt::QueuedConnection);
 }
 
 void TagPool::setTagPool(const QMap<int, TagData> &newPool)

--- a/src/tagpool.h
+++ b/src/tagpool.h
@@ -11,7 +11,7 @@ class TagPool : public QObject
 {
     Q_OBJECT
 public:
-    explicit TagPool(DBManager* dbManager, QObject *parent = nullptr);
+    explicit TagPool(DBManager *dbManager, QObject *parent = nullptr);
     TagData getTag(int id) const;
     bool contains(int id) const;
     QList<int> tagIds() const;
@@ -23,13 +23,13 @@ signals:
 
 private slots:
     void onTagDeleted(int id);
-    void onTagAdded(const TagData& tag);
-    void onTagRenamed(int id, const QString& newName);
-    void onTagColorChanged(int id, const QString& newColor);
+    void onTagAdded(const TagData &tag);
+    void onTagRenamed(int id, const QString &newName);
+    void onTagColorChanged(int id, const QString &newColor);
 
 private:
     QMap<int, TagData> m_pool;
-    DBManager* m_dbManager;
+    DBManager *m_dbManager;
 
     void setTagPool(const QMap<int, TagData> &newPool);
 };

--- a/src/tagtreedelegateeditor.cpp
+++ b/src/tagtreedelegateeditor.cpp
@@ -10,30 +10,31 @@
 #include "nodetreeview.h"
 #include "labeledittype.h"
 
-TagTreeDelegateEditor::TagTreeDelegateEditor(QTreeView *view,
-                                             const QStyleOptionViewItem &option,
-                                             const QModelIndex &index,
-                                             QWidget *parent) :
-    QWidget(parent),
-    m_option(option),
-    m_index(index),
-    #ifdef __APPLE__
-    m_displayFont(QFont(QStringLiteral("SF Pro Text")).exactMatch() ? QStringLiteral("SF Pro Text") : QStringLiteral("Roboto")),
-    #elif _WIN32
-    m_displayFont(QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI") : QStringLiteral("Roboto")),
-    #else
-    m_displayFont(QStringLiteral("Roboto")),
-    #endif
-    #ifdef __APPLE__
-    m_titleFont(m_displayFont, 13, QFont::DemiBold),
-    #else
-    m_titleFont(m_displayFont, 10, QFont::DemiBold),
-    #endif
-    m_titleColor(26, 26, 26),
-    m_titleSelectedColor(255, 255, 255),
-    m_activeColor(68, 138, 201),
-    m_hoverColor(207, 207, 207),
-    m_view(view)
+TagTreeDelegateEditor::TagTreeDelegateEditor(QTreeView *view, const QStyleOptionViewItem &option,
+                                             const QModelIndex &index, QWidget *parent)
+    : QWidget(parent),
+      m_option(option),
+      m_index(index),
+#ifdef __APPLE__
+      m_displayFont(QFont(QStringLiteral("SF Pro Text")).exactMatch()
+                            ? QStringLiteral("SF Pro Text")
+                            : QStringLiteral("Roboto")),
+#elif _WIN32
+      m_displayFont(QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI")
+                                                                   : QStringLiteral("Roboto")),
+#else
+      m_displayFont(QStringLiteral("Roboto")),
+#endif
+#ifdef __APPLE__
+      m_titleFont(m_displayFont, 13, QFont::DemiBold),
+#else
+      m_titleFont(m_displayFont, 10, QFont::DemiBold),
+#endif
+      m_titleColor(26, 26, 26),
+      m_titleSelectedColor(255, 255, 255),
+      m_activeColor(68, 138, 201),
+      m_hoverColor(207, 207, 207),
+      m_view(view)
 {
     setContentsMargins(0, 0, 0, 0);
     auto layout = new QHBoxLayout(this);
@@ -50,40 +51,38 @@ TagTreeDelegateEditor::TagTreeDelegateEditor(QTreeView *view,
     m_label->setSizePolicy(labelPolicy);
     m_label->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
     connect(m_label, &LabelEditType::editingStarted, this, [this] {
-        auto tree_view = dynamic_cast<NodeTreeView*>(m_view);
+        auto tree_view = dynamic_cast<NodeTreeView *>(m_view);
         tree_view->setIsEditing(true);
     });
-    connect(m_label, &LabelEditType::editingFinished, this, [this] (const QString& label) {
-        auto tree_view = dynamic_cast<NodeTreeView*>(m_view);
+    connect(m_label, &LabelEditType::editingFinished, this, [this](const QString &label) {
+        auto tree_view = dynamic_cast<NodeTreeView *>(m_view);
         tree_view->onRenameTagFinished(label);
         tree_view->setIsEditing(false);
     });
-    connect(dynamic_cast<NodeTreeView*>(m_view), &NodeTreeView::renameTagRequested,
-            m_label, &LabelEditType::openEditor);
+    connect(dynamic_cast<NodeTreeView *>(m_view), &NodeTreeView::renameTagRequested, m_label,
+            &LabelEditType::openEditor);
     layout->addWidget(m_label);
     m_contextButton = new PushButtonType(parent);
-    m_contextButton->setMaximumSize({33, 25});
-    m_contextButton->setMinimumSize({33, 25});
+    m_contextButton->setMaximumSize({ 33, 25 });
+    m_contextButton->setMinimumSize({ 33, 25 });
     m_contextButton->setCursor(QCursor(Qt::PointingHandCursor));
     m_contextButton->setFocusPolicy(Qt::TabFocus);
     m_contextButton->setIconSize(QSize(16, 16));
     m_contextButton->setStyleSheet(QStringLiteral(R"(QPushButton { )"
-                                            R"(    border: none; )"
-                                            R"(    padding: 0px; )"
-                                            R"(})"));
-    connect(m_contextButton, &QPushButton::clicked, m_view, [this] (bool) {
-        auto tree_view = dynamic_cast<NodeTreeView*>(m_view);
+                                                  R"(    border: none; )"
+                                                  R"(    padding: 0px; )"
+                                                  R"(})"));
+    connect(m_contextButton, &QPushButton::clicked, m_view, [this](bool) {
+        auto tree_view = dynamic_cast<NodeTreeView *>(m_view);
         if (!m_view->selectionModel()->selectedIndexes().contains(m_index)) {
             tree_view->setCurrentIndexC(m_index);
         }
-        tree_view->onCustomContextMenu(
-                    tree_view->visualRect(m_index).topLeft() + m_contextButton->geometry().bottomLeft());
+        tree_view->onCustomContextMenu(tree_view->visualRect(m_index).topLeft()
+                                       + m_contextButton->geometry().bottomLeft());
     });
     layout->addWidget(m_contextButton, 0, Qt::AlignRight);
     layout->addSpacing(5);
-    connect(m_view, &QTreeView::expanded, this, [this] (const QModelIndex &) {
-        this->update();
-    });
+    connect(m_view, &QTreeView::expanded, this, [this](const QModelIndex &) { this->update(); });
 }
 
 void TagTreeDelegateEditor::updateDelegate()
@@ -94,17 +93,17 @@ void TagTreeDelegateEditor::updateDelegate()
 
     if (m_view->selectionModel()->selectedIndexes().contains(m_index)) {
         m_label->setStyleSheet(QStringLiteral("QLabel{color: rgb(%1, %2, %3);}")
-                               .arg(QString::number(m_titleSelectedColor.red()),
-                                    QString::number(m_titleSelectedColor.green()),
-                                    QString::number(m_titleSelectedColor.blue())));
+                                       .arg(QString::number(m_titleSelectedColor.red()),
+                                            QString::number(m_titleSelectedColor.green()),
+                                            QString::number(m_titleSelectedColor.blue())));
         m_contextButton->setNormalIcon(QIcon(QString::fromUtf8(":/images/3dots_Highlighted.png")));
         m_contextButton->setHoveredIcon(QIcon(QString::fromUtf8(":/images/3dots_Highlighted.png")));
         m_contextButton->setPressedIcon(QIcon(QString::fromUtf8(":/images/3dots_Highlighted.png")));
     } else {
         m_label->setStyleSheet(QStringLiteral("QLabel{color: rgb(%1, %2, %3);}")
-                               .arg(QString::number(m_titleColor.red()),
-                                    QString::number(m_titleColor.green()),
-                                    QString::number(m_titleColor.blue())));
+                                       .arg(QString::number(m_titleColor.red()),
+                                            QString::number(m_titleColor.green()),
+                                            QString::number(m_titleColor.blue())));
         m_contextButton->setNormalIcon(QIcon(QString::fromUtf8(":/images/3dots_Regular.png")));
         m_contextButton->setHoveredIcon(QIcon(QString::fromUtf8(":/images/3dots_Hovered.png")));
         m_contextButton->setPressedIcon(QIcon(QString::fromUtf8(":/images/3dots_Pressed.png")));
@@ -134,7 +133,7 @@ void TagTreeDelegateEditor::mouseDoubleClickEvent(QMouseEvent *event)
 {
     auto iconRect = QRect(rect().x() + 10, rect().y() + (rect().height() - 14) / 2, 14, 14);
     if (iconRect.contains(event->pos())) {
-        dynamic_cast<NodeTreeView*>(m_view)->onChangeTagColorAction();
+        dynamic_cast<NodeTreeView *>(m_view)->onChangeTagColorAction();
     } else if (m_label->geometry().contains(event->pos())) {
         m_label->openEditor();
     } else {

--- a/src/tagtreedelegateeditor.h
+++ b/src/tagtreedelegateeditor.h
@@ -15,10 +15,8 @@ class TagTreeDelegateEditor : public QWidget
 {
     Q_OBJECT
 public:
-    explicit TagTreeDelegateEditor(QTreeView* view,
-                                      const QStyleOptionViewItem &option,
-                                      const QModelIndex &index,
-                                      QWidget *parent = nullptr);
+    explicit TagTreeDelegateEditor(QTreeView *view, const QStyleOptionViewItem &option,
+                                   const QModelIndex &index, QWidget *parent = nullptr);
 
 private:
     QStyleOptionViewItem m_option;
@@ -29,9 +27,9 @@ private:
     QColor m_titleSelectedColor;
     QColor m_activeColor;
     QColor m_hoverColor;
-    QTreeView* m_view;
-    LabelEditType* m_label;
-    PushButtonType* m_contextButton;
+    QTreeView *m_view;
+    LabelEditType *m_label;
+    PushButtonType *m_contextButton;
     void updateDelegate();
 
     // QWidget interface
@@ -39,6 +37,5 @@ protected:
     virtual void paintEvent(QPaintEvent *event) override;
     virtual void mouseDoubleClickEvent(QMouseEvent *event) override;
 };
-
 
 #endif // TAGTREEDELEGATEEDITOR_H

--- a/src/trashbuttondelegateeditor.cpp
+++ b/src/trashbuttondelegateeditor.cpp
@@ -5,33 +5,35 @@
 #include "nodetreemodel.h"
 #include "nodetreeview.h"
 
-TrashButtonDelegateEditor::TrashButtonDelegateEditor(QTreeView *view, const QStyleOptionViewItem &option,
-                                                     const QModelIndex &m_index,
-                                                     QWidget *parent) :
-    QWidget(parent),
-    m_option(option),
-    m_index(m_index),
-    #ifdef __APPLE__
-    m_displayFont(QFont(QStringLiteral("SF Pro Text")).exactMatch() ? QStringLiteral("SF Pro Text") : QStringLiteral("Roboto")),
-    #elif _WIN32
-    m_displayFont(QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI") : QStringLiteral("Roboto")),
-    #else
-    m_displayFont(QStringLiteral("Roboto")),
-    #endif
-    #ifdef __APPLE__
-	m_titleFont(m_displayFont, 13, QFont::DemiBold),
-    #else
-	m_titleFont(m_displayFont, 10, QFont::DemiBold),
-    #endif
-    m_titleColor(26, 26, 26),
-    m_titleSelectedColor(255, 255, 255),
-    m_activeColor(68, 138, 201),
-    m_hoverColor(207, 207, 207),
-    m_view(view)
+TrashButtonDelegateEditor::TrashButtonDelegateEditor(QTreeView *view,
+                                                     const QStyleOptionViewItem &option,
+                                                     const QModelIndex &m_index, QWidget *parent)
+    : QWidget(parent),
+      m_option(option),
+      m_index(m_index),
+#ifdef __APPLE__
+      m_displayFont(QFont(QStringLiteral("SF Pro Text")).exactMatch()
+                            ? QStringLiteral("SF Pro Text")
+                            : QStringLiteral("Roboto")),
+#elif _WIN32
+      m_displayFont(QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI")
+                                                                   : QStringLiteral("Roboto")),
+#else
+      m_displayFont(QStringLiteral("Roboto")),
+#endif
+#ifdef __APPLE__
+      m_titleFont(m_displayFont, 13, QFont::DemiBold),
+#else
+      m_titleFont(m_displayFont, 10, QFont::DemiBold),
+#endif
+      m_titleColor(26, 26, 26),
+      m_titleSelectedColor(255, 255, 255),
+      m_activeColor(68, 138, 201),
+      m_hoverColor(207, 207, 207),
+      m_view(view)
 {
     setContentsMargins(0, 0, 0, 0);
 }
-
 
 void TrashButtonDelegateEditor::paintEvent(QPaintEvent *event)
 {
@@ -62,6 +64,7 @@ void TrashButtonDelegateEditor::paintEvent(QPaintEvent *event)
         painter.setPen(m_titleColor);
     }
     painter.setFont(m_titleFont);
-    painter.drawText(childCountRect, Qt::AlignHCenter | Qt::AlignVCenter, QString::number(childCount));
+    painter.drawText(childCountRect, Qt::AlignHCenter | Qt::AlignVCenter,
+                     QString::number(childCount));
     QWidget::paintEvent(event);
 }

--- a/src/trashbuttondelegateeditor.h
+++ b/src/trashbuttondelegateeditor.h
@@ -12,10 +12,8 @@ class TrashButtonDelegateEditor : public QWidget
 {
     Q_OBJECT
 public:
-    explicit TrashButtonDelegateEditor(QTreeView *view,
-                                       const QStyleOptionViewItem &option,
-                                      const QModelIndex &index,
-                                      QWidget *parent = nullptr);
+    explicit TrashButtonDelegateEditor(QTreeView *view, const QStyleOptionViewItem &option,
+                                       const QModelIndex &index, QWidget *parent = nullptr);
 
 private:
     QStyleOptionViewItem m_option;
@@ -31,6 +29,5 @@ private:
 protected:
     virtual void paintEvent(QPaintEvent *event) override;
 };
-
 
 #endif // TRASHBUTTONDELEGATEEDITOR_H

--- a/src/treeviewlogic.cpp
+++ b/src/treeviewlogic.cpp
@@ -10,81 +10,72 @@
 #include <QApplication>
 #include "customapplicationstyle.h"
 
-TreeViewLogic::TreeViewLogic(NodeTreeView* treeView,
-                             NodeTreeModel* treeModel,
-                             DBManager* dbManager,
-                             QObject *parent) :
-    QObject(parent),
-    m_treeView{treeView},
-    m_treeModel{treeModel},
-    m_dbManager{dbManager},
-    m_needLoadSavedState{false},
-    m_isLastSelectFolder{true},
-    m_lastSelectFolder{},
-    m_lastSelectTags{},
-    m_expandedFolder{}
+TreeViewLogic::TreeViewLogic(NodeTreeView *treeView, NodeTreeModel *treeModel, DBManager *dbManager,
+                             QObject *parent)
+    : QObject(parent),
+      m_treeView{ treeView },
+      m_treeModel{ treeModel },
+      m_dbManager{ dbManager },
+      m_needLoadSavedState{ false },
+      m_isLastSelectFolder{ true },
+      m_lastSelectFolder{},
+      m_lastSelectTags{},
+      m_expandedFolder{}
 {
     m_treeDelegate = new NodeTreeDelegate(m_treeView, m_treeView);
     m_treeView->setItemDelegate(m_treeDelegate);
-    connect(m_dbManager, &DBManager::nodesTagTreeReceived,
-            this, &TreeViewLogic::loadTreeModel, Qt::QueuedConnection);
-    connect(m_treeModel, &NodeTreeModel::topLevelItemLayoutChanged,
-            this, &TreeViewLogic::updateTreeViewSeparator);
-    connect(m_treeView, &NodeTreeView::addFolderRequested,
-            this, [this] {
-        onAddFolderRequested(false);
-    });
-    connect(m_treeDelegate, &NodeTreeDelegate::addFolderRequested,
-            this, [this] {
-        onAddFolderRequested(true);
-    });
-    connect(m_treeDelegate, &NodeTreeDelegate::addTagRequested,
-            this, &TreeViewLogic::onAddTagRequested);
-    connect(m_treeView, &NodeTreeView::renameFolderInDatabase,
-            this, &TreeViewLogic::onRenameNodeRequestedFromTreeView);
-    connect(m_treeView, &NodeTreeView::renameTagInDatabase,
-            this, &TreeViewLogic::onRenameTagRequestedFromTreeView);
-    connect(this, &TreeViewLogic::requestRenameNodeInDB,
-            m_dbManager, &DBManager::renameNode, Qt::QueuedConnection);
-    connect(this, &TreeViewLogic::requestRenameTagInDB,
-            m_dbManager, &DBManager::renameTag, Qt::QueuedConnection);
-    connect(m_treeView, &NodeTreeView::deleteNodeRequested,
-            this, &TreeViewLogic::onDeleteFolderRequested);
-    connect(m_treeView, &NodeTreeView::changeTagColorRequested,
-            this, &TreeViewLogic::onChangeTagColorRequested);
-    connect(m_treeView, &NodeTreeView::deleteTagRequested,
-            this, &TreeViewLogic::onDeleteTagRequested);
-    connect(this, &TreeViewLogic::requestChangeTagColorInDB,
-            m_dbManager, &DBManager::changeTagColor, Qt::QueuedConnection);
-    connect(this, &TreeViewLogic::requestMoveNodeInDB,
-            m_dbManager, &DBManager::moveNode, Qt::QueuedConnection);
-    connect(m_treeView, &NodeTreeView::moveNodeRequested,
-            this, [this] (int nodeId, int targetId) {
+    connect(m_dbManager, &DBManager::nodesTagTreeReceived, this, &TreeViewLogic::loadTreeModel,
+            Qt::QueuedConnection);
+    connect(m_treeModel, &NodeTreeModel::topLevelItemLayoutChanged, this,
+            &TreeViewLogic::updateTreeViewSeparator);
+    connect(m_treeView, &NodeTreeView::addFolderRequested, this,
+            [this] { onAddFolderRequested(false); });
+    connect(m_treeDelegate, &NodeTreeDelegate::addFolderRequested, this,
+            [this] { onAddFolderRequested(true); });
+    connect(m_treeDelegate, &NodeTreeDelegate::addTagRequested, this,
+            &TreeViewLogic::onAddTagRequested);
+    connect(m_treeView, &NodeTreeView::renameFolderInDatabase, this,
+            &TreeViewLogic::onRenameNodeRequestedFromTreeView);
+    connect(m_treeView, &NodeTreeView::renameTagInDatabase, this,
+            &TreeViewLogic::onRenameTagRequestedFromTreeView);
+    connect(this, &TreeViewLogic::requestRenameNodeInDB, m_dbManager, &DBManager::renameNode,
+            Qt::QueuedConnection);
+    connect(this, &TreeViewLogic::requestRenameTagInDB, m_dbManager, &DBManager::renameTag,
+            Qt::QueuedConnection);
+    connect(m_treeView, &NodeTreeView::deleteNodeRequested, this,
+            &TreeViewLogic::onDeleteFolderRequested);
+    connect(m_treeView, &NodeTreeView::changeTagColorRequested, this,
+            &TreeViewLogic::onChangeTagColorRequested);
+    connect(m_treeView, &NodeTreeView::deleteTagRequested, this,
+            &TreeViewLogic::onDeleteTagRequested);
+    connect(this, &TreeViewLogic::requestChangeTagColorInDB, m_dbManager,
+            &DBManager::changeTagColor, Qt::QueuedConnection);
+    connect(this, &TreeViewLogic::requestMoveNodeInDB, m_dbManager, &DBManager::moveNode,
+            Qt::QueuedConnection);
+    connect(m_treeView, &NodeTreeView::moveNodeRequested, this, [this](int nodeId, int targetId) {
         onMoveNodeRequested(nodeId, targetId);
         emit noteMoved(nodeId, targetId);
     });
-    connect(m_treeView, &NodeTreeView::addNoteToTag,
-            this, &TreeViewLogic::addNoteToTag);
-    connect(m_treeModel, &NodeTreeModel::requestExpand,
-            m_treeView, &NodeTreeView::onRequestExpand);
-    connect(m_treeModel, &NodeTreeModel::requestUpdateAbsPath,
-            m_treeView, &NodeTreeView::onUpdateAbsPath);
-    connect(m_treeModel, &NodeTreeModel::requestMoveNode,
-            this, &TreeViewLogic::onMoveNodeRequested);
-    connect(m_treeModel, &NodeTreeModel::requestUpdateNodeRelativePosition,
-            m_dbManager, &DBManager::updateRelPosNode, Qt::QueuedConnection);
-    connect(m_treeModel, &NodeTreeModel::requestUpdateTagRelativePosition,
-            m_dbManager, &DBManager::updateRelPosTag, Qt::QueuedConnection);
-    connect(m_treeModel, &NodeTreeModel::dropFolderSuccessfull,
-            m_treeView, &NodeTreeView::onFolderDropSuccessfull);
-    connect(m_treeModel, &NodeTreeModel::dropTagsSuccessfull,
-            m_treeView, &NodeTreeView::onTagsDropSuccessfull);
-    connect(m_treeModel, &NodeTreeModel::requestMoveFolderToTrash,
-            this, &TreeViewLogic::onDeleteFolderRequested);
-    connect(m_dbManager, &DBManager::childNotesCountUpdatedFolder,
-            this, &TreeViewLogic::onChildNoteCountChangedFolder);
-    connect(m_dbManager, &DBManager::childNotesCountUpdatedTag,
-            this, &TreeViewLogic::onChildNotesCountChangedTag);
+    connect(m_treeView, &NodeTreeView::addNoteToTag, this, &TreeViewLogic::addNoteToTag);
+    connect(m_treeModel, &NodeTreeModel::requestExpand, m_treeView, &NodeTreeView::onRequestExpand);
+    connect(m_treeModel, &NodeTreeModel::requestUpdateAbsPath, m_treeView,
+            &NodeTreeView::onUpdateAbsPath);
+    connect(m_treeModel, &NodeTreeModel::requestMoveNode, this,
+            &TreeViewLogic::onMoveNodeRequested);
+    connect(m_treeModel, &NodeTreeModel::requestUpdateNodeRelativePosition, m_dbManager,
+            &DBManager::updateRelPosNode, Qt::QueuedConnection);
+    connect(m_treeModel, &NodeTreeModel::requestUpdateTagRelativePosition, m_dbManager,
+            &DBManager::updateRelPosTag, Qt::QueuedConnection);
+    connect(m_treeModel, &NodeTreeModel::dropFolderSuccessfull, m_treeView,
+            &NodeTreeView::onFolderDropSuccessfull);
+    connect(m_treeModel, &NodeTreeModel::dropTagsSuccessfull, m_treeView,
+            &NodeTreeView::onTagsDropSuccessfull);
+    connect(m_treeModel, &NodeTreeModel::requestMoveFolderToTrash, this,
+            &TreeViewLogic::onDeleteFolderRequested);
+    connect(m_dbManager, &DBManager::childNotesCountUpdatedFolder, this,
+            &TreeViewLogic::onChildNoteCountChangedFolder);
+    connect(m_dbManager, &DBManager::childNotesCountUpdatedTag, this,
+            &TreeViewLogic::onChildNotesCountChangedTag);
     m_style = new CustomApplicationStyle();
     qApp->setStyle(m_style);
 }
@@ -100,10 +91,9 @@ void TreeViewLogic::loadTreeModel(const NodeTagTreeData &treeData)
     m_treeModel->setTreeData(treeData);
     {
         NodeData node;
-        QMetaObject::invokeMethod(m_dbManager, "getChildNotesCountFolder", Qt::BlockingQueuedConnection,
-                                  Q_RETURN_ARG(NodeData, node),
-                                  Q_ARG(int, SpecialNodeID::RootFolder)
-                                  );
+        QMetaObject::invokeMethod(m_dbManager, "getChildNotesCountFolder",
+                                  Qt::BlockingQueuedConnection, Q_RETURN_ARG(NodeData, node),
+                                  Q_ARG(int, SpecialNodeID::RootFolder));
         auto index = m_treeModel->getAllNotesButtonIndex();
         if (index.isValid()) {
             m_treeModel->setData(index, node.childNotesCount(), NodeItem::Roles::ChildCount);
@@ -111,10 +101,9 @@ void TreeViewLogic::loadTreeModel(const NodeTagTreeData &treeData)
     }
     {
         NodeData node;
-        QMetaObject::invokeMethod(m_dbManager, "getChildNotesCountFolder", Qt::BlockingQueuedConnection,
-                                  Q_RETURN_ARG(NodeData, node),
-                                  Q_ARG(int, SpecialNodeID::TrashFolder)
-                                  );
+        QMetaObject::invokeMethod(m_dbManager, "getChildNotesCountFolder",
+                                  Qt::BlockingQueuedConnection, Q_RETURN_ARG(NodeData, node),
+                                  Q_ARG(int, SpecialNodeID::TrashFolder));
         auto index = m_treeModel->getTrashButtonIndex();
         if (index.isValid()) {
             m_treeModel->setData(index, node.childNotesCount(), NodeItem::Roles::ChildCount);
@@ -138,7 +127,7 @@ void TreeViewLogic::loadTreeModel(const NodeTagTreeData &treeData)
                 m_treeView->setCurrentIndexC(m_treeModel->getAllNotesButtonIndex());
             }
         } else {
-            for (const auto& id: qAsConst(m_lastSelectTags)) {
+            for (const auto &id : qAsConst(m_lastSelectTags)) {
                 m_treeView->setCurrentIndexNC(m_treeModel->tagIndexFromId(id));
             }
         }
@@ -167,7 +156,8 @@ void TreeViewLogic::onAddFolderRequested(bool fromPlusButton)
     QString currentAbsPath;
     int currentTagId = SpecialNodeID::InvalidNodeId;
     if (currentIndex.isValid() && !fromPlusButton) {
-        auto type = static_cast<NodeItem::Type>(currentIndex.data(NodeItem::Roles::ItemType).toInt());
+        auto type =
+                static_cast<NodeItem::Type>(currentIndex.data(NodeItem::Roles::ItemType).toInt());
         if (type == NodeItem::FolderItem) {
             parentId = currentIndex.data(NodeItem::Roles::NodeId).toInt();
             // we don't allow subfolder under default notes folder
@@ -181,7 +171,8 @@ void TreeViewLogic::onAddFolderRequested(bool fromPlusButton)
             currentIndex = m_treeModel->rootIndex();
         }
     } else {
-        currentType = static_cast<NodeItem::Type>(currentIndex.data(NodeItem::Roles::ItemType).toInt());
+        currentType =
+                static_cast<NodeItem::Type>(currentIndex.data(NodeItem::Roles::ItemType).toInt());
         if (currentType == NodeItem::FolderItem) {
             currentAbsPath = currentIndex.data(NodeItem::Roles::AbsPath).toString();
         } else if (currentType == NodeItem::TagItem) {
@@ -203,9 +194,7 @@ void TreeViewLogic::onAddFolderRequested(bool fromPlusButton)
     newFolder.setParentId(parentId);
 
     QMetaObject::invokeMethod(m_dbManager, "addNode", Qt::BlockingQueuedConnection,
-                              Q_RETURN_ARG(int, newlyCreatedNodeId),
-                              Q_ARG(NodeData, newFolder)
-                              );
+                              Q_RETURN_ARG(int, newlyCreatedNodeId), Q_ARG(NodeData, newFolder));
 
     QHash<NodeItem::Roles, QVariant> hs;
     hs[NodeItem::Roles::ItemType] = NodeItem::Type::FolderItem;
@@ -213,16 +202,14 @@ void TreeViewLogic::onAddFolderRequested(bool fromPlusButton)
     hs[NodeItem::Roles::NodeId] = newlyCreatedNodeId;
 
     if (parentId != SpecialNodeID::RootFolder) {
-        hs[NodeItem::Roles::AbsPath] =
-                currentIndex.data(NodeItem::Roles::AbsPath).toString()
+        hs[NodeItem::Roles::AbsPath] = currentIndex.data(NodeItem::Roles::AbsPath).toString()
                 + PATH_SEPERATOR + QString::number(newlyCreatedNodeId);
         m_treeModel->appendChildNodeToParent(currentIndex, hs);
         if (!m_treeView->isExpanded(currentIndex)) {
             m_treeView->expand(currentIndex);
         }
     } else {
-        hs[NodeItem::Roles::AbsPath] =
-                PATH_SEPERATOR + QString::number(SpecialNodeID::RootFolder)
+        hs[NodeItem::Roles::AbsPath] = PATH_SEPERATOR + QString::number(SpecialNodeID::RootFolder)
                 + PATH_SEPERATOR + QString::number(newlyCreatedNodeId);
         m_treeModel->appendChildNodeToParent(m_treeModel->rootIndex(), hs);
     }
@@ -261,13 +248,11 @@ void TreeViewLogic::onAddTagRequested()
     int h = rand * 359;
     int s = 255;
     int v = 128 + rand * 127;
-    auto color = QColor::fromHsv(h,s,v);
+    auto color = QColor::fromHsv(h, s, v);
 
     newTag.setColor(color.name());
     QMetaObject::invokeMethod(m_dbManager, "addTag", Qt::BlockingQueuedConnection,
-                              Q_RETURN_ARG(int, newlyCreatedTagId),
-                              Q_ARG(TagData, newTag)
-                              );
+                              Q_RETURN_ARG(int, newlyCreatedTagId), Q_ARG(TagData, newTag));
 
     QHash<NodeItem::Roles, QVariant> hs;
     hs[NodeItem::Roles::ItemType] = NodeItem::Type::TagItem;
@@ -277,7 +262,8 @@ void TreeViewLogic::onAddTagRequested()
     m_treeModel->appendChildNodeToParent(m_treeModel->rootIndex(), hs);
 }
 
-void TreeViewLogic::onRenameNodeRequestedFromTreeView(const QModelIndex &index, const QString &newName)
+void TreeViewLogic::onRenameNodeRequestedFromTreeView(const QModelIndex &index,
+                                                      const QString &newName)
 {
     m_treeModel->setData(index, newName, NodeItem::Roles::DisplayText);
     auto id = index.data(NodeItem::Roles::NodeId).toInt();
@@ -287,7 +273,8 @@ void TreeViewLogic::onRenameNodeRequestedFromTreeView(const QModelIndex &index, 
 void TreeViewLogic::onDeleteFolderRequested(const QModelIndex &index)
 {
     auto btn = QMessageBox::question(nullptr, "Are you sure you want to delete this folder",
-                                     "Are you sure you want to delete this folder? All notes and any subfolders will be deleted.");
+                                     "Are you sure you want to delete this folder? All notes and "
+                                     "any subfolders will be deleted.");
     if (btn == QMessageBox::Yes) {
         auto id = index.data(NodeItem::Roles::NodeId).toInt();
         if (id < SpecialNodeID::DefaultNotesFolder) {
@@ -296,10 +283,8 @@ void TreeViewLogic::onDeleteFolderRequested(const QModelIndex &index)
         }
         NodeData node;
         QMetaObject::invokeMethod(m_dbManager, "getNode", Qt::BlockingQueuedConnection,
-                                  Q_RETURN_ARG(NodeData, node),
-                                  Q_ARG(int, id)
-                                  );
-        auto parentPath = NodePath{node.absolutePath()}.parentPath();
+                                  Q_RETURN_ARG(NodeData, node), Q_ARG(int, id));
+        auto parentPath = NodePath{ node.absolutePath() }.parentPath();
         auto parentIndex = m_treeModel->folderIndexFromIdPath(parentPath);
         if (parentIndex.isValid()) {
             m_treeModel->deleteRow(index, parentIndex);
@@ -316,7 +301,8 @@ void TreeViewLogic::onDeleteFolderRequested(const QModelIndex &index)
     }
 }
 
-void TreeViewLogic::onRenameTagRequestedFromTreeView(const QModelIndex &index, const QString &newName)
+void TreeViewLogic::onRenameTagRequestedFromTreeView(const QModelIndex &index,
+                                                     const QString &newName)
 {
     m_treeModel->setData(index, newName, NodeItem::Roles::DisplayText);
     auto id = index.data(NodeItem::Roles::NodeId).toInt();
@@ -327,7 +313,7 @@ void TreeViewLogic::onChangeTagColorRequested(const QModelIndex &index)
 {
     if (index.isValid()) {
         auto currentColor = m_treeModel->data(index, NodeItem::Roles::TagColor).toString();
-        auto newColor = QColorDialog::getColor(QColor{currentColor});
+        auto newColor = QColorDialog::getColor(QColor{ currentColor });
         if (newColor.isValid()) {
             m_treeModel->setData(index, newColor.name(), NodeItem::Roles::TagColor);
             auto id = index.data(NodeItem::Roles::NodeId).toInt();
@@ -340,8 +326,7 @@ void TreeViewLogic::onDeleteTagRequested(const QModelIndex &index)
 {
     auto id = index.data(NodeItem::Roles::NodeId).toInt();
     m_treeModel->deleteRow(index, m_treeModel->rootIndex());
-    QMetaObject::invokeMethod(m_dbManager, "removeTag", Qt::QueuedConnection,
-                              Q_ARG(int, id));
+    QMetaObject::invokeMethod(m_dbManager, "removeTag", Qt::QueuedConnection, Q_ARG(int, id));
     m_treeView->setCurrentIndexC(m_treeModel->getAllNotesButtonIndex());
 }
 
@@ -353,7 +338,8 @@ void TreeViewLogic::onChildNotesCountChangedTag(int tagId, int notesCount)
     }
 }
 
-void TreeViewLogic::onChildNoteCountChangedFolder(int folderId, const QString &absPath, int notesCount)
+void TreeViewLogic::onChildNoteCountChangedFolder(int folderId, const QString &absPath,
+                                                  int notesCount)
 {
     QModelIndex index;
     if (folderId == SpecialNodeID::RootFolder) {
@@ -372,9 +358,7 @@ void TreeViewLogic::openFolder(int id)
 {
     NodeData target;
     QMetaObject::invokeMethod(m_dbManager, "getNode", Qt::BlockingQueuedConnection,
-                              Q_RETURN_ARG(NodeData, target),
-                              Q_ARG(int, id)
-                              );
+                              Q_RETURN_ARG(NodeData, target), Q_ARG(int, id));
     if (target.nodeType() != NodeData::Folder) {
         qDebug() << __FUNCTION__ << "Target is not folder!";
         return;
@@ -397,9 +381,7 @@ void TreeViewLogic::onMoveNodeRequested(int nodeId, int targetId)
 {
     NodeData target;
     QMetaObject::invokeMethod(m_dbManager, "getNode", Qt::BlockingQueuedConnection,
-                              Q_RETURN_ARG(NodeData, target),
-                              Q_ARG(int, targetId)
-                              );
+                              Q_RETURN_ARG(NodeData, target), Q_ARG(int, targetId));
     if (target.nodeType() != NodeData::Folder) {
         qDebug() << __FUNCTION__ << "Target is not folder!";
         return;
@@ -415,10 +397,9 @@ void TreeViewLogic::setTheme(Theme theme)
     m_style->setTheme(theme);
 }
 
-void TreeViewLogic::setLastSavedState(bool isLastSelectFolder,
-                                      const QString &lastSelectFolder,
+void TreeViewLogic::setLastSavedState(bool isLastSelectFolder, const QString &lastSelectFolder,
                                       const QSet<int> &lastSelectTag,
-                                      const QStringList& expandedFolder)
+                                      const QStringList &expandedFolder)
 {
     m_isLastSelectFolder = isLastSelectFolder;
     m_lastSelectFolder = lastSelectFolder;
@@ -426,4 +407,3 @@ void TreeViewLogic::setLastSavedState(bool isLastSelectFolder,
     m_expandedFolder = expandedFolder;
     m_needLoadSavedState = true;
 }
-

--- a/src/treeviewlogic.h
+++ b/src/treeviewlogic.h
@@ -15,34 +15,30 @@ class TreeViewLogic : public QObject
 {
     Q_OBJECT
 public:
-    explicit TreeViewLogic(NodeTreeView* treeView,
-                                        NodeTreeModel* treeModel,
-                                        DBManager* dbManager,
-                                        QObject *parent = nullptr);
+    explicit TreeViewLogic(NodeTreeView *treeView, NodeTreeModel *treeModel, DBManager *dbManager,
+                           QObject *parent = nullptr);
     void openFolder(int id);
     void onMoveNodeRequested(int nodeId, int targetId);
     void setTheme(Theme theme);
-    void setLastSavedState(bool isLastSelectFolder,
-                           const QString& lastSelectFolder,
-                           const QSet<int>& lastSelectTag,
-                           const QStringList &expandedFolder);
+    void setLastSavedState(bool isLastSelectFolder, const QString &lastSelectFolder,
+                           const QSet<int> &lastSelectTag, const QStringList &expandedFolder);
 private slots:
     void updateTreeViewSeparator();
     void loadTreeModel(const NodeTagTreeData &treeData);
     void onAddTagRequested();
-    void onRenameNodeRequestedFromTreeView(const QModelIndex& index, const QString& newName);
-    void onDeleteFolderRequested(const QModelIndex& index);
-    void onRenameTagRequestedFromTreeView(const QModelIndex& index, const QString& newName);
-    void onChangeTagColorRequested(const QModelIndex& index);
-    void onDeleteTagRequested(const QModelIndex& index);
+    void onRenameNodeRequestedFromTreeView(const QModelIndex &index, const QString &newName);
+    void onDeleteFolderRequested(const QModelIndex &index);
+    void onRenameTagRequestedFromTreeView(const QModelIndex &index, const QString &newName);
+    void onChangeTagColorRequested(const QModelIndex &index);
+    void onDeleteTagRequested(const QModelIndex &index);
     void onChildNotesCountChangedTag(int tagId, int notesCount);
     void onChildNoteCountChangedFolder(int folderId, const QString &absPath, int notesCount);
 
 signals:
-    void requestRenameNodeInDB(int id, const QString& newName);
-    void requestRenameTagInDB(int id, const QString& newName);
-    void requestChangeTagColorInDB(int id, const QString& newColor);
-    void requestMoveNodeInDB(int id, const NodeData& target);
+    void requestRenameNodeInDB(int id, const QString &newName);
+    void requestRenameTagInDB(int id, const QString &newName);
+    void requestChangeTagColorInDB(int id, const QString &newColor);
+    void requestMoveNodeInDB(int id, const NodeData &target);
     void addNoteToTag(int noteId, int tagId);
     void noteMoved(int nodeId, int targetId);
 
@@ -50,11 +46,11 @@ private:
     void onAddFolderRequested(bool fromPlusButton);
 
 private:
-    NodeTreeView* m_treeView;
-    NodeTreeModel* m_treeModel;
-    NodeTreeDelegate* m_treeDelegate;
-    DBManager* m_dbManager;
-    CustomApplicationStyle* m_style;
+    NodeTreeView *m_treeView;
+    NodeTreeModel *m_treeModel;
+    NodeTreeDelegate *m_treeDelegate;
+    DBManager *m_dbManager;
+    CustomApplicationStyle *m_style;
     bool m_needLoadSavedState;
     bool m_isLastSelectFolder;
     QString m_lastSelectFolder;

--- a/src/updaterwindow.cpp
+++ b/src/updaterwindow.cpp
@@ -1,8 +1,8 @@
 /*********************************************************************************************
-* Mozila License
-* Just a meantime project to see the ability of qt, the framework that my OS might be based on
-* And for those linux users that beleive in the power of notes
-*********************************************************************************************/
+ * Mozila License
+ * Just a meantime project to see the ability of qt, the framework that my OS might be based on
+ * And for those linux users that beleive in the power of notes
+ *********************************************************************************************/
 
 #include "updaterwindow.h"
 #include "ui_updaterwindow.h"
@@ -19,60 +19,64 @@
 
 #include <QSimpleUpdater.h>
 
-#if defined (Q_OS_LINUX) || defined (Q_OS_FREEBSD)
-  #define UseXdgOpen
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+#  define UseXdgOpen
 #else
-  #ifdef UseXdgOpen
-    #undef UseXdgOpen
-  #endif
+#  ifdef UseXdgOpen
+#    undef UseXdgOpen
+#  endif
 #endif
 
 #ifdef UseXdgOpen
-  #include <QProcess>
-  static QProcess XDGOPEN_PROCESS;
+#  include <QProcess>
+static QProcess XDGOPEN_PROCESS;
 #endif
 
 /**
  * Indicates from where we should download the update definitions file
  */
-static const QString UPDATES_URL("https://raw.githubusercontent.com/nuttyartist/notes/master/UPDATES.json");
+static const QString
+        UPDATES_URL("https://raw.githubusercontent.com/nuttyartist/notes/master/UPDATES.json");
 
 /**
  * Download dir
  */
-static const QDir DOWNLOAD_DIR(QDir::homePath()+ "/Downloads/");
+static const QDir DOWNLOAD_DIR(QDir::homePath() + "/Downloads/");
 
 /**
  * Initializes the window components and configures the QSimpleUpdater
  */
-UpdaterWindow::UpdaterWindow(QWidget *parent) :
-    QWidget(parent),
-    m_fileName(""),
-    m_ui(new Ui::UpdaterWindow),
-    m_canMoveWindow(false),
-    m_checkingForUpdates(false),
-    m_dontShowUpdateWindow(false),
-    m_forced(false),
-    m_reply(Q_NULLPTR),
-    m_updater(QSimpleUpdater::getInstance()),
-    m_manager(new QNetworkAccessManager(this))
+UpdaterWindow::UpdaterWindow(QWidget *parent)
+    : QWidget(parent),
+      m_fileName(""),
+      m_ui(new Ui::UpdaterWindow),
+      m_canMoveWindow(false),
+      m_checkingForUpdates(false),
+      m_dontShowUpdateWindow(false),
+      m_forced(false),
+      m_reply(Q_NULLPTR),
+      m_updater(QSimpleUpdater::getInstance()),
+      m_manager(new QNetworkAccessManager(this))
 {
     /* Load the stylesheet */
     QFile file(":/styles/style.css");
-    if(file.open(QIODevice::ReadOnly)){
+    if (file.open(QIODevice::ReadOnly)) {
         setStyleSheet(QString::fromUtf8(file.readAll()).toLatin1());
         file.close();
     }
 
     /* Initialize the UI */
     m_ui->setupUi(this);
-    setWindowTitle(qApp->applicationName()+ " " + tr("Updater"));
+    setWindowTitle(qApp->applicationName() + " " + tr("Updater"));
 
     /* Change fonts */
 #ifdef __APPLE__
-    QFont fontToUse = QFont(QStringLiteral("SF Pro Text")).exactMatch() ? QStringLiteral("SF Pro Text") : QStringLiteral("Roboto");
+    QFont fontToUse = QFont(QStringLiteral("SF Pro Text")).exactMatch()
+            ? QStringLiteral("SF Pro Text")
+            : QStringLiteral("Roboto");
 #elif _WIN32
-    QFont fontToUse = QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI") : QStringLiteral("Roboto");
+    QFont fontToUse = QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI")
+                                                                     : QStringLiteral("Roboto");
 #else
     QFont fontToUse = QFont(QStringLiteral("Roboto"));
 #endif
@@ -80,16 +84,16 @@ UpdaterWindow::UpdaterWindow(QWidget *parent) :
     this->setFont(fontToUse);
     m_ui->changelog->setFont(fontToUse);
     m_ui->changelog->setTextColor(QColor(26, 26, 26));
-    foreach(QWidget *widgetChild, this->findChildren<QWidget *>()) {
+    foreach (QWidget *widgetChild, this->findChildren<QWidget *>()) {
         widgetChild->setFont(fontToUse);
     }
 
-
     /* Connect UI signals/slots */
-    connect(m_ui->closeButton,  &QPushButton::clicked, this, &UpdaterWindow::close);
-    connect(m_ui->updateButton, &QPushButton::clicked, this, &UpdaterWindow::onDownloadButtonClicked);
-    connect(m_updater, &QSimpleUpdater::checkingFinished,this, &UpdaterWindow::onCheckFinished);
-    connect(m_ui->checkBox, &QCheckBox::toggled, this ,&UpdaterWindow::dontShowUpdateWindowChanged);
+    connect(m_ui->closeButton, &QPushButton::clicked, this, &UpdaterWindow::close);
+    connect(m_ui->updateButton, &QPushButton::clicked, this,
+            &UpdaterWindow::onDownloadButtonClicked);
+    connect(m_updater, &QSimpleUpdater::checkingFinished, this, &UpdaterWindow::onCheckFinished);
+    connect(m_ui->checkBox, &QCheckBox::toggled, this, &UpdaterWindow::dontShowUpdateWindowChanged);
 
     /* Start the UI loops */
     updateTitleLabel();
@@ -100,7 +104,7 @@ UpdaterWindow::UpdaterWindow(QWidget *parent) :
 #elif defined Q_OS_MAC || defined Q_OS_LINUX || defined Q_OS_FREEBSD
     setWindowFlags(Qt::Window | Qt::FramelessWindowHint);
 #else
-#error "We don't support your OS yet..."
+#  error "We don't support your OS yet..."
 #endif
 
     /* React when xdg-open finishes (Linux only) */
@@ -140,7 +144,7 @@ void UpdaterWindow::setShowWindowDisable(const bool dontShowWindow)
 void UpdaterWindow::checkForUpdates(bool force)
 {
     /* Change the silent flag */
-    if(!m_updater->getUpdateAvailable(UPDATES_URL)){
+    if (!m_updater->getUpdateAvailable(UPDATES_URL)) {
         m_checkingForUpdates = true;
 
         m_forced = force;
@@ -157,8 +161,8 @@ void UpdaterWindow::checkForUpdates(bool force)
     }
 
     /* Show window if force flag is set */
-    if(force){
-        if(!m_updater->getUpdateAvailable(UPDATES_URL)){
+    if (force) {
+        if (!m_updater->getUpdateAvailable(UPDATES_URL)) {
             m_ui->updateButton->setEnabled(false);
             m_ui->title->setText(tr("Checking for updates...."));
         }
@@ -184,66 +188,65 @@ void UpdaterWindow::resetControls()
     m_ui->availableVersion->setText(m_updater->getLatestVersion(UPDATES_URL));
 
     /* Set title label */
-    if(m_updater->getUpdateAvailable(UPDATES_URL)){
+    if (m_updater->getUpdateAvailable(UPDATES_URL)) {
         m_ui->title->setText(tr("A Newer Version is Available!"));
-    }else{
+    } else {
         m_ui->title->setText(tr("You're up-to-date!"));
     }
 
     /* Reset the progress controls */
     m_ui->progressControls->hide();
     m_ui->progressBar->setValue(0);
-    m_ui->downloadLabel->setText(tr("Downloading Updates")+ "...");
-    m_ui->timeLabel->setText(tr("Time remaining")+ ": " + tr("unknown"));
+    m_ui->downloadLabel->setText(tr("Downloading Updates") + "...");
+    m_ui->timeLabel->setText(tr("Time remaining") + ": " + tr("unknown"));
 
     /* Set changelog text */
     QString changelogText = m_updater->getChangelog(UPDATES_URL);
     m_ui->changelog->setText(changelogText);
-    if(m_ui->changelog->toPlainText().isEmpty()){
+    if (m_ui->changelog->toPlainText().isEmpty()) {
         m_ui->changelog->setText("<p>No changelog found...</p>");
     } else {
-        m_ui->changelog->setText(changelogText.append("\n")); // Don't know why currently changelog box is dissapearing at the bottom, so I add a new line to see the text.
+        m_ui->changelog->setText(changelogText.append(
+                "\n")); // Don't know why currently changelog box is dissapearing at the bottom, so
+                        // I add a new line to see the text.
     }
 
     /* Enable/disable update button */
     bool available = m_updater->getUpdateAvailable(UPDATES_URL);
     bool validOpenUrl = !m_updater->getOpenUrl(UPDATES_URL).isEmpty();
     bool validDownUrl = !m_updater->getDownloadUrl(UPDATES_URL).isEmpty();
-    m_ui->updateButton->setEnabled(available &&(validOpenUrl || validDownUrl));
+    m_ui->updateButton->setEnabled(available && (validOpenUrl || validDownUrl));
 
     /* Resize window */
     bool showAgain = isVisible();
     int height = minimumSizeHint().height();
-    int width = qMax(minimumSizeHint().width(),int(height * 1.2));
+    int width = qMax(minimumSizeHint().width(), int(height * 1.2));
     resize(QSize(width, height));
 
     /* Re-show the window(if required)*/
-    if(showAgain){
+    if (showAgain) {
         showNormal();
     }
 }
 
 /**
  * Changes the number of dots of the title label while the QSimpleUpdater
- * is downloading and interpreting the update definitions file 
+ * is downloading and interpreting the update definitions file
  */
 void UpdaterWindow::updateTitleLabel()
 {
-    if(m_checkingForUpdates)
-    {
-        static int num=0;
+    if (m_checkingForUpdates) {
+        static int num = 0;
         QString base = tr("Checking for updates");
         QString dot = "";
         num++;
         dot.fill('.', num);
-        m_ui->title->setText(base+dot);
-        if(num==4)
-            num=0;
+        m_ui->title->setText(base + dot);
+        if (num == 4)
+            num = 0;
     }
     QTimer::singleShot(500, this, SLOT(updateTitleLabel()));
 }
-
-
 
 /**
  * Updates the text displayed the the UI controls to reflect the information
@@ -251,7 +254,7 @@ void UpdaterWindow::updateTitleLabel()
  */
 void UpdaterWindow::onUpdateAvailable()
 {
-    if(!m_dontShowUpdateWindow){
+    if (!m_dontShowUpdateWindow) {
         resetControls();
         showNormal();
     }
@@ -262,7 +265,7 @@ void UpdaterWindow::onUpdateAvailable()
  */
 void UpdaterWindow::onDownloadButtonClicked()
 {
-    if(m_updater->getUpdateAvailable(UPDATES_URL)){
+    if (m_updater->getUpdateAvailable(UPDATES_URL)) {
         m_ui->updateButton->setEnabled(false);
         startDownload(m_updater->getDownloadUrl(UPDATES_URL));
     }
@@ -273,16 +276,16 @@ void UpdaterWindow::onDownloadButtonClicked()
  * to automatically update the user interface when we receive new data
  * from the download/update server
  */
-void UpdaterWindow::startDownload(const QUrl& url)
+void UpdaterWindow::startDownload(const QUrl &url)
 {
     /* URL is invalid, try opening web browser */
-    if(url.isEmpty()){
+    if (url.isEmpty()) {
         QDesktopServices::openUrl(QUrl(m_updater->getOpenUrl(UPDATES_URL)));
         return;
     }
 
     /* Cancel previous download (if any)*/
-    if(m_reply){
+    if (m_reply) {
         m_reply->abort();
         m_reply->deleteLater();
     }
@@ -298,14 +301,14 @@ void UpdaterWindow::startDownload(const QUrl& url)
 
     /* Set file name */
     m_fileName = m_updater->getDownloadUrl(UPDATES_URL).split("/").last();
-    if(m_fileName.isEmpty()){
+    if (m_fileName.isEmpty()) {
         m_fileName = QString("%1_Update_%2.bin")
-                .arg(qApp->applicationName())
-                .arg(m_updater->getLatestVersion(UPDATES_URL));
+                             .arg(qApp->applicationName())
+                             .arg(m_updater->getLatestVersion(UPDATES_URL));
     }
 
     /* Prepare download directory */
-    if(!DOWNLOAD_DIR.exists())
+    if (!DOWNLOAD_DIR.exists())
         DOWNLOAD_DIR.mkpath(".");
 
     /* Remove previous downloads(if any)*/
@@ -323,21 +326,21 @@ void UpdaterWindow::startDownload(const QUrl& url)
 /**
  * Opens the downloaded file
  */
-void UpdaterWindow::openDownload(const QString& file)
+void UpdaterWindow::openDownload(const QString &file)
 {
     /* File is empty, abort */
-    if(file.isEmpty()){
+    if (file.isEmpty()) {
         return;
     }
 
     /* Change labels */
     m_ui->downloadLabel->setText(tr("Download finished!"));
-    m_ui->timeLabel->setText(tr("Opening downloaded file")+ "...");
+    m_ui->timeLabel->setText(tr("Opening downloaded file") + "...");
 
     /* Try to open the downloaded file (Windows & Mac) */
 #ifndef UseXdgOpen
     bool openUrl = QDesktopServices::openUrl(QUrl::fromLocalFile(file));
-    if(!openUrl){
+    if (!openUrl) {
         openDownloadFolder(file);
         m_ui->progressControls->hide();
         qApp->processEvents();
@@ -368,11 +371,10 @@ void UpdaterWindow::onCheckFinished(const QString &url)
     /* Do not allow the title label to change automatically */
     m_checkingForUpdates = false;
 
-
     /* There is an update available, show the window */
-    if(m_updater->getUpdateAvailable(url)&&(UPDATES_URL == url)){
+    if (m_updater->getUpdateAvailable(url) && (UPDATES_URL == url)) {
         onUpdateAvailable();
-    }else if(m_forced){
+    } else if (m_forced) {
         m_forced = false;
         resetControls();
         showNormal();
@@ -394,7 +396,7 @@ void UpdaterWindow::onXdgOpenFinished(const int exitCode)
         qApp->quit();
     }
 #else
-    Q_UNUSED (exitCode);
+    Q_UNUSED(exitCode);
 #endif
 }
 
@@ -407,12 +409,12 @@ void UpdaterWindow::openDownloadFolder(const QString &file)
 {
     /* Notify the user of the problem */
     QString extension = file.split(".").last();
-    QMessageBox::information(this,
-                             tr("Open Error"),
+    QMessageBox::information(this, tr("Open Error"),
                              tr("It seems that your OS does not have an "
                                 "application that can handle *.%1 files. "
                                 "We'll open the downloads folder for you.")
-                             .arg(extension), QMessageBox::Ok);
+                                     .arg(extension),
+                             QMessageBox::Ok);
 
     /* Get the full path list of the downloaded file */
     QString native_path = QDir::toNativeSeparators(QDir(file).absolutePath());
@@ -420,7 +422,7 @@ void UpdaterWindow::openDownloadFolder(const QString &file)
 
     /* Remove file name from list to get the folder of the update file */
     directories.removeLast();
-    QString path = directories.join (QDir::separator());
+    QString path = directories.join(QDir::separator());
 
     /* Get valid URL and open it */
     QUrl url = QUrl::fromLocalFile(QDir(path).absolutePath());
@@ -438,26 +440,25 @@ void UpdaterWindow::calculateSizes(qint64 received, qint64 total)
     QString receivedSize;
 
     /* Get total size string */
-    if(total < 1024){
+    if (total < 1024) {
         totalSize = tr("%1 bytes").arg(total);
-    }else if(total < (1024 * 1024)){
+    } else if (total < (1024 * 1024)) {
         totalSize = tr("%1 KB").arg(round(total / 1024));
-    }else{
+    } else {
         totalSize = tr("%1 MB").arg(round(total / (1024 * 1024)));
     }
 
     /* Get received size string */
-    if(received < 1024){
+    if (received < 1024) {
         receivedSize = tr("%1 bytes").arg(received);
-    }else if(received < (1024 * 1024)){
+    } else if (received < (1024 * 1024)) {
         receivedSize = tr("%1 KB").arg(received / 1024);
-    }else{
+    } else {
         receivedSize = tr("%1 MB").arg(received / (1024 * 1024));
     }
 
     /* Update the label text */
-    m_ui->downloadLabel->setText(tr("Downloading updates")
-                                 + " (" + receivedSize + " " + tr("of")
+    m_ui->downloadLabel->setText(tr("Downloading updates") + " (" + receivedSize + " " + tr("of")
                                  + " " + totalSize + ")");
 }
 
@@ -467,21 +468,19 @@ void UpdaterWindow::calculateSizes(qint64 received, qint64 total)
  */
 void UpdaterWindow::updateProgress(qint64 received, qint64 total)
 {
-    if(total > 0){
+    if (total > 0) {
         m_ui->progressBar->setMinimum(0);
         m_ui->progressBar->setMaximum(100);
-        m_ui->progressBar->setValue(int((received * 100)/ total));
+        m_ui->progressBar->setValue(int((received * 100) / total));
 
         calculateSizes(received, total);
         calculateTimeRemaining(received, total);
-    }else{
+    } else {
         m_ui->progressBar->setMinimum(0);
         m_ui->progressBar->setMaximum(0);
         m_ui->progressBar->setValue(-1);
-        m_ui->downloadLabel->setText(tr("Downloading Updates")+ "...");
-        m_ui->timeLabel->setText(QString("%1: %2")
-                                 .arg(tr("Time Remaining"))
-                                 .arg(tr("unknown")));
+        m_ui->downloadLabel->setText(tr("Downloading Updates") + "...");
+        m_ui->timeLabel->setText(QString("%1: %2").arg(tr("Time Remaining")).arg(tr("unknown")));
     }
 }
 
@@ -497,73 +496,72 @@ void UpdaterWindow::calculateTimeRemaining(qint64 received, qint64 total)
 {
     uint difference = QDateTime::currentDateTime().toSecsSinceEpoch() - m_startTime;
 
-    if(difference > 0){
+    if (difference > 0) {
         QString timeString;
-        qreal timeRemaining = total /(received / difference);
+        qreal timeRemaining = total / (received / difference);
 
-        if(timeRemaining > 7200){
+        if (timeRemaining > 7200) {
             timeRemaining /= 3600;
             int hours = int(timeRemaining + 0.5);
 
-            if(hours > 1){
+            if (hours > 1) {
                 timeString = tr("about %1 hours").arg(hours);
-            }else{
+            } else {
                 timeString = tr("about one hour");
             }
-        }else if(timeRemaining > 60){
+        } else if (timeRemaining > 60) {
             timeRemaining /= 60;
             int minutes = int(timeRemaining + 0.5);
 
-            if(minutes > 1){
+            if (minutes > 1) {
                 timeString = tr("%1 minutes").arg(minutes);
-            }else{
+            } else {
                 timeString = tr("1 minute");
             }
-        }else if(timeRemaining <= 60){
+        } else if (timeRemaining <= 60) {
             int seconds = int(timeRemaining + 0.5);
 
-            if(seconds > 1){
+            if (seconds > 1) {
                 timeString = tr("%1 seconds").arg(seconds);
-            }else{
+            } else {
                 timeString = tr("1 second");
             }
         }
 
-        m_ui->timeLabel->setText(tr("Time remaining")+ ": " + timeString);
+        m_ui->timeLabel->setText(tr("Time remaining") + ": " + timeString);
     }
 }
 
 void UpdaterWindow::onDownloadFinished()
 {
-   QString redirectedUrl = m_reply->attribute(QNetworkRequest::RedirectionTargetAttribute).toString();
+    QString redirectedUrl =
+            m_reply->attribute(QNetworkRequest::RedirectionTargetAttribute).toString();
 
-   if(redirectedUrl.isEmpty()){
+    if (redirectedUrl.isEmpty()) {
 
         QString filePath = DOWNLOAD_DIR.filePath(m_fileName);
         QFile file(filePath);
-        if(file.open(QIODevice::WriteOnly | QIODevice::Append)){
+        if (file.open(QIODevice::WriteOnly | QIODevice::Append)) {
             file.write(m_reply->readAll());
             file.close();
             qApp->processEvents();
         }
 
         openDownload(filePath);
-   }else{
-       startDownload(redirectedUrl);
-   }
+    } else {
+        startDownload(redirectedUrl);
+    }
 }
 
 /**
  * Allows the user to move the window and registers the position in which
  * the user originally clicked to move the window
  */
-void UpdaterWindow::mousePressEvent(QMouseEvent* event)
+void UpdaterWindow::mousePressEvent(QMouseEvent *event)
 {
-    if(event->button()== Qt::LeftButton){
-        if(event->x()< width() - 5
-                && event->x()>5
-                && event->pos().y()< height() - 5
-                && event->pos().y()> 5){
+    if (event->button() == Qt::LeftButton) {
+        if (event->x() < width() - 5 && event->x() > 5 && event->pos().y() < height() - 5
+            && event->pos().y() > 5) {
             m_canMoveWindow = true;
             m_mousePressX = event->x();
             m_mousePressY = event->pos().y();
@@ -577,9 +575,9 @@ void UpdaterWindow::mousePressEvent(QMouseEvent* event)
  * the window)and moves the window to the desired position of the given
  * \a event
  */
-void UpdaterWindow::mouseMoveEvent(QMouseEvent* event)
+void UpdaterWindow::mouseMoveEvent(QMouseEvent *event)
 {
-    if(m_canMoveWindow){
+    if (m_canMoveWindow) {
         setCursor(Qt::ClosedHandCursor);
         int dx = event->globalX() - m_mousePressX;
         int dy = event->globalY() - m_mousePressY;
@@ -602,5 +600,5 @@ void UpdaterWindow::mouseReleaseEvent(QMouseEvent *event)
  */
 qreal UpdaterWindow::round(qreal input)
 {
-    return qreal(roundf(float(input * 100))/100);
+    return qreal(roundf(float(input * 100)) / 100);
 }

--- a/src/updaterwindow.h
+++ b/src/updaterwindow.h
@@ -1,8 +1,8 @@
 /*********************************************************************************************
-* Mozila License
-* Just a meantime project to see the ability of qt, the framework that my OS might be based on
-* And for those linux users that beleive in the power of notes
-*********************************************************************************************/
+ * Mozila License
+ * Just a meantime project to see the ability of qt, the framework that my OS might be based on
+ * And for those linux users that beleive in the power of notes
+ *********************************************************************************************/
 
 #ifndef UPDATERWINDOW_H
 #define UPDATERWINDOW_H
@@ -23,13 +23,13 @@ class UpdaterWindow : public QWidget
     Q_OBJECT
 
 public:
-    explicit UpdaterWindow (QWidget *parent = 0);
+    explicit UpdaterWindow(QWidget *parent = 0);
     ~UpdaterWindow();
 
     void setShowWindowDisable(const bool dontShowWindow);
 
 public slots:
-    void checkForUpdates (bool force);
+    void checkForUpdates(bool force);
 
 signals:
     void dontShowUpdateWindowChanged(bool state);
@@ -39,23 +39,23 @@ private slots:
     void updateTitleLabel();
     void onUpdateAvailable();
     void onDownloadButtonClicked();
-    void startDownload (const QUrl& url);
+    void startDownload(const QUrl &url);
     void openDownload(const QString &file);
-    void onCheckFinished (const QString& url);
-    void onXdgOpenFinished (const int exitCode);
-    void openDownloadFolder (const QString& file);
-    void calculateSizes (qint64 received, qint64 total);
-    void updateProgress (qint64 received, qint64 total);
-    void calculateTimeRemaining (qint64 received, qint64 total);
+    void onCheckFinished(const QString &url);
+    void onXdgOpenFinished(const int exitCode);
+    void openDownloadFolder(const QString &file);
+    void calculateSizes(qint64 received, qint64 total);
+    void updateProgress(qint64 received, qint64 total);
+    void calculateTimeRemaining(qint64 received, qint64 total);
     void onDownloadFinished();
 
 protected:
-    void mouseMoveEvent (QMouseEvent* event) Q_DECL_OVERRIDE;
-    void mousePressEvent (QMouseEvent* event) Q_DECL_OVERRIDE;
-    void mouseReleaseEvent (QMouseEvent *event) Q_DECL_OVERRIDE;
+    void mouseMoveEvent(QMouseEvent *event) Q_DECL_OVERRIDE;
+    void mousePressEvent(QMouseEvent *event) Q_DECL_OVERRIDE;
+    void mouseReleaseEvent(QMouseEvent *event) Q_DECL_OVERRIDE;
 
 private:
-    qreal round (qreal input);
+    qreal round(qreal input);
 
 private:
     QString m_fileName;
@@ -71,9 +71,9 @@ private:
     bool m_forced;
 
     uint m_startTime;
-    QNetworkReply* m_reply;
-    QSimpleUpdater* m_updater;
-    QNetworkAccessManager* m_manager;
+    QNetworkReply *m_reply;
+    QSimpleUpdater *m_updater;
+    QNetworkAccessManager *m_manager;
 };
 
 #endif


### PR DESCRIPTION
Fixes #387.

This PR adds the .clang-format file from https://wiki.qt.io/Qt_Coding_Style#clang-format. I also ran `clang-format` on every file in src/, using this command: `find src/ -iname *.h -o -iname *.cpp | xargs clang-format -i`

Just to be sure, I rebuilt it with both Qt5 and Qt6 after doing this. No issues found.