### PR TITLE
Tab width is way too high, fixed by setting it to the width of 4 spaces.

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -906,6 +906,14 @@ void MainWindow::setCurrentFontBasedOnTypeface(FontTypeface selectedFontTypeFace
     m_currentSelectedFont = QFont(m_currentFontFamily, m_currentFontPointSize, QFont::Normal);
     m_textEdit->setFont(m_currentSelectedFont);
 
+    // Set tab width
+    QFontMetrics currentFontMetrics(m_currentSelectedFont);
+#if QT_VERSION < QT_VERSION_CHECK(5, 11, 0)
+    m_textEdit->setTabStopWidth(4 * currentFontMetrics.width(' '));
+#else
+    m_textEdit->setTabStopDistance(4 * currentFontMetrics.horizontalAdvance(QLatin1Char(' ')));
+#endif
+
     alignTextEditText();
 }
 
@@ -1887,7 +1895,6 @@ void MainWindow::setTheme(Theme theme)
         m_styleEditorWindow.setTheme(Theme::Light, m_currentThemeBackgroundColor,
                                      m_currentEditorTextColor);
         m_aboutWindow.setTheme(m_currentThemeBackgroundColor, m_currentEditorTextColor);
-        m_noteEditorLogic->setTheme(theme, m_currentEditorTextColor);
         ui->listviewLabel1->setStyleSheet(
                 QStringLiteral("QLabel { color : %1; }").arg(QColor(26, 26, 26).name()));
         m_treeViewLogic->setTheme(theme);
@@ -1914,7 +1921,6 @@ void MainWindow::setTheme(Theme theme)
         m_styleEditorWindow.setTheme(Theme::Dark, m_currentThemeBackgroundColor,
                                      m_currentEditorTextColor);
         m_aboutWindow.setTheme(m_currentThemeBackgroundColor, m_currentEditorTextColor);
-        m_noteEditorLogic->setTheme(theme, m_currentEditorTextColor);
         ui->listviewLabel1->setStyleSheet(
                 QStringLiteral("QLabel { color : %1; }").arg(QColor(204, 204, 204).name()));
         m_treeViewLogic->setTheme(theme);
@@ -1942,7 +1948,6 @@ void MainWindow::setTheme(Theme theme)
         m_styleEditorWindow.setTheme(Theme::Sepia, m_currentThemeBackgroundColor,
                                      QColor(26, 26, 26));
         m_aboutWindow.setTheme(m_currentThemeBackgroundColor, QColor(26, 26, 26));
-        m_noteEditorLogic->setTheme(theme, m_currentEditorTextColor);
         ui->listviewLabel1->setStyleSheet(
                 QStringLiteral("QLabel { color : %1; }").arg(QColor(26, 26, 26).name()));
         m_treeViewLogic->setTheme(theme);
@@ -1950,6 +1955,7 @@ void MainWindow::setTheme(Theme theme)
     }
     }
     ui->tagListView->setBackground(m_currentThemeBackgroundColor);
+    m_noteEditorLogic->setTheme(theme, m_currentEditorTextColor);
 
     setSearchEditStyleSheet(false);
     alignTextEditText();


### PR DESCRIPTION
I felt the tab with is waaay too high (8 spaces), which is very annoying for making todo lists with indented items. I changed this to use 4 spaces instead. In the future, we could let the user choose this width through a preferences window.

## Old:

https://user-images.githubusercontent.com/4633209/219814567-c7e544c4-abf0-4ccb-baa3-8a636414d338.mp4


## New:


https://user-images.githubusercontent.com/4633209/219814550-725f536c-bf7d-43b1-b56e-d28b57a640f1.mp4

---

This  updates every time the theme changes.

An alternative to this PR is to catch the Tab keyboard event and to insert 4 spaces instead. I don't think this is a good idea as existing notes would still have the long tabs, and this feels kind of hacky anyway.