### PR TITLE
Fixes panel widths resetting when resizing (fixes #482)

### DIFF
--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -136,6 +136,8 @@ private:
     QLineEdit *m_searchEdit;
     QLabel *m_editorDateLabel;
     QSplitter *m_splitter;
+    QWidget *m_noteListWidget;
+    QWidget *m_foldersWidget;
     QSystemTrayIcon *m_trayIcon;
 #if !defined(Q_OS_MAC)
     QAction *m_restoreAction;
@@ -189,8 +191,6 @@ private:
     int m_chosenMonoFontIndex;
     int m_editorMediumFontSize;
     int m_currentFontPointSize;
-    bool m_isNoteListCollapsed;
-    bool m_isTreeCollapsed;
     struct m_charsLimitPerFont
     {
         int mono;
@@ -290,9 +290,9 @@ private slots:
     void collapseNoteList();
     void expandNoteList();
     void toggleNoteList();
-    void collapseNodeTree();
-    void expandNodeTree();
-    void toggleNodeTree();
+    void collapseFolderTree();
+    void expandFolderTree();
+    void toggleFolderTree();
     void importNotesFile();
     void exportNotesFile();
     void restoreNotesFile();


### PR DESCRIPTION
This PR removes the m_noteListWidth and m_nodeTreeWidth variables, as I bypass them entirely. It also adds 2 new boolean settings: isNoteListCollapsed and isTreeCollapsed.

I fixed the resizing issue by using the splitter's setStretchFactor method to 0 for the first two panes, and 1 for the editor pane. Collapsing the 2 panes happens by simply hiding the widgets, using the setHidden() method.

Tested on bspwm with a clean settings file.