### PR TITLE
Fix a couple of deprecation warnings

### DIFF
--- a/src/framelesswindow.mm
+++ b/src/framelesswindow.mm
@@ -33,9 +33,7 @@ CFramelessWindow::CFramelessWindow(QWidget *parent)
 + (void)closeButtonAction:(id)sender
 {
     Q_UNUSED(sender);
-    ProcessSerialNumber pn;
-    GetFrontProcess (&pn);
-    ShowHideProcess(&pn,false);
+    [NSApp hide:nil];
 }
 - (void)zoomButtonAction:(id)sender
 {    

--- a/src/updaterwindow.cpp
+++ b/src/updaterwindow.cpp
@@ -294,9 +294,8 @@ void UpdaterWindow::startDownload(const QUrl &url)
     m_startTime = QDateTime::currentDateTime().toSecsSinceEpoch();
     QNetworkRequest netReq(url);
 
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-    netReq.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
-#endif
+    netReq.setAttribute(QNetworkRequest::RedirectPolicyAttribute,
+                        QNetworkRequest::NoLessSafeRedirectPolicy);
     m_reply = m_manager->get(netReq);
 
     /* Set file name */


### PR DESCRIPTION
I noticed these three warnings in our CI pipeline and decided to fix them:

![image](https://user-images.githubusercontent.com/626206/213355689-f5e08444-b03e-4e84-9a2f-c8deafe9503d.png)

![image](https://user-images.githubusercontent.com/626206/213355794-9c60a7cc-3cb5-49f5-a9f2-37df21ca6540.png)
