### PR TITLE
Fix settings not saving when closing the app using native buttons or system shortcut

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2535,7 +2535,7 @@ void MainWindow::onRedCloseButtonClicked()
     if (m_hideToTray) {
         setMainWindowVisibility(false);
     } else {
-        close();
+        QuitApplication();
     }
 }
 
@@ -2553,6 +2553,9 @@ void MainWindow::closeEvent(QCloseEvent *event)
         // don't close the application, just hide to tray
         setMainWindowVisibility(false);
         event->ignore();
+    } else {
+        // save states and quit application
+        QuitApplication();
     }
 }
 


### PR DESCRIPTION
I made a mistake in #470: I didn't call QuitApplication(), so the states were never saved to the settings file. This should be fixed now.