### PR TITLE
Use `Qt::FramelessWindowHint` on Linux and friends

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -156,7 +156,11 @@ void MainWindow::InitData()
         QProgressDialog *pd =
                 new QProgressDialog(tr("Migrating database, please wait."), QString(), 0, 0, this);
         pd->setCancelButton(Q_NULLPTR);
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
+        pd->setWindowFlags(Qt::Window | Qt::FramelessWindowHint | Qt::FramelessWindowHint);
+#else
         pd->setWindowFlags(Qt::Window | Qt::CustomizeWindowHint);
+#endif
         pd->setMinimumDuration(0);
         pd->show();
 
@@ -308,8 +312,13 @@ MainWindow::~MainWindow()
 void MainWindow::setupMainWindow()
 {
 #if !defined(Q_OS_MAC)
-    this->setWindowFlags(Qt::Window | Qt::CustomizeWindowHint);
+    auto flags = Qt::Window | Qt::CustomizeWindowHint;
+#  if defined(Q_OS_UNIX)
+    flags |= Qt::FramelessWindowHint;
+#  endif
+    setWindowFlags(flags);
 #endif
+
 #if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
     this->setAttribute(Qt::WA_TranslucentBackground);
 #endif
@@ -3722,8 +3731,12 @@ void MainWindow::setUseNativeWindowFrame(bool useNativeWindowFrame)
     // Reset window flags to its initial state.
     Qt::WindowFlags flags = Qt::Window;
 
-    if (!useNativeWindowFrame)
+    if (!useNativeWindowFrame) {
         flags |= Qt::CustomizeWindowHint;
+#  if defined(Q_OS_UNIX)
+        flags |= Qt::FramelessWindowHint;
+#  endif
+    }
 
     setWindowFlags(flags);
 #endif

--- a/src/updaterwindow.cpp
+++ b/src/updaterwindow.cpp
@@ -99,8 +99,12 @@ UpdaterWindow::UpdaterWindow(QWidget *parent)
     /* Start the UI loops */
     updateTitleLabel();
 
-    /* Remove window border */
+    /* Remove native window decorations */
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
+    setWindowFlags(windowFlags() | Qt::CustomizeWindowHint | Qt::FramelessWindowHint);
+#else
     setWindowFlags(windowFlags() | Qt::CustomizeWindowHint);
+#endif
 
     /* React when xdg-open finishes (Linux only) */
 #ifdef UseXdgOpen


### PR DESCRIPTION
This hint was removed in commits 8d7cb3e and 20a4d42, but without it, Linux window managers will still use native window decorations on Wayland sessions.

**Before (on KDE Plasma 5.27 + Wayland)**:

![kde-before](https://user-images.githubusercontent.com/626206/220998914-103ec973-e368-4f4a-a7f2-1279c319cd0c.png)

**After (on KDE Plasma 5.27 + Wayland)**:

![kde-after](https://user-images.githubusercontent.com/626206/220998888-b9b01e6e-e243-44d0-8b53-b3c1feda779f.png)