### PR TITLE
Toggle window visibility upon system tray activation

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -53,9 +53,11 @@ MainWindow::MainWindow(QWidget *parent)
       m_editorDateLabel(Q_NULLPTR),
       m_splitter(Q_NULLPTR),
       m_trayIcon(new QSystemTrayIcon(this)),
+#if !defined(Q_OS_MAC)
       m_restoreAction(new QAction(tr("&Hide Notes"), this)),
       m_quitAction(new QAction(tr("&Quit"), this)),
       m_trayIconMenu(new QMenu(this)),
+#endif
       m_listView(Q_NULLPTR),
       m_listModel(Q_NULLPTR),
       m_listViewLogic(Q_NULLPTR),
@@ -191,9 +193,13 @@ void MainWindow::setMainWindowVisibility(bool state)
         show();
         raise();
         activateWindow();
+#if !defined(Q_OS_MAC)
         m_restoreAction->setText(tr("&Hide Notes"));
+#endif
     } else {
+#if !defined(Q_OS_MAC)
         m_restoreAction->setText(tr("&Show Notes"));
+#endif
         hide();
     }
 }
@@ -432,13 +438,18 @@ void MainWindow::setupFonts()
  */
 void MainWindow::setupTrayIcon()
 {
+#if !defined(Q_OS_MAC)
     m_trayIconMenu->addAction(m_restoreAction);
     m_trayIconMenu->addSeparator();
     m_trayIconMenu->addAction(m_quitAction);
+#endif
 
     QIcon icon(QStringLiteral(":images/notes_system_tray_icon.png"));
     m_trayIcon->setIcon(icon);
+
+#if !defined(Q_OS_MAC)
     m_trayIcon->setContextMenu(m_trayIconMenu);
+#endif
     m_trayIcon->show();
 }
 
@@ -682,16 +693,19 @@ void MainWindow::setupSignalsSlots()
     connect(m_searchEdit, &QLineEdit::returnPressed, this, &MainWindow::onSearchEditReturnPressed);
     // clear button
     connect(m_clearButton, &QToolButton::clicked, this, &MainWindow::onClearButtonClicked);
-    // Restore Notes Action
+
+#if !defined(Q_OS_MAC)
+    // System tray context menu action: "Show/Hide Notes"
     connect(m_restoreAction, &QAction::triggered, this, [this]() {
         setMainWindowVisibility(isHidden() || windowState() == Qt::WindowMinimized
                                 || (qApp->applicationState() == Qt::ApplicationInactive));
     });
-    // Quit Action
+    // System tray context menu action: "Quit"
     connect(m_quitAction, &QAction::triggered, this, &MainWindow::QuitApplication);
     // Application state changed
     connect(qApp, &QApplication::applicationStateChanged, this,
             [this]() { m_listView->update(m_listView->currentIndex()); });
+#endif
 
     // MainWindow <-> DBManager
     connect(this, &MainWindow::requestNodesTree, m_dbManager, &DBManager::onNodeTagTreeRequested,
@@ -2402,7 +2416,10 @@ void MainWindow::onYellowMinimizeButtonClicked()
     m_yellowMinimizeButton->setIcon(QIcon(QStringLiteral(":images/yellow.png")));
 
     minimizeWindow();
+
+#  if !defined(Q_OS_MAC)
     m_restoreAction->setText(tr("&Show Notes"));
+#  endif
 #endif
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -184,6 +184,17 @@ void MainWindow::InitData()
 }
 
 /*!
+ * \brief Toggles visibility of the main window upon system tray activation
+ * \param reason The reason the system tray was activated
+ */
+void MainWindow::onSystemTrayIconActivated(QSystemTrayIcon::ActivationReason reason)
+{
+    if (reason == QSystemTrayIcon::Trigger) {
+        setMainWindowVisibility(!isVisible());
+    }
+}
+
+/*!
  * \brief MainWindow::setMainWindowVisibility
  * \param state
  */
@@ -693,6 +704,8 @@ void MainWindow::setupSignalsSlots()
     connect(m_searchEdit, &QLineEdit::returnPressed, this, &MainWindow::onSearchEditReturnPressed);
     // clear button
     connect(m_clearButton, &QToolButton::clicked, this, &MainWindow::onClearButtonClicked);
+    // System tray activation
+    connect(m_trayIcon, &QSystemTrayIcon::activated, this, &MainWindow::onSystemTrayIconActivated);
 
 #if !defined(Q_OS_MAC)
     // System tray context menu action: "Show/Hide Notes"

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -189,9 +189,8 @@ void MainWindow::setMainWindowVisibility(bool state)
 {
     if (state) {
         show();
-        qApp->processEvents();
-        qApp->setActiveWindow(this);
-        qApp->processEvents();
+        raise();
+        activateWindow();
         m_restoreAction->setText(tr("&Hide Notes"));
     } else {
         m_restoreAction->setText(tr("&Show Notes"));

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -243,6 +243,7 @@ private:
 private slots:
     void InitData();
 
+    void onSystemTrayIconActivated(QSystemTrayIcon::ActivationReason reason);
     void onNewNoteButtonPressed();
     void onNewNoteButtonClicked();
     void onTrashButtonPressed();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -132,9 +132,11 @@ private:
     QLabel *m_editorDateLabel;
     QSplitter *m_splitter;
     QSystemTrayIcon *m_trayIcon;
+#if !defined(Q_OS_MAC)
     QAction *m_restoreAction;
     QAction *m_quitAction;
     QMenu *m_trayIconMenu;
+#endif
 
     NoteListView *m_listView;
     NoteListModel *m_listModel;


### PR DESCRIPTION
This will either show or hide the main window upon activating the system tray icon.

- On Windows and macOS, this can be triggered by a single left mouse click on the icon.
- On Linux, this will depend on the system tray implementation, but on KDE Plasma and XFCE, this is also triggered by a single left mouse click, while on GNOME (which requires a [third-party system tray extension](https://github.com/ubuntu/gnome-shell-extension-appindicator)), it's two left mouse clicks.

Part of #450 
Closes #452

---

There's also a (somewhat) related changed I added, which is calling `raise()` followed by `activateWindow()`. The Qt documentation [states](https://doc.qt.io/qt-5/qwidget.html#activateWindow):

>If you want to ensure that the window is stacked on top as well you should also call [raise](https://doc.qt.io/qt-5/qwidget.html#raise)(). Note that the window must be visible, otherwise activateWindow() has no effect.