### PR TITLE
A couple of fixes for frameless mode

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2568,14 +2568,12 @@ void MainWindow::mousePressEvent(QMouseEvent *event)
     m_mousePressY = event->pos().y();
 
     if (event->buttons() == Qt::LeftButton) {
-        if (m_mousePressX < width() - m_layoutMargin && m_mousePressX > m_layoutMargin
-            && m_mousePressY < height() - m_layoutMargin && m_mousePressY > m_layoutMargin) {
+        if (isTitleBar(m_mousePressX, m_mousePressY)) {
 
 #  if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
             m_canMoveWindow = !window()->windowHandle()->startSystemMove();
 #  else
             m_canMoveWindow = true;
-            //            QApplication::setOverrideCursor(QCursor(Qt::ClosedHandCursor));
 #  endif
 
 #  ifndef __APPLE__
@@ -2833,8 +2831,7 @@ void MainWindow::mousePressEvent(QMouseEvent *event)
     }
 
     if (event->button() == Qt::LeftButton) {
-        if (event->pos().x() < width() - 5 && event->pos().x() > 5
-            && event->pos().y() < height() - 5 && event->pos().y() > 5) {
+        if (isTitleBar(event->pos().x(), event->pos().y())) {
 
 #  if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
             m_canMoveWindow = !window()->windowHandle()->startSystemMove();
@@ -3751,4 +3748,26 @@ void MainWindow::setMargins(QMargins margins)
 
     ui->centralWidget->layout()->setContentsMargins(margins);
     m_trafficLightLayout.setGeometry(QRect(4 + margins.left(), 4 + margins.top(), 56, 16));
+}
+
+bool MainWindow::isTitleBar(int x, int y) const
+{
+    if (m_useNativeWindowFrame)
+        return false;
+
+    // The width of the title bar is essentially the width of the main window.
+    int titleBarWidth = width();
+    int titleBarHeight = ui->verticalSpacer_upTreeView->height();
+
+    int adjustedX = x;
+    int adjustedY = y;
+
+    if (!isMaximized() && !isFullScreen()) {
+        titleBarWidth -= m_layoutMargin * 2;
+        adjustedX -= m_layoutMargin;
+        adjustedY -= m_layoutMargin;
+    }
+
+    return (adjustedX >= 0 && adjustedX <= titleBarWidth && adjustedY >= 0
+            && adjustedY <= titleBarHeight);
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -336,6 +336,7 @@ void MainWindow::setupMainWindow()
 #endif
 
 #ifdef _WIN32
+    m_layoutMargin = 0;
     m_trafficLightLayout.setSpacing(0);
     m_trafficLightLayout.setContentsMargins(QMargins(0, 0, 0, 0));
     m_trafficLightLayout.setGeometry(QRect(2, 2, 90, 16));

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2579,7 +2579,7 @@ void MainWindow::mousePressEvent(QMouseEvent *event)
 #  endif
 
 #  ifndef __APPLE__
-        } else {
+        } else if (!isMaximized() && !isFullScreen()) {
             m_canStretchWindow = true;
 
             if ((m_mousePressX < width() && m_mousePressX > width() - m_layoutMargin)
@@ -2666,7 +2666,7 @@ void MainWindow::mouseMoveEvent(QMouseEvent *event)
         }
     }
 
-    if (!m_canMoveWindow) {
+    if (!m_canMoveWindow && !isMaximized() && !isFullScreen()) {
         switch (m_stretchSide) {
         case StretchSide::Right:
         case StretchSide::Left:

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3158,7 +3158,8 @@ double MainWindow::gaussianDist(double x, const double center, double sigma) con
  */
 void MainWindow::mouseDoubleClickEvent(QMouseEvent *event)
 {
-    if (m_useNativeWindowFrame) {
+    if (m_useNativeWindowFrame || event->buttons() != Qt::LeftButton
+        || !isTitleBar(event->pos().x(), event->pos().y())) {
         MainWindowBase::mouseDoubleClickEvent(event);
         return;
     }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3497,17 +3497,6 @@ bool MainWindow::eventFilter(QObject *object, QEvent *event)
         }
 #endif
         break;
-    case QEvent::MouseButtonPress:
-    case QEvent::MouseButtonDblClick:
-        // Only allow double click (maximise/minimise) or dragging (move)
-        // from the top part of the window
-        if (object == ui->frame) {
-            QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);
-            if (mouseEvent->pos().y() >= ui->searchEdit->y()) {
-                return true;
-            }
-        }
-        break;
     case QEvent::KeyPress: {
         auto *keyEvent = static_cast<QKeyEvent *>(event);
         if (keyEvent->key() == Qt::Key_Return && m_searchEdit->text().isEmpty()) {

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -314,6 +314,7 @@ private slots:
     void setNoteListLoading();
     void selectAllNotesInList();
     void updateFrame();
+    bool isTitleBar(int x, int y) const;
 
 signals:
     void requestNodesTree();


### PR DESCRIPTION
**1 - Don't allow resizing the window in certain states:**

While in frameless mode, if the window is either maximized or in full screen, we probably shouldn't allow the user to resize it.

**Bug:**

https://user-images.githubusercontent.com/626206/221879465-beab71e3-ca36-4de0-9974-ea5a786d1fcd.mp4

<br>

---

**2 - Only allow moving the window by grabbing its title bar:**

Previously, while in frameless mode, we could move the window by grabbing some unusual places. Now, we copy what most window managers do and only allow moving the window by grabbing its title bar.

The height of the title bar is defined by the height of the `verticalSpacer_upTreeView` widget (currently 25 pixels).

Closes #494

**Bug:**

https://user-images.githubusercontent.com/626206/220690891-613bed70-9adf-49ed-b9c8-a5b9bb530232.mp4

---

**3 - Don't filter out mouse click events**

This filtering was added to ensure we could only drag the window by grabbing anywhere above the search widget (`ui->searchEdit`).

However, due to changes introduced by ef4bb7f08ea84fbb6213e9fdea4fc053c58bbb23, now the search widget can start hidden (by hiding the notes panel and quitting the app).

This scenario is now handled directly in `MainWindow::mousePressEvent` and `MainWindow::mouseDoubleClickEvent`, so we can remove this entirely.

Fixes #508
