### PR TITLE
Make windows use native window decorations by default

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1243,8 +1243,14 @@ void MainWindow::setupModelView()
  */
 void MainWindow::restoreStates()
 {
+#if defined(Q_OS_WIN)
+    bool nativeByDefault = true;
+#else
+    bool nativeByDefault = false;
+#endif
     setUseNativeWindowFrame(
-            m_settingsDatabase->value(QStringLiteral("useNativeWindowFrame"), false).toBool());
+            m_settingsDatabase->value(QStringLiteral("useNativeWindowFrame"), nativeByDefault)
+                    .toBool());
 
     setHideToTray(m_settingsDatabase->value(QStringLiteral("hideToTray"), true).toBool());
     if (m_hideToTray) {


### PR DESCRIPTION
Users have reported (#521) that it would be better if Windows used native window decorations by default. This PR sets that.

(not tested yet but I assume this small change works fine)

Closes #525