### PR TITLE
CI: Add simple code linting workflow

### DIFF
--- a/.github/workflows/format-lint.yml
+++ b/.github/workflows/format-lint.yml
@@ -1,0 +1,31 @@
+name: Code Linting
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint:
+    name: Format / Lint
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up cmake-format
+        run: pip install cmakelang
+
+      - name: Run clang-format
+        run: find src/ -iregex '.*\.\(cpp\|h\|mm\)$' -print0 | xargs -n 1 -0 clang-format -style=file --dry-run --Werror --color=true
+
+      - name: Run cmake-format
+        run: |
+          cmake-format CMakeLists.txt > CMakeLists-new.txt
+          if ! cmp -s CMakeLists.txt CMakeLists-new.txt
+          then
+              echo 'Please format CMakeLists.txt using cmake-format: https://github.com/cheshirekow/cmake_format'
+              echo 'For example: cmake-format CMakeLists.txt | sponge CMakeLists.txt'
+              exit 1
+          fi

--- a/src/customdocument.cpp
+++ b/src/customdocument.cpp
@@ -40,8 +40,8 @@ bool CustomDocument::eventFilter(QObject *obj, QEvent *event)
 
         // toggle cursor when control key has been pressed or released
         viewport()->setCursor(mouseEvent->modifiers().testFlag(Qt::ControlModifier)
-                                    ? Qt::PointingHandCursor
-                                    : Qt::IBeamCursor);
+                                      ? Qt::PointingHandCursor
+                                      : Qt::IBeamCursor);
     } else if (event->type() == QEvent::KeyPress) {
         auto *keyEvent = static_cast<QKeyEvent *>(event);
 

--- a/src/framelesswindow.cpp
+++ b/src/framelesswindow.cpp
@@ -41,10 +41,10 @@ void CFramelessWindow::setResizeable(bool resizeable)
         setWindowFlags(windowFlags() | Qt::WindowMaximizeButtonHint);
         //        setWindowFlag(Qt::WindowMaximizeButtonHint);
 
-        //此行代码可以带回Aero效果，同时也带回了标题栏和边框,在nativeEvent()会再次去掉标题栏
+        // 此行代码可以带回Aero效果，同时也带回了标题栏和边框,在nativeEvent()会再次去掉标题栏
         //
-        // this line will get titlebar/thick frame/Aero back, which is exactly what we want
-        // we will get rid of titlebar and thick frame again in nativeEvent() later
+        //  this line will get titlebar/thick frame/Aero back, which is exactly what we want
+        //  we will get rid of titlebar and thick frame again in nativeEvent() later
         HWND hwnd = (HWND)this->winId();
         DWORD style = ::GetWindowLong(hwnd, GWL_STYLE);
         ::SetWindowLong(hwnd, GWL_STYLE, style | WS_MAXIMIZEBOX | WS_THICKFRAME | WS_CAPTION);
@@ -57,9 +57,9 @@ void CFramelessWindow::setResizeable(bool resizeable)
         ::SetWindowLong(hwnd, GWL_STYLE, style & ~WS_MAXIMIZEBOX & ~WS_CAPTION);
     }
 
-    //保留一个像素的边框宽度，否则系统不会绘制边框阴影
+    // 保留一个像素的边框宽度，否则系统不会绘制边框阴影
     //
-    // we better left 1 piexl width of border untouch, so OS can draw nice shadow around it
+    //  we better left 1 piexl width of border untouch, so OS can draw nice shadow around it
     const MARGINS shadow = { 1, 1, 1, 1 };
     DwmExtendFrameIntoClientArea(HWND(winId()), &shadow);
 

--- a/src/framelesswindow.h
+++ b/src/framelesswindow.h
@@ -22,26 +22,26 @@ public:
     explicit CFramelessWindow(QWidget *parent = 0);
 
 public:
-    //设置是否可以通过鼠标调整窗口大小
-    // if resizeable is set to false, then the window can not be resized by mouse
-    // but still can be resized programtically
+    // 设置是否可以通过鼠标调整窗口大小
+    //  if resizeable is set to false, then the window can not be resized by mouse
+    //  but still can be resized programtically
     void setResizeable(bool resizeable = true);
     bool isResizeable() { return m_bResizeable; }
 
-    //设置可调整大小区域的宽度，在此区域内，可以使用鼠标调整窗口大小
-    // set border width, inside this aera, window can be resized by mouse
+    // 设置可调整大小区域的宽度，在此区域内，可以使用鼠标调整窗口大小
+    //  set border width, inside this aera, window can be resized by mouse
     void setResizeableAreaWidth(int width = 5);
 
 protected:
