### PR TITLE
Fixed window flags of popup windows

### DIFF
--- a/src/aboutwindow.cpp
+++ b/src/aboutwindow.cpp
@@ -6,10 +6,9 @@
 /**
  * Initializes the window components and configures the AboutWindow
  */
-AboutWindow::AboutWindow(QWidget *parent) : QWidget(parent), m_ui(new Ui::AboutWindow)
+AboutWindow::AboutWindow(QWidget *parent) : QDialog(parent), m_ui(new Ui::AboutWindow)
 {
     m_ui->setupUi(this);
-    this->setWindowFlags(Qt::Window);
     setWindowTitle(tr("About") + " " + qApp->applicationName());
 
     m_ui->aboutText->setText(

--- a/src/aboutwindow.h
+++ b/src/aboutwindow.h
@@ -1,13 +1,13 @@
 #ifndef ABOUTWINDOW_H
 #define ABOUTWINDOW_H
 
-#include <QWidget>
+#include <QDialog>
 
 namespace Ui {
 class AboutWindow;
 }
 
-class AboutWindow : public QWidget
+class AboutWindow : public QDialog
 {
     Q_OBJECT
 

--- a/src/aboutwindow.ui
+++ b/src/aboutwindow.ui
@@ -13,6 +13,9 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">
     <number>0</number>

--- a/src/aboutwindow.ui
+++ b/src/aboutwindow.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>AboutWindow</class>
- <widget class="QWidget" name="AboutWindow">
+ <widget class="QDialog" name="AboutWindow">
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/src/styleeditorwindow.cpp
+++ b/src/styleeditorwindow.cpp
@@ -9,7 +9,7 @@
  * Initializes the window components and configures the StyleEditorWindow
  */
 StyleEditorWindow::StyleEditorWindow(QWidget *parent)
-    : QWidget(parent),
+    : QDialog(parent),
       m_ui(new Ui::StyleEditorWindow),
       m_currentlyClickedButton(Q_NULLPTR),
       m_currentSelectedFontButton(Q_NULLPTR),
@@ -17,8 +17,7 @@ StyleEditorWindow::StyleEditorWindow(QWidget *parent)
       m_isFullWidthClicked(false)
 {
     m_ui->setupUi(this);
-    this->setWindowTitle(tr("Editor Settings"));
-    this->setWindowFlags(Qt::Window | Qt::WindowStaysOnTopHint);
+    setWindowTitle(tr("Editor Settings"));
 
     m_ui->serifButton->setToolTip(
             "Change the text editor font to a serif font.\nClick again to try different fonts");

--- a/src/styleeditorwindow.cpp
+++ b/src/styleeditorwindow.cpp
@@ -9,7 +9,7 @@
  * Initializes the window components and configures the StyleEditorWindow
  */
 StyleEditorWindow::StyleEditorWindow(QWidget *parent)
-    : QDialog(parent),
+    : QDialog(parent, Qt::Tool),
       m_ui(new Ui::StyleEditorWindow),
       m_currentlyClickedButton(Q_NULLPTR),
       m_currentSelectedFontButton(Q_NULLPTR),

--- a/src/styleeditorwindow.h
+++ b/src/styleeditorwindow.h
@@ -7,7 +7,7 @@
 #ifndef STYLEEDITORWINDOW_H
 #define STYLEEDITORWINDOW_H
 
-#include <QWidget>
+#include <QDialog>
 #include <QPushButton>
 
 namespace Ui {
@@ -24,7 +24,7 @@ enum class Theme { Light, Dark, Sepia };
 
 enum class ButtonState { Normal, Hovered, Clicked };
 
-class StyleEditorWindow : public QWidget
+class StyleEditorWindow : public QDialog
 {
     Q_OBJECT
 

--- a/src/styleeditorwindow.ui
+++ b/src/styleeditorwindow.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>StyleEditorWindow</class>
- <widget class="QWidget" name="StyleEditorWindow">
+ <widget class="QDialog" name="StyleEditorWindow">
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/src/updaterwindow.cpp
+++ b/src/updaterwindow.cpp
@@ -48,7 +48,7 @@ static const QDir DOWNLOAD_DIR(QDir::homePath() + "/Downloads/");
  * Initializes the window components and configures the QSimpleUpdater
  */
 UpdaterWindow::UpdaterWindow(QWidget *parent)
-    : QWidget(parent),
+    : QDialog(parent),
       m_fileName(""),
       m_ui(new Ui::UpdaterWindow),
       m_canMoveWindow(false),
@@ -100,7 +100,7 @@ UpdaterWindow::UpdaterWindow(QWidget *parent)
     updateTitleLabel();
 
     /* Remove window border */
-    setWindowFlags(Qt::Window | Qt::CustomizeWindowHint);
+    setWindowFlags(windowFlags() | Qt::CustomizeWindowHint);
 
     /* React when xdg-open finishes (Linux only) */
 #ifdef UseXdgOpen

--- a/src/updaterwindow.h
+++ b/src/updaterwindow.h
@@ -7,7 +7,7 @@
 #ifndef UPDATERWINDOW_H
 #define UPDATERWINDOW_H
 
-#include <QWidget>
+#include <QDialog>
 
 namespace Ui {
 class UpdaterWindow;
@@ -18,7 +18,7 @@ class QNetworkReply;
 class QSimpleUpdater;
 class QNetworkAccessManager;
 
-class UpdaterWindow : public QWidget
+class UpdaterWindow : public QDialog
 {
     Q_OBJECT
 

--- a/src/updaterwindow.ui
+++ b/src/updaterwindow.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>UpdaterWindow</class>
- <widget class="QWidget" name="UpdaterWindow">
+ <widget class="QDialog" name="UpdaterWindow">
   <property name="geometry">
    <rect>
     <x>0</x>


### PR DESCRIPTION
This has been annoying me for a while: on tiling window managers, the popup windows (Style editor, Updater, AboutWindow) have the wrong window flags, causing them to be seen as separate windows instead of popups.

This is before:

https://user-images.githubusercontent.com/4633209/217641899-e408d5e3-2350-4162-b2c5-1af28d6863d8.mp4


This is after:


https://user-images.githubusercontent.com/4633209/217642072-02f91f59-66ca-476d-8480-97dfae7f3c17.mp4



Should also be tested with non-tiling window managers, and on macOS and Windows.