### PR TITLE
chore(ci): bump Qt from 6.2.4 to 6.3.2

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -97,7 +97,7 @@ jobs:
           - os: ubuntu-20.04
             container: ubuntu:20.04
             build-type: release
-            qt-version: 6.2.4
+            qt-version: 6.3.2
     steps:
       - name: Install git PPA in docker container
         # A more recent version of git is required by the checkout action: https://github.com/actions/checkout/issues/758

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -68,7 +68,7 @@ jobs:
             build-type: release
 
           - os: macos-11
-            qt-version: 6.2.4
+            qt-version: 6.3.2
             build-type: release
     steps:
       - name: Checkout code

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,7 +24,7 @@ jobs:
 
           - os: windows-2019
             arch: x64
-            qt-version: 6.2.4
+            qt-version: 6.3.2
             build-type: release
     outputs:
       version: ${{ steps.vars.outputs.version }}


### PR DESCRIPTION
Improves performance when dealing with a large (~5 MB or more) notes database.

Fixes #425

Tested-by: @nuttyartist (macOS)
Tested-by: @guihkx (Linux)