### PR TITLE
Cl: Use create-dmg for better looking dmgs on macOS

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -163,10 +163,25 @@ jobs:
               rm -rv Contents/PlugIns/bearer
           fi
 
+      - name: Install create-dmg and dependencies
+        run: |
+          brew install graphicsmagick imagemagick
+          npm install --global create-dmg@^6.0.0
+
       - name: Build dmg (${{ matrix.build-type }})
         run: |
           cd build
-          hdiutil create -srcfolder 'Notes Better.app' -format UDZO -fs HFS+ -volname 'Notes Better' '${{ steps.vars.outputs.file_name }}'
+          # TODO: Remove most of the code below once we support signing/notarization.
+          set +e
+          create-dmg 'Notes Better.app'
+          code=$?
+          set -e
+          if [[ ${code} -ne 0 && ${code} -ne 2 ]]
+          then
+              echo "create-dmg exited with code ${code}."
+              exit ${code}
+          fi
+          mv *.dmg '${{ steps.vars.outputs.file_name }}'
 
       - name: Upload dmg artifact (${{ matrix.build-type }})
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
#### create-dmg: https://github.com/sindresorhus/create-dmg

It also makes the installation process much easier than just a regular dmg created with `hdiutil`.

I had to add some silly logic to deal with `create-dmg` exiting with code `2` after failing to code sign the app (as we don't do that yet).

So either exit code `0` or `2` means the dmg was created successfully.

---

I believe @nuttyartist mentioned in the past the he was already using `create-dmg` before the AppVeyor -> Github Actions migration, so this shouldn't be news to him. :)

Nevertheless, for the sake of completion, here are some before and after pictures:

Before:

![image](https://user-images.githubusercontent.com/626206/217375650-d07836c8-6b86-4352-88ee-5b1a094c8f40.png)

After:

![with-create-dmg](https://user-images.githubusercontent.com/626206/217375380-0397c045-7617-4c6e-879e-dcf8ca61a02f.png)
