### PR TITLE
Document build options

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Notes is an open source and cross-platform note-taking app that is both beautiful and powerful.
 
-Website: <a href="http://get-notes.com" target="_blank">get-notes.com</a>  
+Website: <a href="https://get-notes.com" target="_blank">get-notes.com</a>
 Our vision for the future on our [Wiki](https://github.com/nuttyartist/notes/wiki/Vision).
 
 ## Screenshots
@@ -35,28 +35,9 @@ Our vision for the future on our [Wiki](https://github.com/nuttyartist/notes/wik
 
 If you use Notes daily, consider donating money so I can pay programmers to develop new features and fix bugs. I partner with [Github Sponsors](https://github.com/sponsors/nuttyartist) and [Patreon](https://www.patreon.com/rubymamis) to receive contributions. You can also put a bounty on specific issues using Bountysource. I currently make a living from ads on the website, but I'd like to stop with that.
 
-## How to clone
+## Building from source
 
-Use this command to clone the repository:
-
-```shell
-$> git clone --recursive  https://github.com/nuttyartist/notes.git
-```
-
-## Dependencies
-
-Make sure the Qt (>= 5.9) development libraries are installed:
-
-- Debian/Ubuntu : qt5-default build-essential qtbase5-private-dev sqlite3
-
-## Compiling
-
-```shell
-$> mkdir build
-$> cd build
-$> cmake .. -DCMAKE_BUILD_TYPE=Release
-$> make -j4
-```
+We have specific instructions for [Windows](docs/build_on_windows.md), [macOS](docs/build_on_macos.md) and [Linux](docs/build_on_linux.md) (and we also provide [build options](docs/build_options.md)).
 
 ## Database path
 

--- a/README.md
+++ b/README.md
@@ -43,11 +43,13 @@ We have specific instructions for [Windows](docs/build_on_windows.md), [macOS](d
 
 The notes database and settings file are stored in:
 
-**Windows** : `C:\Users\user\AppData\Roaming\Awesomeness`  
-**Linux** &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;: `/home/user/.config/Awesomeness/` **or** `/home/snap/notes/x1/.config/Awesomeness` **(using snap)**  
-**Mac** &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;: `/home/user/.config/Awesomeness/`
+| OS      | Path                                                                                                                                             |
+| ------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Windows | `%APPDATA%\Awesomeness`                                                                                                                          |
+| Linux   | `~/.config/Awesomeness`<br>`~/snap/notes/x1/.config/Awesomeness` (Snap)<br>`~/.var/app/io.github.nuttyartist.notes/config/Awesomeness` (Flatpak) |
+| macOS   | `~/.config/Awesomeness`                                                                                                                          |
 
-## Contributers
+## Contributors
 
 ### Developers:
 Alex Spataru  

--- a/docs/build_on_linux.md
+++ b/docs/build_on_linux.md
@@ -1,0 +1,52 @@
+These are common steps to build Notes from source on Linux distributions.
+
+### Requirements
+
+It's impossible to create a guide that will work for all Linux distros out there, but thankfully the only major difference between all of them will be package names, so feel free to add the appropriate package names for your favorite distro down here *(alphabetically, please)*.
+
+| Distro       | Packages                                                     |
+| ------------ | ------------------------------------------------------------ |
+| Arch Linux   | `base-devel` `cmake` `git` `qt6-base` `sqlite`               |
+| Ubuntu 18.04 | `build-essential` `cmake` `qtbase5-private-dev` `sqlite3`    |
+| Ubuntu 22.04 | `build-essential` `cmake` `qt6-base-private-dev` `libgl-dev` |
+
+### Build options
+
+Please refer to [build_options.md](build_options.md).
+
+### Building
+
+First, use `git` to clone the project and its components, and then navigate into it:
+
+```shell
+git clone https://github.com/nuttyartist/notes.git --recurse-submodules
+cd notes
+```
+
+Let's create a build folder called `build`:
+
+```shell
+mkdir build
+cd build
+```
+
+After that, we're ready to build Notes!
+
+Invoke CMake to build the project into a folder called `build`, in [`Release` mode](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html):
+
+```shell
+cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release
+make -j$(nproc)
+```
+
+To run the binary you just built (e.g. for testing purposes), you can simply execute the `notes` binary in the `build` folder:
+
+```shell
+./notes
+```
+
+If you want to install Notes like a regular, Linux desktop application (with its own desktop file and icons), you can simply run (as root):
+
+```shell
+make install
+```

--- a/docs/build_on_macos.md
+++ b/docs/build_on_macos.md
@@ -1,0 +1,57 @@
+These are common steps to build Notes from source on macOS.
+
+### Requirements
+
+macOS Catalina 10.15 (or newer) is required to build Notes.
+
+This guide assumes you already have Xcode Command Line Tools (version 11 or newer) and [Homebrew](https://brew.sh/) both installed.
+
+Required Homebrew packages:
+
+- `git`
+- `qt@6` *(`qt@5` is also supported, but not recommended)*
+- `cmake`
+- `ninja`
+
+### Build options
+
+Please refer to [build_options.md](build_options.md).
+
+### Building
+
+First, use `git` to clone the project and its components, and then navigate into it:
+
+```shell
+git clone https://github.com/nuttyartist/notes.git --recurse-submodules
+cd notes
+```
+
+Optionally, if you want to dedicate all cores of your CPU to build Notes much faster, set this environment variable:
+
+```shell
+export CMAKE_BUILD_PARALLEL_LEVEL=$(sysctl -n hw.logicalcpu)
+```
+
+After that, we're ready to build Notes!
+
+Invoke CMake to build the project into a folder called `build`, in [`Release` mode](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html):
+
+```shell
+cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release'
+```
+
+Alternatively, if you want to target both `x86_64` and `arm64` (Apple Silicon) architectures in a single, universal binary, invoke CMake like this instead *(please note that this might be unsupported on Qt versions older than 6)*:
+
+```shell
+cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES='x86_64;arm64'
+```
+
+After Notes is built, you can use the `macdeployqt` tool from Qt to include the required libraries to your app bundle:
+
+```shell
+macdeployqt 'build/Notes.app' -appstore-compliant
+```
+
+You can now install Notes by either dragging the `Notes.app` folder (found in `build/bin`), into the `Applications` folder.
+
+Alternatively, you can run Notes directly by executing `build/bin/Notes.app/Contents/MacOS/Notes`.

--- a/docs/build_on_windows.md
+++ b/docs/build_on_windows.md
@@ -1,0 +1,79 @@
+These are common steps to build Notes from source on Windows.
+
+### Requirements
+
+Windows 7 (or newer) is required to build Notes.
+
+Additionally, you need to install the following tools/components:
+
+- [Git](https://gitforwindows.org/)
+- [Microsoft Visual C++](https://visualstudio.microsoft.com/downloads) `>= 2015` *(only the build tools are required)*
+- [Qt](https://www.qt.io/download-qt-installer) `>= 5.9` *(using the latest version is recommended)*
+  - [CMake](https://cmake.org/download/) *(can be installed via the Qt installer)*
+  - [Ninja](https://ninja-build.org/) *(can be installed via the Qt installer)*
+
+### Build options
+
+Please refer to [build_options.md](build_options.md).
+
+### Building
+
+The following steps are done all via the command line. If you're not that comfortable with it, you can also to configure the project using a graphical tool like the CMake GUI, or Qt Creator.
+
+Additionally, these commands are meant to be run on the Windows command prompt, *not* on PowerShell (though they can be easily adapted).
+
+First, use `git` to clone the project and its components, and then navigate into it:
+
+```shell
+git clone https://github.com/nuttyartist/notes.git --recurse-submodules
+cd notes
+```
+
+Now, let's configure our build environment. In this example, we will be using Microsoft Visual C++ 2017 and Qt 5.15.2 (the MSVC 2019 build), targeting a 64-bit system.
+
+Depending on what version of these softwares you have installed, you may need to make some path adjustments in the following steps.
+
+Let's begin by invoking the `vcvars64.bat` script from MSVC 2017, which will set some helpful environment variables for us:
+
+```shell
+@call "C:\Program Files (x86)\Microsoft Visual Studio\2015\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
+```
+
+Now, we need to add CMake, Ninja, Qt sources and tools to our `Path` environment variable:
+
+```shell
+set Path=C:\Qt\Tools\CMake_64\bin;%Path%
+set Path=C:\Qt\Tools\Ninja;%Path%
+set Path=C:\Qt\5.15.2\msvc2019_64;%Path%
+set Path=C:\Qt\5.15.2\msvc2019_64\bin;%Path%
+```
+
+Optionally, if you want to dedicate all cores of your CPU to build Notes much faster, set this environment variable:
+
+```shell
+set CMAKE_BUILD_PARALLEL_LEVEL=%NUMBER_OF_PROCESSORS%
+```
+
+After that, we're ready to build Notes!
+
+Invoke CMake to build the project into a folder called `build`, in [`Release` mode](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html):
+
+```shell
+cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
+cmake --install build --prefix build
+```
+
+Now, use the `windeployqt` tool from Qt to copy the required Qt libraries to run Notes:
+
+```shell
+windeployqt build\bin
+```
+
+And then, finally, copy the required OpenSSL libraries to make internet-dependent features work properly (like the auto-updater):
+
+```shell
+copy /B C:\Qt\Tools\OpenSSL\Win_x64\bin\libcrypto-1_1-x64.dll build\bin
+copy /B C:\Qt\Tools\OpenSSL\Win_x64\bin\libssl-1_1-x64.dll build\bin
+```
+
+You can now run Notes by double-clicking the `Notes.exe` executable in the `build\bin` folder.

--- a/docs/build_options.md
+++ b/docs/build_options.md
@@ -1,0 +1,32 @@
+These are options you can use to customize your own build of Notes.
+
+You should set those while invoking CMake to build the project. See the [examples section](#examples) below.
+
+### Options
+
+| Name                                       | Default value | Supported values    | Description                                                 |
+| ------------------------------------------ | ------------- | ------------------- | ----------------------------------------------------------- |
+| `CMAKE_OSX_DEPLOYMENT_TARGET` (macOS-only) | `10.15`       | (any macOS version) | Minimum macOS version to target for deployment              |
+| `USE_QT_VERSION`                           | (unset)       | `5` / `6`           | Use a specific version of Qt to build the app               |
+| `GIT_REVISION`                             | `OFF`         | `ON` / `OFF`        | Append the current git revision to the app's version string |
+| `UPDATE_CHECKER`                           | `ON`          | `ON` / `OFF`        | Enable or disable both the update checker and auto-updater  |
+
+### Examples
+
+To build Notes without any update-checking feature:
+
+```
+cmake -B build -DUPDATE_CHECKER=OFF
+```
+
+To force CMake to use Qt 5 (useful when you also have Qt 6 installed, which will be chosen by default, if present):
+
+```
+cmake -B build -USE_QT_VERSION=5
+```
+
+To build Notes in `Release` mode (for other modes, check the [CMake documentation](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)):
+
+```
+cmake -B build -DCMAKE_BUILD_TYPE=Release
+```


### PR DESCRIPTION
And also add simple guides to build on Windows, macOS and Linux.

Rendered pages:

- [build_options.md](https://github.com/nuttyartist/notes/blob/05f4e75847ce29fab97066f786bba8836bd41ef1/docs/build_options.md)
- [build_on_windows.md](https://github.com/nuttyartist/notes/blob/05f4e75847ce29fab97066f786bba8836bd41ef1/docs/build_on_windows.md)
- [build_on_macos.md](https://github.com/nuttyartist/notes/blob/05f4e75847ce29fab97066f786bba8836bd41ef1/docs/build_on_windows.md)
- [build_on_linux.md](https://github.com/nuttyartist/notes/blob/05f4e75847ce29fab97066f786bba8836bd41ef1/docs/build_on_linux.md)
- [README.md](https://github.com/nuttyartist/notes/blob/05f4e75847ce29fab97066f786bba8836bd41ef1/README.md)