### PR TITLE
CustomMarkdownHighlighter to override default styles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,7 @@ set(GENERAL_PROJECT_SOURCES
     ${PROJECT_SOURCE_DIR}/src/allnotebuttontreedelegateeditor.cpp
     ${PROJECT_SOURCE_DIR}/src/customapplicationstyle.cpp
     ${PROJECT_SOURCE_DIR}/src/customdocument.cpp
+    ${PROJECT_SOURCE_DIR}/src/customMarkdownHighlighter.cpp
     ${PROJECT_SOURCE_DIR}/src/dbmanager.cpp
     ${PROJECT_SOURCE_DIR}/src/defaultnotefolderdelegateeditor.cpp
     ${PROJECT_SOURCE_DIR}/src/editorsettingsbutton.cpp

--- a/src/customMarkdownHighlighter.cpp
+++ b/src/customMarkdownHighlighter.cpp
@@ -1,0 +1,11 @@
+#include "customMarkdownHighlighter.h"
+
+CustomMarkdownHighlighter::CustomMarkdownHighlighter(QTextDocument *parent,
+                                                     HighlightingOptions highlightingOptions)
+    : MarkdownHighlighter(parent, highlightingOptions)
+{
+    // set all header colors
+    for (int i = HighlighterState::H1; i <= HighlighterState::H6; ++i) {
+        _formats[static_cast<HighlighterState>(i)].setForeground(QColor(0, 0, 0));
+    }
+}

--- a/src/customMarkdownHighlighter.cpp
+++ b/src/customMarkdownHighlighter.cpp
@@ -4,8 +4,24 @@ CustomMarkdownHighlighter::CustomMarkdownHighlighter(QTextDocument *parent,
                                                      HighlightingOptions highlightingOptions)
     : MarkdownHighlighter(parent, highlightingOptions)
 {
-    // set all header colors
+}
+
+void CustomMarkdownHighlighter::setHeaderColors(QColor color)
+{
+    // set all header colors to the same color
     for (int i = HighlighterState::H1; i <= HighlighterState::H6; ++i) {
-        _formats[static_cast<HighlighterState>(i)].setForeground(QColor(0, 0, 0));
+        _formats[static_cast<HighlighterState>(i)].setForeground(color);
+    }
+}
+
+void CustomMarkdownHighlighter::setTheme(Theme theme, QColor textColor)
+{
+    setHeaderColors(textColor);
+
+    switch (theme) {
+    case Theme::Light:
+    case Theme::Dark:
+    case Theme::Sepia:
+        break;
     }
 }

--- a/src/customMarkdownHighlighter.h
+++ b/src/customMarkdownHighlighter.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "3rdParty/qmarkdowntextedit/markdownhighlighter.h"
+
+class CustomMarkdownHighlighter : public MarkdownHighlighter
+{
+	public:
+		CustomMarkdownHighlighter(QTextDocument *parent = nullptr,
+			HighlightingOptions highlightingOptions = HighlightingOption::None);
+		~CustomMarkdownHighlighter() override = default;
+};

--- a/src/customMarkdownHighlighter.h
+++ b/src/customMarkdownHighlighter.h
@@ -1,11 +1,15 @@
 #pragma once
 
 #include "3rdParty/qmarkdowntextedit/markdownhighlighter.h"
+#include "styleeditorwindow.h"
 
 class CustomMarkdownHighlighter : public MarkdownHighlighter
 {
-	public:
-		CustomMarkdownHighlighter(QTextDocument *parent = nullptr,
-			HighlightingOptions highlightingOptions = HighlightingOption::None);
-		~CustomMarkdownHighlighter() override = default;
+public:
+    CustomMarkdownHighlighter(QTextDocument *parent = nullptr,
+                              HighlightingOptions highlightingOptions = HighlightingOption::None);
+    ~CustomMarkdownHighlighter() override = default;
+
+    void setTheme(Theme theme, QColor textColor);
+    void setHeaderColors(QColor color);
 };

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1847,7 +1847,7 @@ void MainWindow::setTheme(Theme theme)
         m_styleEditorWindow.setTheme(Theme::Light, m_currentThemeBackgroundColor,
                                      m_currentEditorTextColor);
         m_aboutWindow.setTheme(m_currentThemeBackgroundColor, m_currentEditorTextColor);
-        m_noteEditorLogic->setTheme(theme);
+        m_noteEditorLogic->setTheme(theme, m_currentEditorTextColor);
         ui->listviewLabel1->setStyleSheet(
                 QStringLiteral("QLabel { color : %1; }").arg(QColor(26, 26, 26).name()));
         m_treeViewLogic->setTheme(theme);
@@ -1874,7 +1874,7 @@ void MainWindow::setTheme(Theme theme)
         m_styleEditorWindow.setTheme(Theme::Dark, m_currentThemeBackgroundColor,
                                      m_currentEditorTextColor);
         m_aboutWindow.setTheme(m_currentThemeBackgroundColor, m_currentEditorTextColor);
-        m_noteEditorLogic->setTheme(theme);
+        m_noteEditorLogic->setTheme(theme, m_currentEditorTextColor);
         ui->listviewLabel1->setStyleSheet(
                 QStringLiteral("QLabel { color : %1; }").arg(QColor(204, 204, 204).name()));
         m_treeViewLogic->setTheme(theme);
@@ -1902,7 +1902,7 @@ void MainWindow::setTheme(Theme theme)
         m_styleEditorWindow.setTheme(Theme::Sepia, m_currentThemeBackgroundColor,
                                      QColor(26, 26, 26));
         m_aboutWindow.setTheme(m_currentThemeBackgroundColor, QColor(26, 26, 26));
-        m_noteEditorLogic->setTheme(theme);
+        m_noteEditorLogic->setTheme(theme, m_currentEditorTextColor);
         ui->listviewLabel1->setStyleSheet(
                 QStringLiteral("QLabel { color : %1; }").arg(QColor(26, 26, 26).name()));
         m_treeViewLogic->setTheme(theme);

--- a/src/noteeditorlogic.cpp
+++ b/src/noteeditorlogic.cpp
@@ -330,9 +330,10 @@ QString NoteEditorLogic::getSecondLine(const QString &str)
     return ts.readLine(FIRST_LINE_MAX);
 }
 
