### PR TITLE
Windows: Seamless switch between window decoration modes

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1691,7 +1691,7 @@ void MainWindow::onDotsButtonClicked()
     useNativeFrameAction->setCheckable(true);
     useNativeFrameAction->setChecked(m_useNativeWindowFrame);
     connect(useNativeFrameAction, &QAction::triggered, this,
-            &MainWindow::askBeforeSettingNativeWindowFrame);
+            [this]() { setUseNativeWindowFrame(!m_useNativeWindowFrame); });
 #endif
 
     mainMenu.exec(m_dotsButton->mapToGlobal(QPoint(0, m_dotsButton->height())));
@@ -3538,28 +3538,6 @@ void MainWindow::stayOnTop(bool checked)
 }
 
 /*!
- * \brief MainWindow::askBeforeSettingNativeWindowFrame
- */
-void MainWindow::askBeforeSettingNativeWindowFrame()
-{
-#ifdef _WIN32
-    if (!m_useNativeWindowFrame) {
-        QMessageBox msgBox;
-        msgBox.setText(tr("Warning: After performing this action, you will need to restart your "
-                          "system to revert to custom decoration."));
-        msgBox.setInformativeText(tr("Would you like to continue?"));
-        msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-        msgBox.setDefaultButton(QMessageBox::No);
-        if (msgBox.exec() != QMessageBox::Yes) {
-            return;
-        }
-    }
-#endif
-
-    setUseNativeWindowFrame(!m_useNativeWindowFrame);
-}
-
-/*!
  * \brief MainWindow::increaseHeading
  * Increase markdown heading level
  */
@@ -3655,22 +3633,11 @@ void MainWindow::setUseNativeWindowFrame(bool useNativeWindowFrame)
     m_redCloseButton->setVisible(!useNativeWindowFrame);
     m_yellowMinimizeButton->setVisible(!useNativeWindowFrame);
 
-    auto flags = windowFlags();
+    // Reset window flags to its initial state.
+    Qt::WindowFlags flags = Qt::Window;
 
-#  if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-    if (useNativeWindowFrame)
-        flags &= ~Qt::FramelessWindowHint;
-    else
-        flags |= Qt::FramelessWindowHint;
-#  elif _WIN32
-    if (useNativeWindowFrame) {
-        flags &= ~Qt::CustomizeWindowHint;
-        flags &= ~Qt::FramelessWindowHint;
-    } else {
+    if (!useNativeWindowFrame)
         flags |= Qt::CustomizeWindowHint;
-        flags |= Qt::FramelessWindowHint;
-    }
-#  endif
 
     setWindowFlags(flags);
 #endif

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -155,7 +155,7 @@ void MainWindow::InitData()
         QProgressDialog *pd =
                 new QProgressDialog(tr("Migrating database, please wait."), QString(), 0, 0, this);
         pd->setCancelButton(Q_NULLPTR);
-        pd->setWindowFlags(Qt::Window | Qt::FramelessWindowHint);
+        pd->setWindowFlags(Qt::Window | Qt::CustomizeWindowHint);
         pd->setMinimumDuration(0);
         pd->show();
 
@@ -305,11 +305,8 @@ MainWindow::~MainWindow()
  */
 void MainWindow::setupMainWindow()
 {
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-    this->setWindowFlags(Qt::Window | Qt::FramelessWindowHint);
-    //    this->setAttribute(Qt::WA_TranslucentBackground);
-#elif _WIN32
-    this->setWindowFlags(Qt::CustomizeWindowHint);
+#if !defined(Q_OS_MAC)
+    this->setWindowFlags(Qt::Window | Qt::CustomizeWindowHint);
 #endif
 
     m_greenMaximizeButton = new QPushButton(this);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -283,7 +283,6 @@ private slots:
     void exportNotesFile();
     void restoreNotesFile();
     void stayOnTop(bool checked);
-    void askBeforeSettingNativeWindowFrame();
     void increaseHeading();
     void decreaseHeading();
     void setHeading(int level);

--- a/src/updaterwindow.cpp
+++ b/src/updaterwindow.cpp
@@ -99,13 +99,7 @@ UpdaterWindow::UpdaterWindow(QWidget *parent)
     updateTitleLabel();
 
     /* Remove window border */
-#if defined Q_OS_WIN
-    setWindowFlags(Qt::CustomizeWindowHint);
-#elif defined Q_OS_MAC || defined Q_OS_LINUX || defined Q_OS_FREEBSD
-    setWindowFlags(Qt::Window | Qt::FramelessWindowHint);
-#else
-#  error "We don't support your OS yet..."
-#endif
+    setWindowFlags(Qt::Window | Qt::CustomizeWindowHint);
 
     /* React when xdg-open finishes (Linux only) */
 #ifdef UseXdgOpen


### PR DESCRIPTION
This fixes switching between native and non-native window decorations on Windows, and therefore we also remove the previous confirmation prompt that would tell users they would need to restart their system after the switch.

Before:

https://user-images.githubusercontent.com/626206/213961948-31393f6b-4247-480b-aa95-c04c45c0ce14.mp4

After:

https://user-images.githubusercontent.com/626206/213962037-4ab78056-57ae-4355-b99c-aecc40107c18.mp4

Tested on:

- Windows 7
  - [x] Qt 5
- Windows 10
  - [x] Qt 5
  - [x] Qt 6
- Windows 11
  - [ ] Qt 5
  - [ ] Qt 6