### PR TITLE
Installer: Automatically uninstall different versions on Windows

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -216,7 +216,7 @@ jobs:
           sudo apt update
           sudo apt install -y libpq5 libodbc1
 
-      - name: Build AppImage (${{ matrix.build-type }})
+      - name: Deploy (${{ matrix.build-type }})
         env:
           APPIMAGE_EXTRACT_AND_RUN: 1
         run: |
@@ -225,8 +225,27 @@ jobs:
           mkdir -p Notes/usr/share/icons/hicolor
           cp -r ../packaging/linux/common/icons/* Notes/usr/share/icons/hicolor
           export VERSION='${{ steps.vars.outputs.version }}'
-          ./linuxdeploy-x86_64.AppImage --appdir Notes --output appimage --plugin qt
-          mv Notes*.AppImage '${{ steps.vars.outputs.file_name }}'
+          ./linuxdeploy-x86_64.AppImage --appdir Notes --plugin qt
+
+      - name: Remove unnecessary Qt plugins and libraries
+        shell: bash
+        run: |
+          set -x
+          set -e
+          cd build/Notes
+          if [[ '${{ matrix.qt-version }}' == 5.* ]]
+          then
+              # The bearer plugin has caused problems for us in the past. Plus, it was removed altogether in Qt 6.
+              rm -rv usr/plugins/bearer
+          fi
+
+      - name: Build AppImage (${{ matrix.build-type }})
+        env:
+          APPIMAGE_EXTRACT_AND_RUN: 1
+        run: |
+          cd build
+          ./linuxdeploy-x86_64.AppImage --appdir Notes --output appimage
+          mv -v Notes*.AppImage '${{ steps.vars.outputs.file_name }}'
 
       - name: Upload AppImage artifact (${{ matrix.build-type }})
         uses: actions/upload-artifact@v3

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -144,14 +144,29 @@ jobs:
         run: |
           cmake --install build --prefix .
 
-      - name: Build dmg (${{ matrix.build-type }})
+      - name: Deploy (${{ matrix.build-type }})
         run: |
           cd build
           plutil -insert NSRequiresAquaSystemAppearance -bool true Notes.app/Contents/Info.plist
           # Rename the app folder to "Notes Better", so it doesn't conflict with macOS' "Notes" app.
           mv Notes.app 'Notes Better.app'
-          macdeployqt 'Notes Better.app' -dmg
-          mv 'Notes Better.dmg' '${{ steps.vars.outputs.file_name }}'
+          macdeployqt 'Notes Better.app'
+
+      - name: Remove unnecessary Qt plugins and libraries
+        run: |
+          set -x
+          set -e
+          cd 'build/Notes Better.app'
+          if [[ '${{ matrix.qt-version }}' == 5.* ]]
+          then
+              # The bearer plugin has caused problems for us in the past. Plus, it was removed altogether in Qt 6.
+              rm -rv Contents/PlugIns/bearer
+          fi
+
+      - name: Build dmg (${{ matrix.build-type }})
+        run: |
+          cd build
+          hdiutil create -srcfolder 'Notes Better.app' -format UDZO -fs HFS+ -volname 'Notes Better' '${{ steps.vars.outputs.file_name }}'
 
       - name: Upload dmg artifact (${{ matrix.build-type }})
         uses: actions/upload-artifact@v3

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -83,6 +83,16 @@ jobs:
         run: |
           windeployqt build\bin
 
+      - name: Remove unnecessary Qt plugins and libraries
+        run: |
+          Set-Location build\bin
+          # We ship all required runtime DLLs individually.
+          Remove-Item -Verbose vc_redist.*.exe
+          if ('${{ matrix.qt-version }}'.StartsWith('5.')) {
+              # The bearer plugin has caused problems for us in the past. Plus, it was removed altogether in Qt 6.
+              Remove-Item -Verbose -Recurse bearer
+          }
+
       - name: Include required runtime libraries (${{ matrix.build-type }}, ${{ matrix.arch }})
         run: |
           Set-Location build\bin
@@ -120,7 +130,6 @@ jobs:
                   # Only 64-bit builds also need 'vcruntime140_1.dll' (tested on Windows 7)
                   Copy-Item $env:VCToolsRedistDir\${{ matrix.arch }}\Microsoft.VC142.CRT\vcruntime140_1.dll
               }
-              Remove-Item vc_redist.*.exe
           } else {
               # On debug builds, the libraries above are included automatically, so we only need 'urtcbased.dll'.
               Copy-Item $env:WindowsSdkBinPath\${{ matrix.arch }}\ucrt\ucrtbased.dll

--- a/packaging/windows/Notes_Inno_Script_Github.iss
+++ b/packaging/windows/Notes_Inno_Script_Github.iss
@@ -1,17 +1,5 @@
 #define Version GetEnv("APP_VERSION")
 
-[Code]
-function GetDefaultInstallDir(Param: string): string;
-var
-  Version: TWindowsVersion;
-begin
-  GetWindowsVersionEx(Version);
-  if IsWin64() and (Version.Major >= 10) and (Version.Minor >= 0) and (Version.Build >= 17763) then
-    Result := ExpandConstant('{autopf64}')
-  else
-    Result := ExpandConstant('{autopf32}')
-end;
-
 [Setup]
 ; NOTE: The value of AppId uniquely identifies this application.
 ; Do not use the same AppId value in installers for other applications.
@@ -30,6 +18,117 @@ UninstallDisplayName=Notes
 OutputBaseFilename=NotesSetup_{#Version}
 Compression=lzma
 SolidCompression=yes
+
+[Code]
+function GetDefaultInstallDir(Param: string): string;
+var
+  Version: TWindowsVersion;
+begin
+  GetWindowsVersionEx(Version);
+  if IsWin64() and (Version.Major >= 10) and (Version.Minor >= 0) and (Version.Build >= 17763) then
+    Result := ExpandConstant('{autopf64}')
+  else
+    Result := ExpandConstant('{autopf32}')
+end;
+
+function ParamExists(const Param: string): boolean;
+var
+  K: integer;
+begin
+  for K := 1 to ParamCount() do
+  begin
+    if SameText(ParamStr(K), Param) then
+    begin
+      Result := true;
+      Exit;
+    end;
+  end;
+  Result := false;
+end;
+
+// If a different version of Notes is already installed, this function will invoke its uninstaller.
+// You can disable this behavior by invoking the installer via command line with /SKIPVERSIONCHECK.
+function InitializeSetup(): boolean;
+var
+  ParamSilent, ParamVerySilent, ParamSuppressMsgBoxes: boolean;
+  OurRegKey, Uninstaller, UninstallerParams, InstalledVersion: string;
+  RootsToSearchIn: array of integer;
+  K, ResultCode: integer;
+begin
+  if ParamExists('/SKIPVERSIONCHECK') then
+  begin
+    Result := true;
+    Exit;
+  end;
+  ParamSilent := ParamExists('/SILENT');
+  ParamVerySilent := ParamExists('/VERYSILENT');
+  ParamSuppressMsgBoxes := ParamExists('/SUPPRESSMSGBOXES');
+  OurRegKey := ExpandConstant('Software\Microsoft\Windows\CurrentVersion\Uninstall\{#SetupSetting("AppId")}_is1');
+  SetLength(RootsToSearchIn, 1);
+  RootsToSearchIn[0] := HKLM32;
+  // We have to also search in HKLM64, because some older versions of the installer ran in 64-bit install mode.
+  if IsWin64() then
+  begin
+    SetLength(RootsToSearchIn, 2);
+    RootsToSearchIn[1] := HKLM64;
+  end;
+  for K := 0 to (GetArrayLength(RootsToSearchIn) - 1) do
+  begin
+    if not RegQueryStringValue(RootsToSearchIn[K], OurRegKey, 'UninstallString', Uninstaller) then
+    begin
+      continue;
+    end;
+    if not RegQueryStringValue(RootsToSearchIn[K], OurRegKey, 'DisplayVersion', InstalledVersion) then
+    begin
+      continue;
+    end;
+    if SameText('{#SetupSetting("AppVersion")}', InstalledVersion) then
+    begin
+      continue;
+    end;
+    if not (ParamSilent or ParamVerySilent or ParamSuppressMsgBoxes) then
+    begin
+      if (MsgBox('Another version of {#SetupSetting("AppName")} is installed and must be removed first.'#13#13
+                 'Don''t worry, all your notes will be safe.'#13#13
+                 'Once the uninstall is complete, you''ll be prompted to install version {#SetupSetting("AppVersion")}.'#13#13
+                 'Uninstall version ' + InstalledVersion + ' now?',
+                 mbConfirmation, MB_YESNO) = IDNO) then
+      begin
+        Result := false;
+        Exit;
+      end;
+    end;
+    // We run the _uninstaller_ with /VERYSILENT by default.
+    UninstallerParams := '/VERYSILENT';
+    // If _this_ installer was invoked with /SILENT or /SUPPRESSMSGBOXES, we forward those to the uninstaller.
+    if ParamSilent then
+    begin
+      UninstallerParams := UninstallerParams + ' /SILENT';
+    end;
+    if ParamSuppressMsgBoxes then
+    begin
+      UninstallerParams := UninstallerParams + ' /SUPPRESSMSGBOXES';
+    end;
+    if not Exec(RemoveQuotes(Uninstaller), UninstallerParams, '', SW_SHOW, ewWaitUntilTerminated, ResultCode)
+       or (ResultCode <> 0) then
+    begin
+      // Error message boxes can't be suppressed.
+      MsgBox('Failed to uninstall version ' + InstalledVersion + '. Reason:'#13#13
+             + SysErrorMessage(ResultCode) + '. (code ' + IntToStr(ResultCode) + ')'#13#13
+             'Try uninstalling it from the Windows Control Panel.',
+             mbCriticalError, MB_OK);
+      Result := false;
+      Exit;
+    end;
+    if not (ParamSilent or ParamVerySilent or ParamSuppressMsgBoxes) then
+    begin
+      MsgBox('Uninstall of version ' + InstalledVersion + ' is complete.'#13#13
+             'Installation of version {#SetupSetting("AppVersion")} will start after pressing OK...',
+             mbInformation, MB_OK);
+    end;
+  end;
+  Result := true;
+end;
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"

--- a/packaging/windows/Notes_Inno_Script_Github.iss
+++ b/packaging/windows/Notes_Inno_Script_Github.iss
@@ -88,7 +88,6 @@ Source: "{#SourcePath}\Notes32\Qt5Network.dll"; DestDir: "{app}"; Flags: ignorev
 Source: "{#SourcePath}\Notes32\Qt5Sql.dll"; DestDir: "{app}"; Flags: ignoreversion; MinVersion: 6.1
 Source: "{#SourcePath}\Notes32\Qt5Svg.dll"; DestDir: "{app}"; Flags: ignoreversion; MinVersion: 6.1
 Source: "{#SourcePath}\Notes32\Qt5Widgets.dll"; DestDir: "{app}"; Flags: ignoreversion; MinVersion: 6.1
-Source: "{#SourcePath}\Notes32\bearer\*"; DestDir: "{app}\bearer"; Flags: ignoreversion recursesubdirs createallsubdirs; MinVersion: 6.1
 Source: "{#SourcePath}\Notes32\iconengines\*"; DestDir: "{app}\iconengines"; Flags: ignoreversion recursesubdirs createallsubdirs; MinVersion: 6.1
 Source: "{#SourcePath}\Notes32\imageformats\*"; DestDir: "{app}\imageformats"; Flags: ignoreversion recursesubdirs createallsubdirs; MinVersion: 6.1
 Source: "{#SourcePath}\Notes32\platforms\*"; DestDir: "{app}\platforms"; Flags: ignoreversion recursesubdirs createallsubdirs; MinVersion: 6.1


### PR DESCRIPTION
If one or more different versions of Notes are currently installed, we now tell users they must uninstall them before proceeding.

This behavior is enabled by default, but it can by completely bypassed by invoking the installer via the command line with the `/SKIPVERSIONCHECK` parameter.

That's mainly done because it's been reported in the past that some dlls included in previous versions of the installer would cause issues.

And because these dlls don't get removed automatically upon installing a new version, they could still cause issues...

We could also approach this problem by maintaining a list of problematic files in [`[InstallDelete]`](https://jrsoftware.org/ishelp/index.php?topic=installdeletesection), but in my opinion, it's much easier to just uninstall any version that's different from the one the user is trying to currently install.

Part of #267.