### PR TITLE
Improvements to Linux packaging

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,6 +2,8 @@ name: Linux
 on:
   push:
   pull_request:
+env:
+  APP_ID: io.github.nuttyartist.notes
 jobs:
   # This job is mainly to make sure Notes will compile with Qt from Ubuntu's repository.
   # So it doesn't make much sense to have different build types other than 'debug' here.
@@ -111,6 +113,7 @@ jobs:
           apt update
 
       - name: Install other dependencies in docker container
+        # - appstream: Used to validate the AppStream metadata file.
         # - cmake: Used to help build the application.
         # - curl: Used to download the linuxdeploy AppImage tool.
         # - git: To clone this repository.
@@ -125,7 +128,7 @@ jobs:
           echo UTC > /etc/timezone
           # install packages
           apt update
-          apt install -y cmake curl git libfontconfig1 libxkbcommon-x11-0 python3 python3-pip sudo
+          apt install -y appstream cmake curl git libfontconfig1 libxkbcommon-x11-0 python3 python3-pip sudo
           # Upgrade to the latest setuptools, as Ubuntu's python3-setuptools package has compatibility issues with aqtinstall.
           python3 -m pip install --upgrade setuptools
 
@@ -244,6 +247,12 @@ jobs:
               rm -v usr/plugins/sqldrivers/libqsqlmysql.so
               rm -v usr/lib/libmysqlclient.so.*
           fi