-    //设置一个标题栏widget，此widget会被当做标题栏对待
-    // set a widget which will be treat as SYSTEM titlebar
+    // 设置一个标题栏widget，此widget会被当做标题栏对待
+    //  set a widget which will be treat as SYSTEM titlebar
     void setTitleBar(QWidget *titlebar);
 
-    //在标题栏控件内，也可以有子控件如标签控件“label1”，此label1遮盖了标题栏，导致不能通过label1拖动窗口
-    //要解决此问题，使用addIgnoreWidget(label1)
-    // generally, we can add widget say "label1" on titlebar, and it will cover the titlebar under
-    // it as a result, we can not drag and move the MainWindow with this "label1" again we can fix
-    // this by add "label1" to a ignorelist, just call addIgnoreWidget(label1)
+    // 在标题栏控件内，也可以有子控件如标签控件“label1”，此label1遮盖了标题栏，导致不能通过label1拖动窗口
+    // 要解决此问题，使用addIgnoreWidget(label1)
+    //  generally, we can add widget say "label1" on titlebar, and it will cover the titlebar under
+    //  it as a result, we can not drag and move the MainWindow with this "label1" again we can fix
+    //  this by add "label1" to a ignorelist, just call addIgnoreWidget(label1)
     void addIgnoreWidget(QWidget *widget);
 
 #    if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
@@ -87,36 +87,37 @@ private:
     void initUI();
 
 public:
-    //设置可拖动区域的高度，在此区域内，可以通过鼠标拖动窗口, 0表示整个窗口都可拖动
-    // In draggable area, window can be moved by mouse, (height = 0) means that the whole window is
-    // draggable
+    // 设置可拖动区域的高度，在此区域内，可以通过鼠标拖动窗口, 0表示整个窗口都可拖动
+    //  In draggable area, window can be moved by mouse, (height = 0) means that the whole window is
+    //  draggable
     void setDraggableAreaHeight(int height = 0);
 
-    //只有OS X10.10及以后系统，才支持OS X原生样式包括：三个系统按钮、窗口圆角、窗口阴影
-    //类初始化完成后，可以通过此函数查看是否已经启用了原生样式。如果未启动，需要自定义关闭按钮、最小化按钮、最大化按钮
-    // Native style（three system button/ round corner/ drop shadow） works only on OS X 10.10 or
-    // later after init, we should check whether NativeStyle is OK with this function if NOT ok, we
-    // should implement close button/ min button/ max button ourself
+    // 只有OS X10.10及以后系统，才支持OS X原生样式包括：三个系统按钮、窗口圆角、窗口阴影
+    // 类初始化完成后，可以通过此函数查看是否已经启用了原生样式。如果未启动，需要自定义关闭按钮、最小化按钮、最大化按钮
+    //  Native style（three system button/ round corner/ drop shadow） works only on OS X 10.10 or
+    //  later after init, we should check whether NativeStyle is OK with this function if NOT ok, we
+    //  should implement close button/ min button/ max button ourself
     bool isNativeStyleOK() { return m_bNativeSystemBtn; }
 
-    //如果设置setCloseBtnQuit(false)，那么点击关闭按钮后，程序不会退出，而是会隐藏,只有在OS X 10.10
-    //及以后系统中有效 if setCloseBtnQuit(false), then when close button is clicked, the application
-    // will hide itself instead of quit be carefull, after you set this to false, you can NOT change
-    // it to true again this function should be called inside of the constructor function of derived
-    // classes, and can NOT be called more than once only works for OS X 10.10 or later
+    // 如果设置setCloseBtnQuit(false)，那么点击关闭按钮后，程序不会退出，而是会隐藏,只有在OS X 10.10
+    // 及以后系统中有效 if setCloseBtnQuit(false), then when close button is clicked, the
+    // application
+    //  will hide itself instead of quit be carefull, after you set this to false, you can NOT
+    //  change it to true again this function should be called inside of the constructor function of
+    //  derived classes, and can NOT be called more than once only works for OS X 10.10 or later
     void setCloseBtnQuit(bool bQuit = true);
 
-    //启用或禁用关闭按钮，只有在isNativeStyleOK()返回true的情况下才有效
-    // enable or disable Close button, only worked if isNativeStyleOK() returns true
+    // 启用或禁用关闭按钮，只有在isNativeStyleOK()返回true的情况下才有效
+    //  enable or disable Close button, only worked if isNativeStyleOK() returns true
     void setCloseBtnEnabled(bool bEnable = true);
 
-    //启用或禁用最小化按钮，只有在isNativeStyleOK()返回true的情况下才有效
-    // enable or disable Miniaturize button, only worked if isNativeStyleOK() returns true
+    // 启用或禁用最小化按钮，只有在isNativeStyleOK()返回true的情况下才有效
+    //  enable or disable Miniaturize button, only worked if isNativeStyleOK() returns true
     void setMinBtnEnabled(bool bEnable = true);
 
