### PR TITLE
Update shortcut to summon Notes on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Our vision for the future on our [Wiki](https://github.com/nuttyartist/notes/wik
 - Markdown Support. Format text without lifting your hands from the keyboard.
 - Different themes. Switch between Light, Dark, and Sepia.
 - Feed View. Select multiple notes to see them all one after another in the editor.
-- Always runs in the background. Use the hotkey "Windows" + 'N' to summon Notes. "control" + "N" for macOS.
+- Always runs in the background. Use the hotkey <kbd>Win</kbd>+<kbd>Shift</kbd>+<kbd>N</kbd> to summon Notes. <kbd>Ctrl</kbd>+<kbd>N</kbd> for macOS.
 - Keyboard shortcuts. Meant to have the option to be used solely with a keyboard (but more work needs to be done there).
 - What feature will you contribute?
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -505,10 +505,10 @@ void MainWindow::setupKeyboardShortcuts()
     new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_Backslash), this, SLOT(resetBlockFormat()));
 
     QxtGlobalShortcut *shortcut = new QxtGlobalShortcut(this);
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-    shortcut->setShortcut(QKeySequence(Qt::META | Qt::SHIFT | Qt::Key_N));
-#else
+#if defined(Q_OS_MACOS)
     shortcut->setShortcut(QKeySequence(Qt::META | Qt::Key_N));
+#else
+    shortcut->setShortcut(QKeySequence(Qt::META | Qt::SHIFT | Qt::Key_N));
 #endif
     connect(shortcut, &QxtGlobalShortcut::activated, this, [=]() {
         // workaround prevent textEdit and searchEdit


### PR DESCRIPTION
The <kbd>Win</kbd>+<kbd>N</kbd> shortcut is now used by Windows 11 to bring up their [notification center](https://support.microsoft.com/en-us/windows/how-to-open-notification-center-and-quick-settings-f8dc196e-82db-5d67-f55e-ba5586fbb038), so replace it by <kbd>Win</kbd>+<kbd>Shift</kbd>+<kbd>N</kbd>.

Fixes #475