### PR TITLE
Ignore some events when using native window decorations

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2526,6 +2526,11 @@ void MainWindow::closeEvent(QCloseEvent *event)
  */
 void MainWindow::mousePressEvent(QMouseEvent *event)
 {
+    if (m_useNativeWindowFrame) {
+        MainWindowBase::mousePressEvent(event);
+        return;
+    }
+
     m_mousePressX = event->pos().x();
     m_mousePressY = event->pos().y();
 
@@ -2578,7 +2583,7 @@ void MainWindow::mousePressEvent(QMouseEvent *event)
         event->accept();
 
     } else {
-        QMainWindow::mousePressEvent(event);
+        MainWindowBase::mousePressEvent(event);
     }
 }
 
@@ -2589,6 +2594,11 @@ void MainWindow::mousePressEvent(QMouseEvent *event)
  */
 void MainWindow::mouseMoveEvent(QMouseEvent *event)
 {
+    if (m_useNativeWindowFrame) {
+        MainWindowBase::mouseMoveEvent(event);
+        return;
+    }
+
 #  ifndef __APPLE__
     if (!m_canStretchWindow && !m_canMoveWindow) {
         m_mousePressX = event->pos().x();
@@ -2772,6 +2782,11 @@ void MainWindow::mouseMoveEvent(QMouseEvent *event)
  */
 void MainWindow::mouseReleaseEvent(QMouseEvent *event)
 {
+    if (m_useNativeWindowFrame) {
+        MainWindowBase::mouseReleaseEvent(event);
+        return;
+    }
+
     m_canMoveWindow = false;
     m_canStretchWindow = false;
     QApplication::restoreOverrideCursor();
@@ -2785,6 +2800,11 @@ void MainWindow::mouseReleaseEvent(QMouseEvent *event)
  */
 void MainWindow::mousePressEvent(QMouseEvent *event)
 {
+    if (m_useNativeWindowFrame) {
+        MainWindowBase::mousePressEvent(event);
+        return;
+    }
+
     if (event->button() == Qt::LeftButton) {
         if (event->pos().x() < this->width() - 5 && event->pos().x() > 5
             && event->pos().y() < this->height() - 5 && event->pos().y() > 5) {
@@ -2805,6 +2825,11 @@ void MainWindow::mousePressEvent(QMouseEvent *event)
  */
 void MainWindow::mouseMoveEvent(QMouseEvent *event)
 {
+    if (m_useNativeWindowFrame) {
+        MainWindowBase::mouseMoveEvent(event);
+        return;
+    }
+
     if (m_canMoveWindow) {
         //        this->setCursor(Qt::ClosedHandCursor);
         int dx = event->globalPos().x() - m_mousePressX;
@@ -2820,6 +2845,11 @@ void MainWindow::mouseMoveEvent(QMouseEvent *event)
  */
 void MainWindow::mouseReleaseEvent(QMouseEvent *event)
 {
+    if (m_useNativeWindowFrame) {
+        MainWindowBase::mouseReleaseEvent(event);
+        return;
+    }
+
     m_canMoveWindow = false;
     //    this->unsetCursor();
     event->accept();
@@ -3118,6 +3148,11 @@ double MainWindow::gaussianDist(double x, const double center, double sigma) con
  */
 void MainWindow::mouseDoubleClickEvent(QMouseEvent *event)
 {
+    if (m_useNativeWindowFrame) {
+        MainWindowBase::mouseDoubleClickEvent(event);
+        return;
+    }
+
 #ifndef __APPLE__
     maximizeWindow();
 #else


### PR DESCRIPTION
Currently, these events are only being used to handle window management (moving, resizing, etc.) when we're in 'frameless mode'.

So, they can be ignored when the native window frame is used.

This fixes some mildly annoying bugs present when we're using native window decorations, such as:

- Being able to maximize/unmaximize the window by double clicking next to its title bar
- Being able to move or resize the window by grabbing next to its edges

Videos of these bugs are [down this thread](https://github.com/nuttyartist/notes/pull/460#issuecomment-1420593061).