-    //启用或禁用zoom（最大化）按钮，只有在isNativeStyleOK()返回true的情况下才有效
-    // enable or disable Zoom button(fullscreen button), only worked if isNativeStyleOK() returns
-    // true
+    // 启用或禁用zoom（最大化）按钮，只有在isNativeStyleOK()返回true的情况下才有效
+    //  enable or disable Zoom button(fullscreen button), only worked if isNativeStyleOK() returns
+    //  true
     void setZoomBtnEnabled(bool bEnable = true);
 
     bool isCloseBtnEnabled() { return m_bIsCloseBtnEnabled; }
@@ -149,18 +150,18 @@ private:
 
     //===============================================
     // TODO
-    //下面的代码是试验性质的
+    // 下面的代码是试验性质的
     // tentative code
 
-    //窗口从全屏状态恢复正常大小时，标题栏又会出现，原因未知。
-    //默认情况下，系统的最大化按钮(zoom button)是进入全屏，为了避免标题栏重新出现的问题，
-    //以上代码已经重新定义了系统zoom button的行为，是其功能变为最大化而不是全屏
-    //以下代码尝试，每次窗口从全屏状态恢复正常大小时，都再次进行设置，以消除标题栏
-    // after the window restore from fullscreen mode, the titlebar will show again, it looks like a
-    // BUG on OS X 10.10 and later, click the system green button (zoom button) will make the app
-    // become fullscreen so we have override it's action to "maximized" in the CFramelessWindow
-    // Constructor function but we may try something else such as delete the titlebar again and
-    // again...
+    // 窗口从全屏状态恢复正常大小时，标题栏又会出现，原因未知。
+    // 默认情况下，系统的最大化按钮(zoom button)是进入全屏，为了避免标题栏重新出现的问题，
+    // 以上代码已经重新定义了系统zoom button的行为，是其功能变为最大化而不是全屏
+    // 以下代码尝试，每次窗口从全屏状态恢复正常大小时，都再次进行设置，以消除标题栏
+    //  after the window restore from fullscreen mode, the titlebar will show again, it looks like a
+    //  BUG on OS X 10.10 and later, click the system green button (zoom button) will make the app
+    //  become fullscreen so we have override it's action to "maximized" in the CFramelessWindow
+    //  Constructor function but we may try something else such as delete the titlebar again and
+    //  again...
 private:
     bool m_bTitleBarVisible;
 

--- a/src/framelesswindow.mm
+++ b/src/framelesswindow.mm
@@ -1,7 +1,7 @@
 ﻿#include "framelesswindow.h"
 #ifdef Q_OS_MAC
-#include <QDebug>
-#include <Cocoa/Cocoa.h>
+#  include <QDebug>
+#  include <Cocoa/Cocoa.h>
 
 CFramelessWindow::CFramelessWindow(QWidget *parent)
     : QMainWindow(parent),
@@ -35,17 +35,17 @@ CFramelessWindow::CFramelessWindow(QWidget *parent)
 }
 @end
 
