### PR TITLE
CI: Don't ship non-SQLite Qt drivers

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -238,6 +238,15 @@ jobs:
               # The bearer plugin has caused problems for us in the past. Plus, it was removed altogether in Qt 6.
               rm -rv usr/plugins/bearer
           fi
+          # We only use the SQLite Qt driver, so it's fine to delete others.
+          rm -v usr/plugins/sqldrivers/libqsqlodbc.so
+          rm -v usr/plugins/sqldrivers/libqsqlpsql.so
+          if [[ '${{ matrix.qt-version }}' == 6.* ]]
+          then
+              # The Qt 6 build also has a MySQL Qt driver we don't use.
+              rm -v usr/plugins/sqldrivers/libqsqlmysql.so
+              rm -v usr/lib/libmysqlclient.so.*
+          fi
 
       - name: Build AppImage (${{ matrix.build-type }})
         env:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -150,7 +150,7 @@ jobs:
           plutil -insert NSRequiresAquaSystemAppearance -bool true Notes.app/Contents/Info.plist
           # Rename the app folder to "Notes Better", so it doesn't conflict with macOS' "Notes" app.
           mv Notes.app 'Notes Better.app'
-          macdeployqt 'Notes Better.app'
+          macdeployqt 'Notes Better.app' -appstore-compliant
 
       - name: Remove unnecessary Qt plugins and libraries
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -92,6 +92,9 @@ jobs:
               # The bearer plugin has caused problems for us in the past. Plus, it was removed altogether in Qt 6.
               Remove-Item -Verbose -Recurse bearer
           }
+          # We only use the SQLite Qt driver, so it's fine to delete others.
+          Remove-Item -Verbose sqldrivers\qsqlodbc.dll
+          Remove-Item -Verbose sqldrivers\qsqlpsql.dll
 
       - name: Include required runtime libraries (${{ matrix.build-type }}, ${{ matrix.arch }})
         run: |


### PR DESCRIPTION
We only use the SQLite driver, so we remove other drivers to reduce the final size of the app.

On macOS, this is accomplished automatically, thanks to the `-appstore-compliant` flag from `macdeployqt`:

```shell
$ macdeployqt 'Notes Better.app' -appstore-compliant
WARNING: Plugin "libqsqlodbc.dylib" uses private API and is not Mac App store compliant.
WARNING: Skip plugin "libqsqlodbc.dylib"
WARNING: Plugin "libqsqlpsql.dylib" uses private API and is not Mac App store compliant.
WARNING: Skip plugin "libqsqlpsql.dylib"
```