### PR TITLE
UI: Get rid of the "context help" button

### DIFF
--- a/src/aboutwindow.cpp
+++ b/src/aboutwindow.cpp
@@ -9,6 +9,9 @@
 AboutWindow::AboutWindow(QWidget *parent) : QDialog(parent), m_ui(new Ui::AboutWindow)
 {
     m_ui->setupUi(this);
+#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
+    setWindowFlag(Qt::WindowContextHelpButtonHint, false);
+#endif
     setWindowTitle(tr("About") + " " + QCoreApplication::applicationName());
 
     m_ui->aboutText->setText(

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,6 +16,10 @@ int main(int argc, char *argv[])
     app.setApplicationName("Notes");
     app.setApplicationVersion(APP_VERSION);
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0) && QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    app.setAttribute(Qt::AA_DisableWindowContextHelpButton);
+#endif
+
     // Load fonts from resources
     // Roboto
     QFontDatabase::addApplicationFont(":/fonts/roboto-hinted/Roboto-Bold.ttf");

--- a/src/updaterwindow.cpp
+++ b/src/updaterwindow.cpp
@@ -62,6 +62,9 @@ UpdaterWindow::UpdaterWindow(QWidget *parent)
 
     /* Initialize the UI */
     m_ui->setupUi(this);
+#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
+    setWindowFlag(Qt::WindowContextHelpButtonHint, false);
+#endif
     setWindowTitle(qApp->applicationName() + " " + tr("Updater"));
 
     /* Change fonts */


### PR DESCRIPTION
We currently don't do anything with it, and the button is disabled by default on Qt 6, so let's also disable it on Qt 5 builds.

This was reported in #496, and this fix is based on https://github.com/nuttyartist/notes/issues/496#issuecomment-1441486941! :)