### PR TITLE
Build: Enable extra compiler warnings by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,8 +188,10 @@ set(SOURCES
     # qrc files
     ${PROJECT_SOURCE_DIR}/src/fonts.qrc
     ${PROJECT_SOURCE_DIR}/src/images.qrc
-    ${PROJECT_SOURCE_DIR}/src/styles.qrc
-    # 3rdParty source files
+    ${PROJECT_SOURCE_DIR}/src/styles.qrc)
+
+# Third-party source files.
+set(SOURCES_3RD_PARTY
     ${PROJECT_SOURCE_DIR}/3rdParty/qautostart/src/qautostart.cpp
     ${PROJECT_SOURCE_DIR}/3rdParty/qautostart/src/qautostart.h
     ${PROJECT_SOURCE_DIR}/3rdParty/qmarkdowntextedit/linenumberarea.h
@@ -213,22 +215,25 @@ set(SOURCES
     ${PROJECT_SOURCE_DIR}/3rdParty/qxt/qxtglobalshortcut.h
     ${PROJECT_SOURCE_DIR}/3rdParty/qxt/qxtglobalshortcut_p.h)
 
-set(MACX_PROJECT_SOURCES
-    ${PROJECT_SOURCE_DIR}/src/framelesswindow.mm
-    ${PROJECT_SOURCE_DIR}/src/framelesswindow.h
-    ${PROJECT_SOURCE_DIR}/src/images/notes_icon.icns
-    ${PROJECT_SOURCE_DIR}/3rdParty/qxt/qxtglobalshortcut_mac.cpp)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  list(APPEND SOURCES ${PROJECT_SOURCE_DIR}/src/framelesswindow.mm
+       ${PROJECT_SOURCE_DIR}/src/framelesswindow.h
+       ${PROJECT_SOURCE_DIR}/src/images/notes_icon.icns)
+  list(APPEND SOURCES_3RD_PARTY
+       ${PROJECT_SOURCE_DIR}/3rdParty/qxt/qxtglobalshortcut_mac.cpp)
+elseif(UNIX)
+  list(APPEND SOURCES_3RD_PARTY
+       ${PROJECT_SOURCE_DIR}/3rdParty/qxt/qxtglobalshortcut_x11.cpp)
+elseif(WIN32)
+  list(APPEND SOURCES ${PROJECT_SOURCE_DIR}/src/framelesswindow.cpp
+       ${PROJECT_SOURCE_DIR}/src/framelesswindow.h
+       ${PROJECT_SOURCE_DIR}/src/images/notes.rc)
+  list(APPEND SOURCES_3RD_PARTY
+       ${PROJECT_SOURCE_DIR}/3rdParty/qxt/qxtglobalshortcut_win.cpp)
+endif()
 
-set(WIN32_PROJECT_SOURCES
-    ${PROJECT_SOURCE_DIR}/src/framelesswindow.cpp
-    ${PROJECT_SOURCE_DIR}/src/framelesswindow.h
-    ${PROJECT_SOURCE_DIR}/src/images/notes.rc
-    ${PROJECT_SOURCE_DIR}/3rdParty/qxt/qxtglobalshortcut_win.cpp)
-
-set(LINUX_PROJECT_SOURCES
-    ${PROJECT_SOURCE_DIR}/3rdParty/qxt/qxtglobalshortcut_x11.cpp)
-
-add_executable(${PROJECT_NAME} WIN32 MACOSX_BUNDLE ${SOURCES})
+add_executable(${PROJECT_NAME} WIN32 MACOSX_BUNDLE ${SOURCES}
+                                                   ${SOURCES_3RD_PARTY})
 
 target_include_directories(
   ${PROJECT_NAME}
@@ -274,8 +279,6 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   set_source_files_properties(${PROJECT_SOURCE_DIR}/src/images/notes_icon.icns
                               PROPERTIES MACOSX_PACKAGE_LOCATION "Resources")
 
-  target_sources(${PROJECT_NAME} PUBLIC ${MACX_PROJECT_SOURCES})
-
   target_link_libraries(${PROJECT_NAME} PUBLIC "-framework Carbon"
                                                "-framework Cocoa")
 elseif(UNIX)
@@ -283,12 +286,8 @@ elseif(UNIX)
   string(TOLOWER ${PROJECT_NAME} BINARY_NAME)
   set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME ${BINARY_NAME})
 
-  target_sources(${PROJECT_NAME} PUBLIC ${LINUX_PROJECT_SOURCES})
-
   target_link_libraries(${PROJECT_NAME} PUBLIC X11)
 elseif(WIN32)
-  target_sources(${PROJECT_NAME} PUBLIC ${WIN32_PROJECT_SOURCES})
-
   target_compile_definitions(${PROJECT_NAME} PUBLIC QXT_STATIC)
 
   target_link_libraries(${PROJECT_NAME} PUBLIC user32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,10 +235,12 @@ endif()
 add_executable(${PROJECT_NAME} WIN32 MACOSX_BUNDLE ${SOURCES}
                                                    ${SOURCES_3RD_PARTY})
 
+target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/src)
+
+# Include third-party headers as 'system' files, in order to silence compiler warnings on them.
 target_include_directories(
-  ${PROJECT_NAME}
-  PUBLIC ${PROJECT_SOURCE_DIR}/src
-         ${PROJECT_SOURCE_DIR}/3rdParty/QSimpleUpdater/include
+  ${PROJECT_NAME} SYSTEM
+  PUBLIC ${PROJECT_SOURCE_DIR}/3rdParty/QSimpleUpdater/include
          ${PROJECT_SOURCE_DIR}/3rdParty/qautostart/src
          ${PROJECT_SOURCE_DIR}/3rdParty/qmarkdowntextedit
          ${PROJECT_SOURCE_DIR}/3rdParty/qxt)
@@ -247,6 +249,17 @@ target_compile_definitions(
   ${PROJECT_NAME}
   PUBLIC APP_VERSION="${PROJECT_VERSION}${GIT_REV}"
          QT_DISABLE_DEPRECATED_BEFORE=0x050900 QSU_INCLUDE_MOC=1)
+
+# Enable useful compiler warnings (except on third-party code).
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES
+                                           "Clang")
+  target_compile_options(${PROJECT_NAME} PUBLIC -Wall -Wextra -Wpedantic
+                                                -Wshadow)
+  set_source_files_properties(${SOURCES_3RD_PARTY} PROPERTIES COMPILE_FLAGS -w)
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+  target_compile_options(${PROJECT_NAME} PUBLIC /W4)
+  set_source_files_properties(${SOURCES_3RD_PARTY} PROPERTIES COMPILE_FLAGS /w)
+endif()
 
 target_link_libraries(
   ${PROJECT_NAME}

--- a/src/allnotebuttontreedelegateeditor.cpp
+++ b/src/allnotebuttontreedelegateeditor.cpp
@@ -7,11 +7,11 @@
 
 AllNoteButtonTreeDelegateEditor::AllNoteButtonTreeDelegateEditor(QTreeView *view,
                                                                  const QStyleOptionViewItem &option,
-                                                                 const QModelIndex &m_index,
+                                                                 const QModelIndex &index,
                                                                  QWidget *parent)
     : QWidget(parent),
       m_option(option),
-      m_index(m_index),
+      m_index(index),
 #ifdef __APPLE__
       m_displayFont(QFont(QStringLiteral("SF Pro Text")).exactMatch()
                             ? QStringLiteral("SF Pro Text")

--- a/src/customapplicationstyle.cpp
+++ b/src/customapplicationstyle.cpp
@@ -8,25 +8,18 @@ void CustomApplicationStyle::drawPrimitive(PrimitiveElement element, const QStyl
     if (element == QStyle::PE_IndicatorItemViewItemDrop) {
         painter->setRenderHint(QPainter::Antialiasing, true);
 
-        QColor c;
-        //        if (m_theme == Theme::Dark) {
-        //            c = QColor(15, 45, 90);
-        //        } else {
-        c = QColor(207, 207, 207);
-        //        }
-        QPen pen(c);
+        QColor color(207, 207, 207);
+        QPen pen(color);
         pen.setWidth(2);
-        c.setAlpha(50);
-        QBrush brush(c);
-
         painter->setPen(pen);
-        painter->setBrush(brush);
+
         if (option->rect.height() == 0) {
+            color.setAlpha(50);
+            painter->setBrush(color);
             painter->drawLine(option->rect.topLeft(), option->rect.topRight());
         } else {
-            c.setAlpha(200);
-            QBrush brush(c);
-            painter->fillRect(option->rect, brush);
+            color.setAlpha(200);
+            painter->fillRect(option->rect, color);
         }
     } else {
         QProxyStyle::drawPrimitive(element, option, painter, widget);

--- a/src/dbmanager.cpp
+++ b/src/dbmanager.cpp
@@ -1019,8 +1019,7 @@ NodeData DBManager::getNode(int nodeId)
                            R"("title" )"
                            R"(FROM node_table WHERE id=:id LIMIT 1;)");
             query2.bindValue(":id", node.parentId());
-            bool status = query2.exec();
-            if (status) {
+            if (query2.exec()) {
                 query2.next();
                 node.setParentName(query2.value(0).toString());
             } else {
@@ -1136,8 +1135,7 @@ void DBManager::moveNode(int nodeId, const NodeData &target)
         query.prepare(R"(SELECT id, absolute_path FROM "node_table" )"
                       R"(WHERE absolute_path like (:path_expr) || '%';)");
         query.bindValue(QStringLiteral(":path_expr"), oldAbsolutePath);
-        bool status = query.exec();
-        if (status) {
+        if (query.exec()) {
             while (query.next()) {
                 if (query.value(0).toInt() != node.id()) {
                     childs[query.value(0).toInt()] = query.value(1).toString();
@@ -1166,8 +1164,7 @@ void DBManager::moveNode(int nodeId, const NodeData &target)
                 query.bindValue(QStringLiteral(":absolute_path"), newP);
                 query.bindValue(QStringLiteral(":id"), id);
             }
-            bool status = query.exec();
-            if (!status) {
+            if (!query.exec()) {
                 qDebug() << __FUNCTION__ << __LINE__ << query.lastError();
             }
         }
@@ -1305,7 +1302,6 @@ void DBManager::searchForNotes(const QString &keyword, const ListViewInfo &inf)
         QVector<QSet<int>> nds;
         for (const auto &tagId : inf.currentTagList) {
             QSet<int> nd;
-            QSqlQuery query(m_db);
             query.prepare(R"(SELECT "node_id" FROM tag_relationship WHERE tag_id = :tag_id;)");
             query.bindValue(QStringLiteral(":tag_id"), tagId);
             bool status = query.exec();
@@ -1794,8 +1790,7 @@ void DBManager::onImportNotesRequested(const QString &fileName)
                 qr.bindValue(QStringLiteral(":name"), tag.name());
                 qr.bindValue(QStringLiteral(":color"), tag.color());
                 QVector<int> ids;
-                bool status = qr.exec();
-                if (status) {
+                if (qr.exec()) {
                     while (qr.next()) {
                         ids.append(qr.value(0).toInt());
                     }
@@ -1865,8 +1860,7 @@ void DBManager::onImportNotesRequested(const QString &fileName)
                                      static_cast<int>(NodeData::Folder));
                         qr.bindValue(QStringLiteral(":parent_id"), folderIdMap[node.parentId()]);
                         QVector<int> ids;
-                        bool status = qr.exec();
-                        if (status) {
+                        if (qr.exec()) {
                             while (qr.next()) {
                                 ids.append(qr.value(0).toInt());
                             }

--- a/src/defaultnotefolderdelegateeditor.cpp
+++ b/src/defaultnotefolderdelegateeditor.cpp
@@ -6,11 +6,11 @@
 
 DefaultNoteFolderDelegateEditor::DefaultNoteFolderDelegateEditor(QTreeView *view,
                                                                  const QStyleOptionViewItem &option,
-                                                                 const QModelIndex &m_index,
+                                                                 const QModelIndex &index,
                                                                  QWidget *parent)
     : QWidget(parent),
       m_option(option),
-      m_index(m_index),
+      m_index(index),
 #ifdef __APPLE__
       m_displayFont(QFont(QStringLiteral("SF Pro Text")).exactMatch()
                             ? QStringLiteral("SF Pro Text")

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1167,14 +1167,12 @@ void MainWindow::setupDatabases()
     } else if (needMigrateFromV1_5_0) {
         QFile noteDBFile(noteDBFilePath);
         noteDBFile.rename(dir.path() + QDir::separator() + QStringLiteral("oldNotes.db"));
-        {
-            QFile noteDBFile(noteDBFilePath);
-            if (!noteDBFile.open(QIODevice::WriteOnly))
-                qFatal("ERROR : Can't create database file");
+        noteDBFile.setFileName(noteDBFilePath);
+        if (!noteDBFile.open(QIODevice::WriteOnly))
+            qFatal("ERROR : Can't create database file");
 
-            noteDBFile.close();
-            doCreate = true;
-        }
+        noteDBFile.close();
+        doCreate = true;
     }
 
     if (needMigrateFromV1_5_0) {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1155,11 +1155,9 @@ void MainWindow::setupDatabases()
             m_db.setDatabaseName(noteDBFilePath);
             if (m_db.open()) {
                 QSqlQuery query(m_db);
-                bool status = query.exec(
-                        "SELECT name FROM sqlite_master WHERE type='table' AND name='tag_table';");
-                if (status) {
-                    query.next();
-                    if (query.value(0).toString() == "tag_table") {
+                if (query.exec("SELECT name FROM sqlite_master WHERE type='table' AND "
+                               "name='tag_table';")) {
+                    if (query.next() && query.value(0).toString() == "tag_table") {
                         needMigrateFromV1_5_0 = false;
                     }
                 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -397,17 +397,6 @@ void MainWindow::setupMainWindow()
     ui->listviewLabel2->setMaximumSize({ 40, 25 });
 
 #ifdef __APPLE__
-    QString m_displayFont(QFont(QStringLiteral("SF Pro Text")).exactMatch()
-                                  ? QStringLiteral("SF Pro Text")
-                                  : QStringLiteral("Roboto"));
-#elif _WIN32
-    QString m_displayFont(QFont(QStringLiteral("Segoe UI")).exactMatch()
-                                  ? QStringLiteral("Segoe UI")
-                                  : QStringLiteral("Roboto"));
-#else
-    QString m_displayFont(QStringLiteral("Roboto"));
-#endif
-#ifdef __APPLE__
     QFont m_titleFont(m_displayFont, 13, QFont::DemiBold);
 #else
     QFont m_titleFont(m_displayFont, 10, QFont::DemiBold);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -397,12 +397,12 @@ void MainWindow::setupMainWindow()
     ui->listviewLabel2->setMaximumSize({ 40, 25 });
 
 #ifdef __APPLE__
-    QFont m_titleFont(m_displayFont, 13, QFont::DemiBold);
+    QFont titleFont(m_displayFont, 13, QFont::DemiBold);
 #else
-    QFont m_titleFont(m_displayFont, 10, QFont::DemiBold);
+    QFont titleFont(m_displayFont, 10, QFont::DemiBold);
 #endif
-    ui->listviewLabel1->setFont(m_titleFont);
-    ui->listviewLabel2->setFont(m_titleFont);
+    ui->listviewLabel1->setFont(titleFont);
+    ui->listviewLabel2->setFont(titleFont);
     ui->listviewLabel1->setStyleSheet("QLabel { color :  rgb(0, 0, 0); }");
     ui->listviewLabel2->setStyleSheet("QLabel { color :  rgb(132, 132, 132); }");
     m_splitterStyle = new SplitterStyle();

--- a/src/nodetreeview.cpp
+++ b/src/nodetreeview.cpp
@@ -602,9 +602,9 @@ void NodeTreeView::mousePressEvent(QMouseEvent *event)
             case NodeItem::Type::TagItem: {
                 auto oldIndexes = selectionModel()->selectedIndexes();
                 for (const auto &ix : qAsConst(oldIndexes)) {
-                    auto itemType =
+                    auto selectedItemType =
                             static_cast<NodeItem::Type>(ix.data(NodeItem::Roles::ItemType).toInt());
-                    if (itemType != NodeItem::Type::TagItem) {
+                    if (selectedItemType != NodeItem::Type::TagItem) {
                         setCurrentIndex(QModelIndex());
                         clearSelection();
                         break;

--- a/src/notelistdelegate.cpp
+++ b/src/notelistdelegate.cpp
@@ -349,7 +349,6 @@ void NoteListDelegate::paintBackground(QPainter *painter, const QStyleOptionView
         }
     } else {
         if (m_view->isPinnedNotesCollapsed()) {
-            auto isPinned = index.data(NoteListModel::NoteIsPinned).value<bool>();
             if (!isPinned) {
                 bufferPainter.fillRect(bufferRect, QBrush(m_defaultColor));
             }

--- a/src/notelistdelegateeditor.cpp
+++ b/src/notelistdelegateeditor.cpp
@@ -125,13 +125,13 @@ NoteListDelegateEditor::NoteListDelegateEditor(const NoteListDelegate *delegate,
         m_tagListView->setGeometry(10, y - 5, rect().width() - 15, m_tagListView->height());
     }
     connect(m_tagListView->verticalScrollBar(), &QScrollBar::valueChanged, this, [this] {
-        auto m_index = dynamic_cast<NoteListModel *>(m_view->model())->getNoteIndex(m_id);
+        auto idx = dynamic_cast<NoteListModel *>(m_view->model())->getNoteIndex(m_id);
         dynamic_cast<NoteListModel *>(m_view->model())
-                ->setData(m_index, getScrollBarPos(), NoteListModel::NoteTagListScrollbarPos);
+                ->setData(idx, getScrollBarPos(), NoteListModel::NoteTagListScrollbarPos);
     });
     QTimer::singleShot(0, this, [this] {
-        auto index = dynamic_cast<NoteListModel *>(m_view->model())->getNoteIndex(m_id);
-        setScrollBarPos(index.data(NoteListModel::NoteTagListScrollbarPos).toInt());
+        auto idx = dynamic_cast<NoteListModel *>(m_view->model())->getNoteIndex(m_id);
+        setScrollBarPos(idx.data(NoteListModel::NoteTagListScrollbarPos).toInt());
     });
     m_view->setEditorWidget(m_id, this);
     setMouseTracking(true);
@@ -188,7 +188,6 @@ void NoteListDelegateEditor::paintBackground(QPainter *painter, const QStyleOpti
             m_tagListView->setBackground(m_hoverColor);
         }
     } else {
-        auto isPinned = index.data(NoteListModel::NoteIsPinned).value<bool>();
         if (m_view->isPinnedNotesCollapsed() && !isPinned) {
             bufferPainter.fillRect(bufferRect, QBrush(m_defaultColor));
             m_tagListView->setBackground(m_defaultColor);

--- a/src/notelistmodel.cpp
+++ b/src/notelistmodel.cpp
@@ -533,7 +533,6 @@ void NoteListModel::setNotesIsPinned(const QModelIndexList &indexes, bool isPinn
 
     if (isPinned) {
         emit rowsAboutToBeMovedC(needMovingIndexes);
-        int moved = 0;
         beginResetModel();
         for (const auto &id : qAsConst(needMovingIds)) {
             auto index = getNoteIndex(id);
@@ -545,7 +544,6 @@ void NoteListModel::setNotesIsPinned(const QModelIndexList &indexes, bool isPinn
                 continue;
             }
             m_pinnedList.prepend(m_noteList.takeAt(sourceRow - m_pinnedList.size()));
-            ++moved;
         }
         endResetModel();
         QModelIndexList destinations;

--- a/src/notelistmodel.cpp
+++ b/src/notelistmodel.cpp
@@ -453,8 +453,7 @@ bool NoteListModel::dropMimeData(const QMimeData *mime, Qt::DropAction action, i
                 auto lastMod = index.data(NoteDeletionDateTime).toDateTime();
                 for (destinationChild = 0; destinationChild < m_noteList.size();
                      ++destinationChild) {
-                    const auto &note = m_noteList[destinationChild];
-                    if (note.deletionDateTime() <= lastMod) {
+                    if (m_noteList[destinationChild].deletionDateTime() <= lastMod) {
                         break;
                     }
                 }
@@ -462,8 +461,7 @@ bool NoteListModel::dropMimeData(const QMimeData *mime, Qt::DropAction action, i
                 auto lastMod = index.data(NoteLastModificationDateTime).toDateTime();
                 for (destinationChild = 0; destinationChild < m_noteList.size();
                      ++destinationChild) {
-                    const auto &note = m_noteList[destinationChild];
-                    if (note.lastModificationdateTime() <= lastMod) {
+                    if (m_noteList[destinationChild].deletionDateTime() <= lastMod) {
                         break;
                     }
                 }

--- a/src/notelistmodel.cpp
+++ b/src/notelistmodel.cpp
@@ -164,14 +164,6 @@ QVariant NoteListModel::data(const QModelIndex &index, int role) const
     if (role < NoteID || role > NoteIsPinned) {
         return QVariant();
     }
-    auto getRef = [this](int row) -> const NodeData & {
-        if (row < m_pinnedList.size()) {
-            return m_pinnedList[row];
-        } else {
-            row = row - m_pinnedList.size();
-            return m_noteList[row];
-        }
-    };
     const NodeData &note = getRef(index.row());
     if (role == NoteID) {
         return note.id();
@@ -213,14 +205,6 @@ bool NoteListModel::setData(const QModelIndex &index, const QVariant &value, int
         return false;
     }
 
-    auto getRef = [this](int row) -> NodeData & {
-        if (row < m_pinnedList.size()) {
-            return m_pinnedList[row];
-        } else {
-            row = row - m_pinnedList.size();
-            return m_noteList[row];
-        }
-    };
     NodeData &note = getRef(index.row());
     if (role == NoteID) {
         note.setId(value.toInt());
@@ -328,6 +312,20 @@ bool NoteListModel::isInAllNote() const
             && (m_listViewInfo.parentFolderId == SpecialNodeID::RootFolder);
 }
 
+NodeData &NoteListModel::getRef(int row)
+{
+    if (row < m_pinnedList.size())
+        return m_pinnedList[row];
+    return m_noteList[row - m_pinnedList.size()];
+}
+
+const NodeData &NoteListModel::getRef(int row) const
+{
+    if (row < m_pinnedList.size())
+        return m_pinnedList[row];
+    return m_noteList[row - m_pinnedList.size()];
+}
+
 bool NoteListModel::removeRows(int row, int count, const QModelIndex &parent)
 {
     if (row < 0 || (row + count) > (m_pinnedList.size() + m_noteList.size())) {
@@ -384,14 +382,6 @@ bool NoteListModel::dropMimeData(const QMimeData *mime, Qt::DropAction action, i
                                  const QModelIndex &parent)
 {
     Q_UNUSED(column);
-    auto getRef = [this](int row) -> NodeData & {
-        if (row < m_pinnedList.size()) {
-            return m_pinnedList[row];
-        } else {
-            row = row - m_pinnedList.size();
-            return m_noteList[row];
-        }
-    };
 
     if (!(mime->hasFormat(NOTE_MIME) && action == Qt::MoveAction)) {
         return false;
@@ -506,14 +496,6 @@ bool NoteListModel::hasPinnedNote() const
 
 void NoteListModel::setNotesIsPinned(const QModelIndexList &indexes, bool isPinned)
 {
-    auto getRef = [this](int row) -> NodeData & {
-        if (row < m_pinnedList.size()) {
-            return m_pinnedList[row];
-        } else {
-            row = row - m_pinnedList.size();
-            return m_noteList[row];
-        }
-    };
     emit requestCloseNoteEditor(indexes);
     QSet<int> needMovingIds;
     QModelIndexList needMovingIndexes;
@@ -626,14 +608,6 @@ bool NoteListModel::isFirstPinnedNote(const QModelIndex &index) const
     if (index.row() > 0) {
         return false;
     }
-    auto getRef = [this](int row) -> const NodeData & {
-        if (row < m_pinnedList.size()) {
-            return m_pinnedList[row];
-        } else {
-            row = row - m_pinnedList.size();
-            return m_noteList[row];
-        }
-    };
     const NodeData &note = getRef(index.row());
     if (index.row() == 0 && note.isPinnedNote()) {
         return true;
@@ -646,14 +620,6 @@ bool NoteListModel::isFirstUnpinnedNote(const QModelIndex &index) const
     if (!index.isValid()) {
         return false;
     }
-    auto getRef = [this](int row) -> const NodeData & {
-        if (row < m_pinnedList.size()) {
-            return m_pinnedList[row];
-        } else {
-            row = row - m_pinnedList.size();
-            return m_noteList[row];
-        }
-    };
     const NodeData &note = getRef(index.row());
     if ((index.row() - m_pinnedList.size()) == 0 && !note.isPinnedNote()) {
         return true;

--- a/src/notelistmodel.h
+++ b/src/notelistmodel.h
@@ -66,6 +66,8 @@ private:
     ListViewInfo m_listViewInfo;
     void updatePinnedRelativePosition();
     bool isInAllNote() const;
+    NodeData &getRef(int row);
+    const NodeData &getRef(int row) const;
 
 signals:
     void rowCountChanged();

--- a/src/notelistview.cpp
+++ b/src/notelistview.cpp
@@ -441,8 +441,8 @@ void NoteListView::startDrag(Qt::DropActions supportedActions)
     Q_UNUSED(supportedActions);
     Q_D(NoteListView);
     auto indexes = selectedIndexes();
-    QMimeData *data = d->model->mimeData(indexes);
-    if (!data) {
+    QMimeData *mimeData = d->model->mimeData(indexes);
+    if (!mimeData) {
         return;
     }
     QRect rect;
@@ -512,7 +512,7 @@ void NoteListView::startDrag(Qt::DropActions supportedActions)
     }
     QDrag *drag = new QDrag(this);
     drag->setPixmap(pixmap);
-    drag->setMimeData(data);
+    drag->setMimeData(mimeData);
     if (indexes.size() == 1) {
         drag->setHotSpot(d->pressedPosition - rect.topLeft());
     } else {
@@ -524,7 +524,7 @@ void NoteListView::startDrag(Qt::DropActions supportedActions)
     /// Delete later, if there is no drop event.
     if (dropAction == Qt::IgnoreAction) {
         drag->deleteLater();
-        data->deleteLater();
+        mimeData->deleteLater();
     }
 #if QT_VERSION > QT_VERSION_CHECK(5, 15, 0)
     d->dropEventMoved = false;
@@ -747,8 +747,8 @@ void NoteListView::onCustomContextMenu(QPoint point)
             const auto tagIds = m_tagPool->tagIds();
             for (const auto &id : tagIds) {
                 bool all = true;
-                for (const auto &index : qAsConst(indexList)) {
-                    auto tags = index.data(NoteListModel::NoteTagsList).value<QSet<int>>();
+                for (const auto &selectedIndex : qAsConst(indexList)) {
+                    auto tags = selectedIndex.data(NoteListModel::NoteTagsList).value<QSet<int>>();
                     if (!tags.contains(id)) {
                         all = false;
                         break;
@@ -859,9 +859,10 @@ void NoteListView::onCustomContextMenu(QPoint point)
                 auto action = new QAction(folders[id], this);
                 connect(action, &QAction::triggered, this, [this, id] {
                     auto indexes = selectedIndexes();
-                    for (const auto &index : qAsConst(indexes)) {
-                        if (index.isValid()) {
-                            emit moveNoteRequested(index.data(NoteListModel::NoteID).toInt(), id);
+                    for (const auto &selectedIndex : qAsConst(indexes)) {
+                        if (selectedIndex.isValid()) {
+                            emit moveNoteRequested(
+                                    selectedIndex.data(NoteListModel::NoteID).toInt(), id);
                         }
                     }
                 });

--- a/src/notelistview.cpp
+++ b/src/notelistview.cpp
@@ -298,13 +298,8 @@ void NoteListView::mousePressEvent(QMouseEvent *e)
         if (!oldIndexes.contains(index)) {
             if (e->modifiers() == Qt::ControlModifier) {
                 setSelectionMode(QAbstractItemView::MultiSelection);
-                auto oldIndexes = selectionModel()->selectedIndexes();
-                if (oldIndexes.contains(index) && oldIndexes.size() > 1) {
-                    selectionModel()->select(index, QItemSelectionModel::Deselect);
-                } else {
-                    setCurrentIndex(index);
-                    selectionModel()->setCurrentIndex(index, QItemSelectionModel::SelectCurrent);
-                }
+                setCurrentIndex(index);
+                selectionModel()->setCurrentIndex(index, QItemSelectionModel::SelectCurrent);
                 auto selectedIndexes = selectionModel()->selectedIndexes();
                 emit notePressed(selectedIndexes);
             } else {

--- a/src/trashbuttondelegateeditor.cpp
+++ b/src/trashbuttondelegateeditor.cpp
@@ -7,10 +7,10 @@
 
 TrashButtonDelegateEditor::TrashButtonDelegateEditor(QTreeView *view,
                                                      const QStyleOptionViewItem &option,
-                                                     const QModelIndex &m_index, QWidget *parent)
+                                                     const QModelIndex &index, QWidget *parent)
     : QWidget(parent),
       m_option(option),
-      m_index(m_index),
+      m_index(index),
 #ifdef __APPLE__
       m_displayFont(QFont(QStringLiteral("SF Pro Text")).exactMatch()
                             ? QStringLiteral("SF Pro Text")


### PR DESCRIPTION
This enables some extra warnings on supported compilers, by default. The options are:

- GCC/Clang: [`-Wall -Wextra -Wpedantic -Wshadow`](https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html)
- MSVC: [`/W4`](https://learn.microsoft.com/en-us/cpp/build/reference/compiler-option-warning-level?view=msvc-140#remarks)

For obvious reasons, these flags had to be disabled on third-party sources, that's why I moved them into their own list in `CMakeLists.txt`.