### PR TITLE
Added alt+up/down shortcut to move current line

### DIFF
--- a/docs/keyboard_shortcuts.md
+++ b/docs/keyboard_shortcuts.md
@@ -40,6 +40,8 @@ These shortcuts are meant to be used while the Notes window is currently focused
 | <kbd>Ctrl</kbd> + <kbd>B</kbd>                        | Wrap current word or selection into \*\* \*\* **(bold)**      |
 | <kbd>Ctrl</kbd> + <kbd>I</kbd>                        | Wrap current word or selection into \* \* *(italic)*          |
 | <kbd>Ctrl</kbd> + <kbd>S</kbd>                        | Wrap current word or selection into \~ \~ ~~(strikethrough)~~ |
+| <kbd>Alt</kbd>  + <kbd>Up</kbd> 						| Move current block up                                         |
+| <kbd>Alt</kbd>  + <kbd>Down</kbd> 					| Move current block down                                       |
 | <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>-</kbd>     | Decrease heading size                                         |
 | <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>=</kbd>     | Increase heading size                                         |
 | <kbd>Ctrl</kbd> + (<kbd>1</kbd> through <kbd>6</kbd>) | Set a specific heading size                                   |

--- a/src/customDocument.h
+++ b/src/customDocument.h
@@ -18,6 +18,8 @@ public:
     void openUrl(const QString &urlString);
     QMap<QString, QString> parseMarkdownUrlsFromText(const QString &text);
     QUrl getUrlUnderMouse();
+    void moveBlockUp();
+    void moveBlockDown();
 signals:
     void resized();
 


### PR DESCRIPTION
This is something I've been meaning to add for a while, and it seems to work so far:

https://user-images.githubusercontent.com/4633209/229840697-82738395-0e3d-4f69-a398-99ca82f4af67.mp4

Basically, pressing alt + arrow up or down will move the current line up/down one line. It's especially useful when moving things around in a list of items. I use this feature a lot in VSCode, which is why I wanted to implement it here as well.

What do you guys think? Is this something useful for Notes? The implementation is kind of ugly but I don't see a better way to implement it, as the editor is kind of limited. 
