### PR TITLE
Assorted small fixes for the text editor

### DIFF
--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -913,6 +913,9 @@ color: rgb(132, 132, 132);
                <bold>false</bold>
               </font>
              </property>
+             <property name="horizontalScrollBarPolicy">
+              <enum>Qt::ScrollBarAlwaysOff</enum>
+             </property>
              <property name="focusPolicy">
               <enum>Qt::StrongFocus</enum>
              </property>

--- a/src/noteeditorlogic.cpp
+++ b/src/noteeditorlogic.cpp
@@ -140,7 +140,7 @@ void NoteEditorLogic::showNotesInEditor(const QVector<NodeData> &notes)
         m_textEdit->verticalScrollBar()->setValue(verticalScrollBarValueToRestore);
         m_textEdit->blockSignals(false);
         m_textEdit->setReadOnly(true);
-        m_textEdit->setTextInteractionFlags(Qt::NoTextInteraction);
+        m_textEdit->setTextInteractionFlags(Qt::TextSelectableByMouse);
         m_textEdit->setFocusPolicy(Qt::NoFocus);
         highlightSearch();
     }

--- a/src/noteeditorlogic.cpp
+++ b/src/noteeditorlogic.cpp
@@ -31,7 +31,6 @@ NoteEditorLogic::NoteEditorLogic(CustomDocument *textEdit, QLabel *editorDateLab
 {
     m_highlighter = new MarkdownHighlighter(m_textEdit->document());
     connect(m_textEdit, &QTextEdit::textChanged, this, &NoteEditorLogic::onTextEditTextChanged);
-    connect(m_textEdit, &CustomDocument::resized, this, &NoteEditorLogic::editorResized);
     connect(this, &NoteEditorLogic::requestCreateUpdateNote, m_dbManager,
             &DBManager::onCreateUpdateRequestedNoteContent, Qt::QueuedConnection);
     // auto save timer
@@ -107,6 +106,7 @@ void NoteEditorLogic::showNotesInEditor(const QVector<NodeData> &notes)
         m_currentNotes = notes;
         m_tagListView->setVisible(false);
         m_textEdit->blockSignals(true);
+        auto verticalScrollBarValueToRestore = m_textEdit->verticalScrollBar()->value();
         m_textEdit->clear();
         auto padding = m_currentAdaptableEditorPadding > m_currentMinimumEditorPadding
                 ? m_currentAdaptableEditorPadding
@@ -137,6 +137,7 @@ void NoteEditorLogic::showNotesInEditor(const QVector<NodeData> &notes)
                 cursor.insertText("\n");
             }
         }
+        m_textEdit->verticalScrollBar()->setValue(verticalScrollBarValueToRestore);
         m_textEdit->blockSignals(false);
         m_textEdit->setReadOnly(true);
         m_textEdit->setTextInteractionFlags(Qt::NoTextInteraction);
@@ -262,19 +263,6 @@ void NoteEditorLogic::onNoteTagListChanged(int noteId, const QSet<int> &tagIds)
     if (currentEditingNoteId() == noteId) {
         m_currentNotes[0].setTagIds(tagIds);
         showTagListForCurrentNote();
-    }
-}
-
-void NoteEditorLogic::editorResized()
-{
-    if (currentEditingNoteId() != SpecialNodeID::InvalidNodeId) {
-        int verticalScrollBarValueToRestore = m_textEdit->verticalScrollBar()->value();
-        m_textEdit->setText(m_textEdit->toPlainText());
-        m_textEdit->verticalScrollBar()->setValue(verticalScrollBarValueToRestore);
-    } else {
-        int verticalScrollBarValueToRestore = m_textEdit->verticalScrollBar()->value();
-        showNotesInEditor(m_currentNotes);
-        m_textEdit->verticalScrollBar()->setValue(verticalScrollBarValueToRestore);
     }
 }
 

--- a/src/noteeditorlogic.h
+++ b/src/noteeditorlogic.h
@@ -48,8 +48,6 @@ public slots:
     void onTextEditTextChanged();
     void closeEditor();
     void onNoteTagListChanged(int noteId, const QSet<int> &tagIds);
-private slots:
-    void editorResized();
 signals:
     void requestCreateUpdateNote(const NodeData &note);
     void noteEditClosed(const NodeData &note, bool selectNext);


### PR DESCRIPTION
Bug 1: In some scenarios (e.g. when selecting multiple notes), the horizontal scrollbar of the text editor widget could show up:

https://user-images.githubusercontent.com/626206/212414860-ace80379-caff-43c4-b480-e9e1e8ab1164.mp4

---

Bug 2: While writing a long-enough note, or even while resizing the main window, the text cursor of editor widget would reset at the very beginning of the note (very annoying 😆):

https://user-images.githubusercontent.com/626206/212415593-220ef771-2d70-4348-a816-9abd58c58fb6.mp4

Fixes #424

---

Bug 3: After selecting multiple notes, we wouldn't allow their contents to be selected/copied. We now do:

https://user-images.githubusercontent.com/626206/212416677-6a6f8184-d877-49df-b3a6-7cd371c5e0f3.mp4
