### PR TITLE
List view: Don't move a note to the top if it's already there

### DIFF
--- a/src/listviewlogic.cpp
+++ b/src/listviewlogic.cpp
@@ -144,12 +144,15 @@ void ListViewLogic::moveNoteToTop(const NodeData &note)
     if (noteIndex.isValid()) {
         m_listView->scrollToTop();
 
-        // move the current selected note to the top
+        // move the current selected note to the top (unless it's already there)
         QModelIndex destinationIndex;
         if (note.isPinnedNote()) {
             destinationIndex = m_listModel->index(0);
         } else {
             destinationIndex = m_listModel->index(m_listModel->getFirstUnpinnedNote().row());
+        }
+        if (noteIndex == destinationIndex) {
+            return;
         }
         m_listModel->moveRow(noteIndex, noteIndex.row(), destinationIndex, destinationIndex.row());
 


### PR DESCRIPTION
## Short version

Whenever a note is updated (i.e. by typing into it), we move that note to the very top of the list view.

The problem is that at every character typed, we trigger [`ListViewLogic::moveNoteToTop()`](https://github.com/nuttyartist/notes/blob/16b39e240ee628f014e2df121dc8402343754491/src/listviewlogic.cpp#L141), which then moves that note to the top, but also updates our `Settings.ini`, in order to change its `currentSelectNotesId` property.

It might not look like it, but this whole process ends up being very I/O heavy. And while it was not really noticeable on Linux/macOS, on Windows, however, this absolutely tanks the performance (especially on slow storage).

So, to prevent a note from being moved to the top unnecessarily, we now simply check if it's already there, and by consequence we avoid updating `Settings.ini` unnecessarily.

Fixes #339

---

## Longer (boring) version

I came across this while trying to investigate #339, which I couldn't reproduce on my Linux machine, at all.

But on my Windows 7 VM, it looks *really* bad:

https://user-images.githubusercontent.com/626206/212498525-de4a2184-9dea-4175-b6fe-5cde439d6f8c.mp4

But since my debugging skills on Windows are pretty much non-existent, I had to look into this from a different angle...

While I was inspecting the database file in `%APPDATA%\Awesomeness\`, I noticed other files getting created/deleted like crazy there.

So I went back to Linux and tried to reproduce the issue there... 😄 

To do that, I used [`inotifywait(1)`](https://linux.die.net/man/1/inotifywait) to monitor file moving operations in `~/.config/Awesomeness`. The actual command looks like this:

```
inotifywait --timefmt '%F %T' --format '%T %w %e %f' -e move -m -r ~/.config/Awesomeness
```

And fair enough, it was also reproducible on Linux! Although I didn't really experience that same level of Windows slowness, but I figured it could be because the Windows VM is stored on a hard disk, while my Linux installation sits on a SSD:

https://user-images.githubusercontent.com/626206/212499107-27b73b80-c4a9-4d05-b5bb-b7994c7b762c.mp4

Anyway, after that, it was all about digging into the code and finding the culprit! :)

And just for comparison, here's a recording of my Windows 7 VM *with* the fix:

https://user-images.githubusercontent.com/626206/212499466-76aaae06-0e30-46fa-8f64-d74d70341657.mp4

P.S.: As you can see in the video, I had to keep pressing <kbd>Enter</kbd> before reaching the end of the line, because the editor currently doesn't wrap non-words, and you guys wouldn't be able to see what I was typing...

Maybe another bug to fix in the future. :)