### PR TITLE
Bump Qt from 6.3.2 to 6.4.3

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -263,7 +263,7 @@ jobs:
           - os: ubuntu-20.04
             container: ubuntu:20.04
             build-type: release
-            qt-version: 6.3.2
+            qt-version: 6.4.3
     steps:
       - name: Install git PPA in docker container
         # A more recent version of git is required by the checkout action: https://github.com/actions/checkout/issues/758

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -81,7 +81,7 @@ jobs:
             build-type: release
 
           - os: macos-11
-            qt-version: 6.3.2
+            qt-version: 6.4.3
             build-type: release
     steps:
       - name: Checkout code

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -29,7 +29,7 @@ jobs:
 
           - os: windows-2019
             arch: x64
-            qt-version: 6.3.2
+            qt-version: 6.4.3
             build-type: release
     outputs:
       version: ${{ steps.vars.outputs.version }}


### PR DESCRIPTION
There have been a lot of bug fixes between these two versions, and not a single regression! *wink wink*

Besides 6.3 not getting any more updates, [6.5](https://wiki.qt.io/Qt_6.5_Release#Qt_6.5_release_plan) is just around the corner, so I think it makes sense to update to 6.4.3 now, and then let 6.5 mature for a bit, right?