-void NoteEditorLogic::setTheme(Theme newTheme)
+void NoteEditorLogic::setTheme(Theme newTheme, QColor textColor)
 {
     m_tagListDelegate->setTheme(newTheme);
+    m_highlighter->setTheme(newTheme, textColor);
     switch (newTheme) {
     case Theme::Light: {
         m_spacerColor = QColor(191, 191, 191);

--- a/src/noteeditorlogic.cpp
+++ b/src/noteeditorlogic.cpp
@@ -1,6 +1,6 @@
 #include "noteeditorlogic.h"
 #include "customDocument.h"
-#include "markdownhighlighter.h"
+#include "customMarkdownHighlighter.h"
 #include "dbmanager.h"
 #include "taglistview.h"
 #include "taglistmodel.h"
@@ -29,7 +29,7 @@ NoteEditorLogic::NoteEditorLogic(CustomDocument *textEdit, QLabel *editorDateLab
       m_currentAdaptableEditorPadding{ 0 },
       m_currentMinimumEditorPadding{ 0 }
 {
-    m_highlighter = new MarkdownHighlighter(m_textEdit->document());
+    m_highlighter = new CustomMarkdownHighlighter(m_textEdit->document());
     connect(m_textEdit, &QTextEdit::textChanged, this, &NoteEditorLogic::onTextEditTextChanged);
     connect(this, &NoteEditorLogic::requestCreateUpdateNote, m_dbManager,
             &DBManager::onCreateUpdateRequestedNoteContent, Qt::QueuedConnection);
@@ -65,7 +65,7 @@ void NoteEditorLogic::setMarkdownEnabled(bool newMarkdownEnabled)
         m_highlighter = nullptr;
     }
     if (newMarkdownEnabled) {
-        m_highlighter = new MarkdownHighlighter(m_textEdit->document());
+        m_highlighter = new CustomMarkdownHighlighter(m_textEdit->document());
     } else {
         delete m_highlighter;
         m_highlighter = nullptr;

--- a/src/noteeditorlogic.h
+++ b/src/noteeditorlogic.h
@@ -7,7 +7,7 @@
 #include "styleeditorwindow.h"
 
 class CustomDocument;
-class MarkdownHighlighter;
+class CustomMarkdownHighlighter;
 class QLabel;
 class QLineEdit;
 class DBManager;
@@ -35,7 +35,7 @@ public:
 
     static QString getFirstLine(const QString &str);
     static QString getSecondLine(const QString &str);
-    void setTheme(Theme newTheme);
+    void setTheme(Theme theme, QColor textColor);
 
     int currentAdaptableEditorPadding() const;
     void setCurrentAdaptableEditorPadding(int newCurrentAdaptableEditorPadding);
@@ -63,7 +63,7 @@ private:
 
 private:
     CustomDocument *m_textEdit;
-    MarkdownHighlighter *m_highlighter;
+    CustomMarkdownHighlighter *m_highlighter;
     QLabel *m_editorDateLabel;
     QLineEdit *m_searchEdit;
     TagListView *m_tagListView;


### PR DESCRIPTION
Fixes #389 

This class adds a way for us to set our own colors, fonts, etc. to the MarkdownHighlighter from the QMarkdownTextEdit submodule, by simply extending the class and overriding the styles that we want in the constructor.