### PR TITLE
Fixed X11 linking on BSD systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -320,7 +320,8 @@ elseif(UNIX)
   string(TOLOWER ${PROJECT_NAME} BINARY_NAME)
   set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME ${BINARY_NAME})
 
-  target_link_libraries(${PROJECT_NAME} PUBLIC X11)
+  find_package(X11 REQUIRED)
+  target_link_libraries(${PROJECT_NAME} PUBLIC ${X11_LIBRARIES})
 
   include(GNUInstallDirs)
 


### PR DESCRIPTION
According to [this comment](https://github.com/nuttyartist/notes/commit/ff2735f0a7b3fd0ec9f7db4f4c974633a4a06a47#r103979026), the current linking of the X11 libraries in CMakeLists.txt will not work for systems like FreeBSD who install third-party libraries in a location diffrent than the default library paths. 

This PR aims to fix this issue by using find_package first.