### PR TITLE
Build: Add more information to the macOS bundle

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,7 +224,21 @@ target_link_libraries(
          Qt${QT_VERSION_MAJOR}::WidgetsPrivate)
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-  set(MACOSX_BUNDLE_ICON_FILE notes_icon.icns)
+  string(TIMESTAMP CURRENT_YEAR "%Y")
+  set(COPYRIGHT_TEXT
+      "Copyright (c) 2015-${CURRENT_YEAR} Ruby Mamistvalove and contributors.")
+
+  set_target_properties(
+    ${PROJECT_NAME}
+    PROPERTIES MACOSX_BUNDLE_BUNDLE_NAME ${PROJECT_NAME}
+               MACOSX_BUNDLE_GUI_IDENTIFIER "io.github.nuttyartist.notes"
+               MACOSX_BUNDLE_ICON_FILE "notes_icon.icns"
+               MACOSX_BUNDLE_BUNDLE_VERSION ${PROJECT_VERSION}
+               MACOSX_BUNDLE_SHORT_VERSION_STRING ${PROJECT_VERSION}
+               MACOSX_BUNDLE_LONG_VERSION_STRING ${PROJECT_VERSION}
+               MACOSX_BUNDLE_COPYRIGHT ${COPYRIGHT_TEXT}
+               MACOSX_BUNDLE_INFO_STRING ${COPYRIGHT_TEXT})
+
   set_source_files_properties(${PROJECT_SOURCE_DIR}/src/images/notes_icon.icns
                               PROPERTIES MACOSX_PACKAGE_LOCATION "Resources")
 


### PR DESCRIPTION
This adds more information to macOS' [`Info.plist`](https://developer.apple.com/documentation/bundleresources/information_property_list), which by consequence also silences CMake warnings from our CI pipeline.

Some of those keys seem to be legacy and are only used on the Qt 5 build, but as long as they don't explode things on the Qt 6 build, I think it should be fine.

I haven't tested this at all, so I kindly ask anyone with access to a Mac computer to test this and make sure things don't explode. ^^

Fixes #442