-//此类用于支持重载系统按钮的行为
-//this Objective-c class is used to override the action of sysytem close button and zoom button
-//https://stackoverflow.com/questions/27643659/setting-c-function-as-selector-for-nsbutton-produces-no-results
-@interface ButtonPasser : NSObject{
+// 此类用于支持重载系统按钮的行为
+// this Objective-c class is used to override the action of sysytem close button and zoom button
+// https://stackoverflow.com/questions/27643659/setting-c-function-as-selector-for-nsbutton-produces-no-results
+@interface ButtonPasser : NSObject {
 }
-@property(readwrite) CFramelessWindow* window;
+@property (readwrite) CFramelessWindow *window;
 + (void)closeButtonAction:(id)sender;
 - (void)zoomButtonAction:(id)sender;
 @end
 
-@implementation ButtonPasser{   
+@implementation ButtonPasser {
 }
 + (void)closeButtonAction:(id)sender
 {
@@ -53,18 +53,21 @@ CFramelessWindow::CFramelessWindow(QWidget *parent)
     [NSApp hide:nil];
 }
 - (void)zoomButtonAction:(id)sender
-{    
+{
     Q_UNUSED(sender);
-    if (0 == self.window) return;
+    if (0 == self.window)
+        return;
 
     if (self.window->isFullScreen() || self.window->isMaximized()) {
         self.window->showNormal();
         emit self.window->toggleFullScreen(false);
     } else {
-        NSView* view = sender;
-        if (0 == view) return;
+        NSView *view = sender;
+        if (0 == view)
+            return;
         NSWindow *window = view.window;
-        if (0 == window) return;
+        if (0 == window)
+            return;
 
         [window toggleFullScreen:window];
         emit self.window->toggleFullScreen(true);
@@ -76,17 +79,25 @@ void CFramelessWindow::initUI()
 {
     m_bNativeSystemBtn = false;
 
-    //如果当前osx版本老于10.9，则后续代码不可用。转为使用定制的系统按钮，不支持自由缩放窗口及窗口阴影
-//    if (QSysInfo::MV_None == QSysInfo::macVersion())
-//    {
-//        if (QSysInfo::MV_None == QSysInfo::MacintoshVersion) {setWindowFlags(Qt::FramelessWindowHint); return;}
-//    }
-//    if (QSysInfo::MV_10_9 >= QSysInfo::MacintoshVersion) {setWindowFlags(Qt::FramelessWindowHint); return;}
+    // 如果当前osx版本老于10.9，则后续代码不可用。转为使用定制的系统按钮，不支持自由缩放窗口及窗口阴影
+    //    if (QSysInfo::MV_None == QSysInfo::macVersion())
+    //    {
+    //        if (QSysInfo::MV_None == QSysInfo::MacintoshVersion)
+    //        {setWindowFlags(Qt::FramelessWindowHint); return;}
+    //    }
+    //    if (QSysInfo::MV_10_9 >= QSysInfo::MacintoshVersion)
+    //    {setWindowFlags(Qt::FramelessWindowHint); return;}
 
-    NSView* view = (NSView*)winId();
-    if (0 == view) {setWindowFlags(Qt::FramelessWindowHint); return;}
+    NSView *view = (NSView *)winId();
+    if (0 == view) {
+        setWindowFlags(Qt::FramelessWindowHint);
+        return;
+    }
     NSWindow *window = view.window;
-    if (0 == window) {setWindowFlags(Qt::FramelessWindowHint); return;}
+    if (0 == window) {
+        setWindowFlags(Qt::FramelessWindowHint);
+        return;
+    }
 
     AppObserver *observer = [[AppObserver alloc] init];
     if (observer) {
@@ -105,22 +116,22 @@ void CFramelessWindow::initUI()
         qWarning() << "Failed to set up Notification Observer!";
     }
 
-    //设置标题文字和图标为不可见
-    window.titleVisibility = NSWindowTitleHidden;   //MAC_10_10及以上版本支持
-    //设置标题栏为透明
-    window.titlebarAppearsTransparent = YES;        //MAC_10_10及以上版本支持
-    //设置不可由标题栏拖动,避免与自定义拖动冲突
-    [window setMovable:NO];                         //MAC_10_6及以上版本支持
-    //window.movableByWindowBackground = YES;
-    //设置view扩展到标题栏
-    window.styleMask |=  NSWindowStyleMaskFullSizeContentView; //MAC_10_10及以上版本支持
+    // 设置标题文字和图标为不可见
+    window.titleVisibility = NSWindowTitleHidden; // MAC_10_10及以上版本支持
+    // 设置标题栏为透明
+    window.titlebarAppearsTransparent = YES; // MAC_10_10及以上版本支持
+    // 设置不可由标题栏拖动,避免与自定义拖动冲突
+    [window setMovable:NO]; // MAC_10_6及以上版本支持
+    // window.movableByWindowBackground = YES;
+    // 设置view扩展到标题栏
+    window.styleMask |= NSWindowStyleMaskFullSizeContentView; // MAC_10_10及以上版本支持
 
     m_bNativeSystemBtn = true;
 
-    ButtonPasser * passer = [[ButtonPasser alloc] init];
+    ButtonPasser *passer = [[ButtonPasser alloc] init];
     passer.window = this;
-    //重载全屏按钮的行为
-    //override the action of fullscreen button
+    // 重载全屏按钮的行为
+    // override the action of fullscreen button
     NSButton *zoomButton = [window standardWindowButton:NSWindowZoomButton];
     [zoomButton setTarget:passer];
     [zoomButton setAction:@selector(zoomButtonAction:)];
@@ -129,23 +140,30 @@ void CFramelessWindow::initUI()
     // Currently, doesn't work
     NSButton *closeButton = [window standardWindowButton:NSWindowCloseButton];
     NSButton *minimizeButton = [window standardWindowButton:NSWindowMiniaturizeButton];
-    closeButton.frame = NSMakeRect(closeButton.frame.origin.x + 10, closeButton.frame.origin.y, closeButton.frame.size.width, closeButton.frame.size.height);
-    minimizeButton.frame = NSMakeRect(minimizeButton.frame.origin.x + 10, minimizeButton.frame.origin.y, minimizeButton.frame.size.width, minimizeButton.frame.size.height);
-    zoomButton.frame = NSMakeRect(zoomButton.frame.origin.x + 10, zoomButton.frame.origin.y, zoomButton.frame.size.width, zoomButton.frame.size.height);
+    closeButton.frame = NSMakeRect(closeButton.frame.origin.x + 10, closeButton.frame.origin.y,
+                                   closeButton.frame.size.width, closeButton.frame.size.height);
+    minimizeButton.frame =
+            NSMakeRect(minimizeButton.frame.origin.x + 10, minimizeButton.frame.origin.y,
+                       minimizeButton.frame.size.width, minimizeButton.frame.size.height);
+    zoomButton.frame = NSMakeRect(zoomButton.frame.origin.x + 10, zoomButton.frame.origin.y,
+                                  zoomButton.frame.size.width, zoomButton.frame.size.height);
 }
 
 void CFramelessWindow::setCloseBtnQuit(bool bQuit)
 {
-    if (bQuit || !m_bNativeSystemBtn) return;
-    NSView* view = (NSView*)winId();
-    if (0 == view) return;
+    if (bQuit || !m_bNativeSystemBtn)
+        return;
+    NSView *view = (NSView *)winId();
+    if (0 == view)
+        return;
     NSWindow *window = view.window;
-    if (0 == window) return;
+    if (0 == window)
+        return;
 
-    //重载关闭按钮的行为
-    //override the action of close button
-    //https://stackoverflow.com/questions/27643659/setting-c-function-as-selector-for-nsbutton-produces-no-results
-    //https://developer.apple.com/library/content/documentation/General/Conceptual/CocoaEncyclopedia/Target-Action/Target-Action.html
+    // 重载关闭按钮的行为
+    // override the action of close button
+    // https://stackoverflow.com/questions/27643659/setting-c-function-as-selector-for-nsbutton-produces-no-results
+    // https://developer.apple.com/library/content/documentation/General/Conceptual/CocoaEncyclopedia/Target-Action/Target-Action.html
     NSButton *closeButton = [window standardWindowButton:NSWindowCloseButton];
     [closeButton setTarget:[ButtonPasser class]];
     [closeButton setAction:@selector(closeButtonAction:)];
@@ -153,55 +171,65 @@ void CFramelessWindow::setCloseBtnQuit(bool bQuit)
 
 void CFramelessWindow::setCloseBtnEnabled(bool bEnable)
 {
-    if (!m_bNativeSystemBtn) return;
-    NSView* view = (NSView*)winId();
-    if (0 == view) return;
+    if (!m_bNativeSystemBtn)
+        return;
+    NSView *view = (NSView *)winId();
+    if (0 == view)
+        return;
     NSWindow *window = view.window;
-    if (0 == window) return;
+    if (0 == window)
+        return;
 
     m_bIsCloseBtnEnabled = bEnable;
-    if (bEnable){
+    if (bEnable) {
         [[window standardWindowButton:NSWindowCloseButton] setEnabled:YES];
-    }else{
+    } else {
         [[window standardWindowButton:NSWindowCloseButton] setEnabled:NO];
     }
 }
 
 void CFramelessWindow::setMinBtnEnabled(bool bEnable)
 {
-    if (!m_bNativeSystemBtn) return;
-    NSView* view = (NSView*)winId();
-    if (0 == view) return;
+    if (!m_bNativeSystemBtn)
+        return;
+    NSView *view = (NSView *)winId();
+    if (0 == view)
+        return;
     NSWindow *window = view.window;
-    if (0 == window) return;
+    if (0 == window)
+        return;
 
     m_bIsMinBtnEnabled = bEnable;
-    if (bEnable){
+    if (bEnable) {
         [[window standardWindowButton:NSWindowMiniaturizeButton] setEnabled:YES];
-    }else{
+    } else {
         [[window standardWindowButton:NSWindowMiniaturizeButton] setEnabled:NO];
     }
 }
 
 void CFramelessWindow::setZoomBtnEnabled(bool bEnable)
 {
-    if (!m_bNativeSystemBtn) return;
-    NSView* view = (NSView*)winId();
-    if (0 == view) return;
+    if (!m_bNativeSystemBtn)
+        return;
+    NSView *view = (NSView *)winId();
+    if (0 == view)
+        return;
     NSWindow *window = view.window;
-    if (0 == window) return;
+    if (0 == window)
+        return;
 
     m_bIsZoomBtnEnabled = bEnable;
-    if (bEnable){
+    if (bEnable) {
         [[window standardWindowButton:NSWindowZoomButton] setEnabled:YES];
-    }else{
+    } else {
         [[window standardWindowButton:NSWindowZoomButton] setEnabled:NO];
     }
 }
 
 void CFramelessWindow::setDraggableAreaHeight(int height)
 {
-    if (height < 0) height = 0;
+    if (height < 0)
+        height = 0;
     m_draggableHeight = height;
 }
 
@@ -221,16 +249,16 @@ void CFramelessWindow::showEvent(QShowEvent *event)
 
 void CFramelessWindow::mousePressEvent(QMouseEvent *event)
 {
-    if ((event->button() != Qt::LeftButton) || isMaximized() )
-    {
+    if ((event->button() != Qt::LeftButton) || isMaximized()) {
         return QMainWindow::mousePressEvent(event);
     }
 
     int height = size().height();
-    if (m_draggableHeight > 0) height = m_draggableHeight;
+    if (m_draggableHeight > 0)
+        height = m_draggableHeight;
     QRect rc;
-    rc.setRect(0,0,size().width(), height);
-    if(rc.contains(this->mapFromGlobal(QCursor::pos()))==true)//如果按下的位置
+    rc.setRect(0, 0, size().width(), height);
+    if (rc.contains(this->mapFromGlobal(QCursor::pos())) == true) // 如果按下的位置
     {
         m_WindowPos = this->pos();
         m_MousePos = event->globalPos();
@@ -242,8 +270,7 @@ void CFramelessWindow::mousePressEvent(QMouseEvent *event)
 void CFramelessWindow::mouseReleaseEvent(QMouseEvent *event)
 {
     m_bWinMoving = false;
-    if ((event->button() == Qt::LeftButton))
-    {
+    if ((event->button() == Qt::LeftButton)) {
         m_bMousePressed = false;
     }
     return QMainWindow::mouseReleaseEvent(event);
@@ -251,7 +278,8 @@ void CFramelessWindow::mouseReleaseEvent(QMouseEvent *event)
 
 void CFramelessWindow::mouseMoveEvent(QMouseEvent *event)
 {
-    if (!m_bMousePressed) return QMainWindow::mouseMoveEvent(event);
+    if (!m_bMousePressed)
+        return QMainWindow::mouseMoveEvent(event);
     m_bWinMoving = true;
     this->move(m_WindowPos + (event->globalPos() - m_MousePos));
     return QMainWindow::mouseMoveEvent(event);
@@ -260,11 +288,11 @@ void CFramelessWindow::mouseMoveEvent(QMouseEvent *event)
 void CFramelessWindow::resizeEvent(QResizeEvent *event)
 {
     QMainWindow::resizeEvent(event);
-    //TODO
-//    if (!isFullScreen())
-//    {
-//        emit restoreFromFullScreen();
-//    }
+    // TODO
+    //    if (!isFullScreen())
+    //    {
+    //        emit restoreFromFullScreen();
+    //    }
 }
 
 void CFramelessWindow::onRestoreFromFullScreen()
@@ -274,39 +302,45 @@ void CFramelessWindow::onRestoreFromFullScreen()
 
 void CFramelessWindow::setTitlebarVisible(bool bTitlebarVisible)
 {
-    if (!m_bNativeSystemBtn) return;
-    NSView* view = (NSView*)winId();
-    if (0 == view) return;
+    if (!m_bNativeSystemBtn)
+        return;
+    NSView *view = (NSView *)winId();
+    if (0 == view)
+        return;
     NSWindow *window = view.window;
-    if (0 == window) return;
+    if (0 == window)
+        return;
 
     m_bTitleBarVisible = bTitlebarVisible;
-    if (bTitlebarVisible)
-    {
-        window.styleMask ^= NSWindowStyleMaskFullSizeContentView; //MAC_10_10及以上版本支持
-    }else{
-        window.styleMask |= NSWindowStyleMaskFullSizeContentView; //MAC_10_10及以上版本支持
+    if (bTitlebarVisible) {
+        window.styleMask ^= NSWindowStyleMaskFullSizeContentView; // MAC_10_10及以上版本支持
+    } else {
+        window.styleMask |= NSWindowStyleMaskFullSizeContentView; // MAC_10_10及以上版本支持
     }
 }
 
 void CFramelessWindow::maximizeWindowMac()
 {
-    NSView* view = (NSView*)winId();
-    if (0 == view) return;
+    NSView *view = (NSView *)winId();
+    if (0 == view)
+        return;
     NSWindow *window = view.window;
-    if (0 == window) return;
+    if (0 == window)
+        return;
 
     [window zoom:window];
 }
 
 void CFramelessWindow::setWindowAlwaysOnTopMac(bool isAlwaysOnTop)
 {
-    NSView* view = (NSView*)winId();
-    if (0 == view) return;
+    NSView *view = (NSView *)winId();
+    if (0 == view)
+        return;
     NSWindow *window = view.window;
-    if (0 == window) return;
+    if (0 == window)
+        return;
 
-    if(isAlwaysOnTop)
+    if (isAlwaysOnTop)
         [window setLevel:NSFloatingWindowLevel];
     else
         [window setLevel:NSNormalWindowLevel];
@@ -314,10 +348,12 @@ void CFramelessWindow::setWindowAlwaysOnTopMac(bool isAlwaysOnTop)
 
 void CFramelessWindow::setStandardWindowButtonsMacVisibility(bool isVisible)
 {
-    NSView* view = (NSView*)winId();
-    if (0 == view) return;
+    NSView *view = (NSView *)winId();
+    if (0 == view)
+        return;
     NSWindow *window = view.window;
-    if (0 == window) return;
+    if (0 == window)
+        return;
 
     NSButton *closeButton = [window standardWindowButton:NSWindowCloseButton];
     NSButton *minimizeButton = [window standardWindowButton:NSWindowMiniaturizeButton];
@@ -327,4 +363,4 @@ void CFramelessWindow::setStandardWindowButtonsMacVisibility(bool isVisible)
     [zoomButton setHidden:!isVisible];
 }
 
-#endif //Q_OS_MAC
+#endif // Q_OS_MAC

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1280,8 +1280,10 @@ void MainWindow::restoreStates()
         m_splitter->restoreState(
                 m_settingsDatabase->value(QStringLiteral("splitterSizes")).toByteArray());
 
-    m_foldersWidget->setHidden(m_settingsDatabase->value(QStringLiteral("isTreeCollapsed")).toBool());
-    m_noteListWidget->setHidden(m_settingsDatabase->value(QStringLiteral("isNoteListCollapsed")).toBool());
+    m_foldersWidget->setHidden(
+            m_settingsDatabase->value(QStringLiteral("isTreeCollapsed")).toBool());
+    m_noteListWidget->setHidden(
+            m_settingsDatabase->value(QStringLiteral("isNoteListCollapsed")).toBool());
 
     m_splitter->setCollapsible(0, false);
     m_splitter->setCollapsible(1, false);
@@ -1613,7 +1615,8 @@ void MainWindow::onDotsButtonClicked()
     folderTreeVisibilityAction->setShortcutVisibleInContextMenu(true);
 #endif
     if (isFolderTreeCollapsed) {
-        connect(folderTreeVisibilityAction, &QAction::triggered, this, &MainWindow::expandFolderTree);
+        connect(folderTreeVisibilityAction, &QAction::triggered, this,
+                &MainWindow::expandFolderTree);
     } else {
         connect(folderTreeVisibilityAction, &QAction::triggered, this,
                 &MainWindow::collapseFolderTree);
@@ -1935,8 +1938,7 @@ void MainWindow::setTheme(Theme theme)
         m_currentEditorTextColor = QColor(95, 74, 50);
         m_currentEditorBackgroundColor = m_currentThemeBackgroundColor;
         m_currentRightFrameColor = m_currentThemeBackgroundColor;
-        setStyleSheet(
-                QStringLiteral("QMainWindow { background-color: rgb(251, 240, 217); }"));
+        setStyleSheet(QStringLiteral("QMainWindow { background-color: rgb(251, 240, 217); }"));
         ui->verticalSpacer_upSearchEdit->setStyleSheet(
                 QStringLiteral("QWidget{ background-color: %1;}")
                         .arg(m_currentThemeBackgroundColor.name()));
@@ -2226,7 +2228,8 @@ void MainWindow::QuitApplication()
     m_settingsDatabase->setValue(QStringLiteral("splitterSizes"), m_splitter->saveState());
 
     m_settingsDatabase->setValue(QStringLiteral("isTreeCollapsed"), m_foldersWidget->isHidden());
-    m_settingsDatabase->setValue(QStringLiteral("isNoteListCollapsed"), m_noteListWidget->isHidden());
+    m_settingsDatabase->setValue(QStringLiteral("isNoteListCollapsed"),
+                                 m_noteListWidget->isHidden());
 
     QString currentFontTypefaceString;
     switch (m_currentFontTypeface) {
@@ -2583,25 +2586,20 @@ void MainWindow::mousePressEvent(QMouseEvent *event)
             if ((m_mousePressX < width() && m_mousePressX > width() - m_layoutMargin)
                 && (m_mousePressY < m_layoutMargin && m_mousePressY > 0)) {
                 m_stretchSide = StretchSide::TopRight;
-            } else if ((m_mousePressX < width()
-                        && m_mousePressX > width() - m_layoutMargin)
-                       && (m_mousePressY < height()
-                           && m_mousePressY > height() - m_layoutMargin)) {
+            } else if ((m_mousePressX < width() && m_mousePressX > width() - m_layoutMargin)
+                       && (m_mousePressY < height() && m_mousePressY > height() - m_layoutMargin)) {
                 m_stretchSide = StretchSide::BottomRight;
             } else if ((m_mousePressX < m_layoutMargin && m_mousePressX > 0)
                        && (m_mousePressY < m_layoutMargin && m_mousePressY > 0)) {
                 m_stretchSide = StretchSide::TopLeft;
             } else if ((m_mousePressX < m_layoutMargin && m_mousePressX > 0)
-                       && (m_mousePressY < height()
-                           && m_mousePressY > height() - m_layoutMargin)) {
+                       && (m_mousePressY < height() && m_mousePressY > height() - m_layoutMargin)) {
                 m_stretchSide = StretchSide::BottomLeft;
-            } else if (m_mousePressX < width()
-                       && m_mousePressX > width() - m_layoutMargin) {
+            } else if (m_mousePressX < width() && m_mousePressX > width() - m_layoutMargin) {
                 m_stretchSide = StretchSide::Right;
             } else if (m_mousePressX < m_layoutMargin && m_mousePressX > 0) {
                 m_stretchSide = StretchSide::Left;
-            } else if (m_mousePressY < height()
-                       && m_mousePressY > height() - m_layoutMargin) {
+            } else if (m_mousePressY < height() && m_mousePressY > height() - m_layoutMargin) {
                 m_stretchSide = StretchSide::Bottom;
             } else if (m_mousePressY < m_layoutMargin && m_mousePressY > 0) {
                 m_stretchSide = StretchSide::Top;
@@ -2639,23 +2637,19 @@ void MainWindow::mouseMoveEvent(QMouseEvent *event)
             && (m_mousePressY < m_layoutMargin && m_mousePressY > 0)) {
             m_stretchSide = StretchSide::TopRight;
         } else if ((m_mousePressX < width() && m_mousePressX > width() - m_layoutMargin)
-                   && (m_mousePressY < height()
-                       && m_mousePressY > height() - m_layoutMargin)) {
+                   && (m_mousePressY < height() && m_mousePressY > height() - m_layoutMargin)) {
             m_stretchSide = StretchSide::BottomRight;
         } else if ((m_mousePressX < m_layoutMargin && m_mousePressX > 0)
                    && (m_mousePressY < m_layoutMargin && m_mousePressY > 0)) {
             m_stretchSide = StretchSide::TopLeft;
         } else if ((m_mousePressX < m_layoutMargin && m_mousePressX > 0)
-                   && (m_mousePressY < height()
-                       && m_mousePressY > height() - m_layoutMargin)) {
+                   && (m_mousePressY < height() && m_mousePressY > height() - m_layoutMargin)) {
             m_stretchSide = StretchSide::BottomLeft;
-        } else if (m_mousePressX < width()
-                   && m_mousePressX > width() - m_layoutMargin) {
+        } else if (m_mousePressX < width() && m_mousePressX > width() - m_layoutMargin) {
             m_stretchSide = StretchSide::Right;
         } else if (m_mousePressX < m_layoutMargin && m_mousePressX > 0) {
             m_stretchSide = StretchSide::Left;
-        } else if (m_mousePressY < height()
-                   && m_mousePressY > height() - m_layoutMargin) {
+        } else if (m_mousePressY < height() && m_mousePressY > height() - m_layoutMargin) {
             m_stretchSide = StretchSide::Bottom;
         } else if (m_mousePressY < m_layoutMargin && m_mousePressY > 0) {
             m_stretchSide = StretchSide::Top;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -51,11 +51,11 @@ class TagPool;
 class SplitterStyle;
 
 #if defined(Q_OS_WINDOWS) || defined(Q_OS_WIN)
-//#if defined(__MINGW32__) || defined(__GNUC__)
+// #if defined(__MINGW32__) || defined(__GNUC__)
 using MainWindowBase = QMainWindow;
-//#else
-// using MainWindowBase = CFramelessWindow;
-//#endif
+// #else
+//  using MainWindowBase = CFramelessWindow;
+// #endif
 #elif defined(Q_OS_MACOS)
 using MainWindowBase = CFramelessWindow;
 #else


### PR DESCRIPTION
Right now it only does two things:

- Run `clang-format` on first-party sources (and returns an error if it finds any unformatted file)
- Run `cmake-format` on `CMakeLists.txt` (and returns an error if the file is not properly formatted)

In the future, we can use this workflow to add more helpful tools, like `clang-tidy`, to help us keep the code base consistent.

Ah, I obviously had to format all files in `src/`, otherwise the CI would fail. :)