+
+      - name: Validate AppStream metadata
+        if: matrix.container != 'ubuntu:18.04'
+        run: |
+          cd build/Notes
+          appstreamcli validate --verbose 'usr/share/metainfo/${{ env.APP_ID }}.metainfo.xml'
 
       - name: Build AppImage (${{ matrix.build-type }})
         env:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -225,7 +225,6 @@ jobs:
           install -Dm644 -t Notes/usr/share/applications ../packaging/linux/common/notes.desktop
           mkdir -p Notes/usr/share/icons/hicolor
           cp -r ../packaging/linux/common/icons/* Notes/usr/share/icons/hicolor
-          export VERSION='${{ steps.vars.outputs.version }}'
           ./linuxdeploy-x86_64.AppImage --appdir Notes --plugin qt
 
       - name: Remove unnecessary Qt plugins and libraries
@@ -254,6 +253,7 @@ jobs:
           APPIMAGE_EXTRACT_AND_RUN: 1
         run: |
           cd build
+          export VERSION='${{ steps.vars.outputs.version }}'
           ./linuxdeploy-x86_64.AppImage --appdir Notes --output appimage
           mv -v Notes*.AppImage '${{ steps.vars.outputs.file_name }}'
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -116,6 +116,7 @@ jobs:
         # - appstream: Used to validate the AppStream metadata file.
         # - cmake: Used to help build the application.
         # - curl: Used to download the linuxdeploy AppImage tool.
+        # - desktop-file-utils: Used to validate the desktop file.
         # - git: To clone this repository.
         # - libfontconfig1: Used as dependency of the resulting AppImage.
         # - libxkbcommon-x11-0: Used as dependency of the resulting AppImage.
@@ -128,7 +129,7 @@ jobs:
           echo UTC > /etc/timezone
           # install packages
           apt update
-          apt install -y appstream cmake curl git libfontconfig1 libxkbcommon-x11-0 python3 python3-pip sudo
+          apt install -y appstream cmake curl desktop-file-utils git libfontconfig1 libxkbcommon-x11-0 python3 python3-pip sudo
           # Upgrade to the latest setuptools, as Ubuntu's python3-setuptools package has compatibility issues with aqtinstall.
           python3 -m pip install --upgrade setuptools
 
@@ -253,6 +254,11 @@ jobs:
         run: |
           cd build/Notes
           appstreamcli validate --verbose 'usr/share/metainfo/${{ env.APP_ID }}.metainfo.xml'
+
+      - name: Validate desktop file
+        run: |
+          cd build/Notes
+          desktop-file-validate 'usr/share/applications/${{ env.APP_ID }}.desktop'
 
       - name: Build AppImage (${{ matrix.build-type }})
         env:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -222,9 +222,6 @@ jobs:
           APPIMAGE_EXTRACT_AND_RUN: 1
         run: |
           cd build
-          install -Dm644 -t Notes/usr/share/applications ../packaging/linux/common/notes.desktop
-          mkdir -p Notes/usr/share/icons/hicolor
-          cp -r ../packaging/linux/common/icons/* Notes/usr/share/icons/hicolor
           ./linuxdeploy-x86_64.AppImage --appdir Notes --plugin qt
 
       - name: Remove unnecessary Qt plugins and libraries

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,7 +226,7 @@ if(UPDATE_CHECKER)
     ${PROJECT_SOURCE_DIR}/3rdParty/QSimpleUpdater/src/Updater.h)
 endif()
 
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+if(APPLE)
   list(APPEND SOURCES ${PROJECT_SOURCE_DIR}/src/framelesswindow.mm
        ${PROJECT_SOURCE_DIR}/src/framelesswindow.h
        ${PROJECT_SOURCE_DIR}/src/images/notes_icon.icns)
@@ -293,7 +293,7 @@ target_link_libraries(
          Qt${QT_VERSION_MAJOR}::Widgets
          Qt${QT_VERSION_MAJOR}::WidgetsPrivate)
 
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+if(APPLE)
   string(TIMESTAMP CURRENT_YEAR "%Y")
   set(COPYRIGHT_TEXT
       "Copyright (c) 2015-${CURRENT_YEAR} Ruby Mamistvalove and contributors.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -329,6 +329,12 @@ elseif(UNIX)
   install(FILES ${CMAKE_BINARY_DIR}/${APP_ID}.desktop
           DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications)
 
+  configure_file(
+    ${PROJECT_SOURCE_DIR}/packaging/linux/common/notes.appdata.xml.in
+    ${CMAKE_BINARY_DIR}/${APP_ID}.metainfo.xml)
+  install(FILES ${CMAKE_BINARY_DIR}/${APP_ID}.metainfo.xml
+          DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/metainfo)
+
   foreach(
     ICON_SIZE
     16

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.10)
 
 set(APP_VERSION 2.0.0)
+set(APP_ID "io.github.nuttyartist.notes")
 
 # Any of the options below can be changed by passing -D<option name>=<value> to CMake.
 set(CMAKE_OSX_DEPLOYMENT_TARGET
@@ -300,7 +301,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   set_target_properties(
     ${PROJECT_NAME}
     PROPERTIES MACOSX_BUNDLE_BUNDLE_NAME ${PROJECT_NAME}
-               MACOSX_BUNDLE_GUI_IDENTIFIER "io.github.nuttyartist.notes"
+               MACOSX_BUNDLE_GUI_IDENTIFIER ${APP_ID}
                MACOSX_BUNDLE_ICON_FILE "notes_icon.icns"
                MACOSX_BUNDLE_BUNDLE_VERSION ${PROJECT_VERSION}
                MACOSX_BUNDLE_SHORT_VERSION_STRING ${PROJECT_VERSION}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,7 +276,8 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES
   target_compile_options(${PROJECT_NAME} PUBLIC -Wall -Wextra -Wpedantic
                                                 -Wshadow)
   set_source_files_properties(${SOURCES_3RD_PARTY} PROPERTIES COMPILE_FLAGS -w)
-elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" AND MSVC_VERSION GREATER_EQUAL
+                                                 1920)
   target_compile_options(${PROJECT_NAME} PUBLIC /W4)
   set_source_files_properties(${SOURCES_3RD_PARTY} PROPERTIES COMPILE_FLAGS /w)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -321,6 +321,37 @@ elseif(UNIX)
   set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME ${BINARY_NAME})
 
   target_link_libraries(${PROJECT_NAME} PUBLIC X11)
+
+  include(GNUInstallDirs)
+
+  configure_file(${PROJECT_SOURCE_DIR}/packaging/linux/common/notes.desktop.in
+                 ${CMAKE_BINARY_DIR}/${APP_ID}.desktop)
+  install(FILES ${CMAKE_BINARY_DIR}/${APP_ID}.desktop
+          DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications)
+
+  foreach(
+    ICON_SIZE
+    16
+    22
+    24
+    32
+    48
+    64
+    128
+    256
+    512)
+    install(
+      FILES
+        ${PROJECT_SOURCE_DIR}/packaging/linux/common/icons/${ICON_SIZE}x${ICON_SIZE}/notes.png
+      DESTINATION
+        ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/${ICON_SIZE}x${ICON_SIZE}/apps
+      RENAME ${APP_ID}.png)
+  endforeach()
+
+  install(
+    FILES ${PROJECT_SOURCE_DIR}/packaging/linux/common/icons/scalable/notes.svg
+    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/scalable/apps
+    RENAME ${APP_ID}.svg)
 elseif(WIN32)
   target_compile_definitions(${PROJECT_NAME} PUBLIC QXT_STATIC)
 

--- a/packaging/linux/common/notes.appdata.xml.in
+++ b/packaging/linux/common/notes.appdata.xml.in
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2022 Ruby Mamistvalove -->
+<component type="desktop-application">
+    <id>@APP_ID@</id>
+    <launchable type="desktop-id">@APP_ID@.desktop</launchable>
+    <metadata_license>CC0-1.0</metadata_license>
+    <project_license>MPL-2.0</project_license>
+    <name>@PROJECT_NAME@</name>
+    <developer_name>Ruby Mamistvalove</developer_name>
+    <update_contact>ruby.mamistvalove_AT_gmail.com</update_contact>
+    <summary>Note-taking application, write down your thoughts</summary>
+    <url type="homepage">https://www.get-notes.com/</url>
+    <url type="bugtracker">https://github.com/nuttyartist/notes/issues</url>
+    <url type="donation">https://github.com/sponsors/nuttyartist</url>
+    <description>
+        <p>Notes is an open source and cross-platform note-taking app that is both beautiful and powerful.</p>
+        <p>Features overview:</p>
+        <ul>
+            <li>Native app (written in C++ with Qt)</li>
+            <li>Fast with a low memory footprint</li>
+            <li>Beautiful and sleek looking, yet still powerful</li>
+            <li>Fully open source and cross-platform (Linux, macOS, Windows)</li>
+            <li>Completely private: Tracks nothing</li>
+            <li>Folders and tags: Organize your ideas hierarchically using nested folders and universally using tags</li>
+            <li>Markdown Support: Format text without lifting your hands from the keyboard</li>
+            <li>Different themes: Switch between Light, Dark, and Sepia</li>
+            <li>Feed View: Select multiple notes to see them all one after another in the editor</li>
+            <li>Always runs in the background: Use the hotkey <code>Super</code> + <code>Shift</code> + <code>N</code> to summon Notes</li>
+        </ul>
+    </description>
+    <screenshots>
+        <!-- TODO: Upload these screenshots to a better place. -->
+        <screenshot type="default">
+            <image>https://user-images.githubusercontent.com/626206/222927528-64941f78-4093-4d3d-8000-fd0dca61980a.png</image>
+            <caption>Light theme</caption>
+        </screenshot>
+        <screenshot>
+            <image>https://user-images.githubusercontent.com/626206/222927531-a52cd062-acd1-49b2-9b58-543ff5772c6e.png</image>
+            <caption>Editor settings</caption>
+        </screenshot>
+        <screenshot>
+            <image>https://user-images.githubusercontent.com/626206/222927543-6c91792f-3fa3-430b-94b7-c2ff92f6ed4d.png</image>
+            <caption>Dark theme</caption>
+        </screenshot>
+        <screenshot>
+            <image>https://user-images.githubusercontent.com/626206/222927546-1d333c84-2d82-4e2d-8c96-a15f42d56af2.png</image>
+            <caption>Sepia theme</caption>
+        </screenshot>
+        <screenshot>
+            <image>https://user-images.githubusercontent.com/626206/222930768-87a1f5ef-1707-45c3-9322-fb0e64869cc2.png</image>
+            <caption>Compact mode</caption>
+        </screenshot>
+    </screenshots>
+    <content_rating type="oars-1.1" />
+    <releases>
+        <release date="2023-03-08" version="2.1.0">
+            <description>
+                <p>A new release is here with some new features and many bug fixes and improvements.</p>
+                <p>New features:</p>
+                <ul>
+                    <li>You can now open external links by holding <code>Ctrl</code> while clicking them</li>
+                    <li>You can now format text using keyboard shortcuts: <code>Ctrl</code> + <code>B</code> (Bold) | <code>Ctrl</code> + <code>I</code> (Italic) | <code>Ctrl</code> + <code>S</code> (Strikethrough)</li>
+                    <li>You can create different heading levels with <code>Ctrl</code> + <code>1</code>...<code>6</code></li>
+                    <li>You can increase or decrease levels by using <code>Ctrl</code> + <code>Shift</code> + (<code>+</code> or <code>-</code>)</li>
+                    <li>You can now access the app menu by pressing <code>F10</code> (<code>Fn</code> + <code>F10</code> on macOS)</li>
+                </ul>
+                <p>Improvements and bug fixes:</p>
+                <ul>
+                    <li>Automatic updates now work on Windows</li>
+                    <li>Fixed bugs with native window decoration</li>
+                    <li>We improved the style of selecting multiple notes</li>
+                    <li>Fixed a bug on Windows causing extreme input delay when editing text</li>
+                    <li>Streamlined the look and feel of some windows to match the OS better</li>
+                    <li>Fixed issues when resizing the window's splitters and resizing the window itself</li>
+                    <li>Fixed some bugs causing crashes</li>
+                    <li>Many more fixes and improvements under the hood</li>
+                </ul>
+            </description>
+        </release>
+        <release date="2022-09-08" version="2.0.0">
+            <description>
+                <p>A new release is here with major new features and many bug fixes and improvements:</p>
+                <ul>
+                    <li>Folders and tags: Organize your ideas hierarchically using nested folders and universally using tags</li>
+                    <li>Pinned notes: Pin your most important notes at the top of each folder</li>
+                    <li>Different themes: Switch between Light, Dark, and Sepia</li>
+                    <li>Editor settings window: Change between different fonts and change the size/width of your text</li>
+                    <li>Feed View: Select multiple notes to see them all one after another in the editor</li>
+                    <li>Option to change the database path, so you can more easily sync your notes with a cloud provider</li>
+                    <li>Many bug fixes</li>
+                </ul>
+            </description>
+        </release>
+    </releases>
+    <provides>
+        <binary>@BINARY_NAME@</binary>
+    </provides>
+</component>

--- a/packaging/linux/common/notes.desktop
+++ b/packaging/linux/common/notes.desktop
@@ -1,9 +1,9 @@
 [Desktop Entry]
 Type=Application
-Terminal=false
-StartupNotify=true
 Name=Notes
 Comment=Write down your thoughts
 Categories=Utility;
 Exec=notes
 Icon=notes
+StartupNotify=true
+StartupWMClass=Notes

--- a/packaging/linux/common/notes.desktop.in
+++ b/packaging/linux/common/notes.desktop.in
@@ -1,9 +1,9 @@
 [Desktop Entry]
 Type=Application
-Name=Notes
+Name=@PROJECT_NAME@
 Comment=Write down your thoughts
 Categories=Utility;
-Exec=notes
-Icon=notes
+Exec=@BINARY_NAME@
+Icon=@APP_ID@
 StartupNotify=true
-StartupWMClass=Notes
+StartupWMClass=@PROJECT_NAME@


### PR DESCRIPTION
These changes are meant to make things easier for package maintainers to distribute Notes on their Linux distribution.

We now use CMake to configure *and* install:

- The [desktop file](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html)
- The [AppStream metadata file](https://freedesktop.org/software/appstream/docs/chap-Metadata.html) (added just now!)
- ... And of course, our app icons in [many resolutions](https://github.com/nuttyartist/notes/tree/fe80934e8625bfbd72c5892305e2b44b2f9cd1ae/packaging/linux/common/icons)!

Now, Linux package maintainers won't have to look for those files manually, or perhaps tweak them before packaging Notes: It should be all done automagically!

The build steps for packaging should be as easy as:

```shell
$ cmake -B builddir -DCMAKE_INSTALL_PREFIX=/usr \
    -DCMAKE_BUILD_TYPE=Release \
    -DUPDATE_CHECKER=OFF 
$ cmake --build builddir
$ DESTDIR="package_dir" cmake --install builddir
```

P.S.: There are some changes unrelated to Linux here as well, but since they're so minor, I decided to include them here instead of opening a new PR. Hope it's okay.... :)