### PR TITLE
Aesthetic changes, improve dark mode

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -327,6 +327,10 @@ void MainWindow::setupMainWindow()
     ui->listviewLabel1->setStyleSheet(m_styleSheet);
     ui->listviewLabel2->setStyleSheet(m_styleSheet);
 
+    // splitters
+    ui->verticalSplitterLine_left->setStyleSheet(m_styleSheet);
+    ui->verticalSplitterLine_middle->setStyleSheet(m_styleSheet);
+
     // buttons
     ui->toggleTreeViewButton->setStyleSheet(m_styleSheet);
     ui->styleEditorButton->setStyleSheet(m_styleSheet);
@@ -1806,6 +1810,8 @@ void MainWindow::setTheme(Theme theme)
     setCSSThemeAndUpdate(ui->styleEditorButton, theme);
     setCSSThemeAndUpdate(ui->listviewLabel1, theme);
     setCSSThemeAndUpdate(ui->searchEdit, theme);
+    setCSSThemeAndUpdate(ui->verticalSplitterLine_left, theme);
+    setCSSThemeAndUpdate(ui->verticalSplitterLine_middle, theme);
     setCSSThemeAndUpdate(ui->frameRight, m_currentTheme);
     setCSSThemeAndUpdate(ui->frameRightTop, m_currentTheme);
 
@@ -1815,7 +1821,7 @@ void MainWindow::setTheme(Theme theme)
         break;
     }
     case Theme::Dark: {
-        m_currentEditorTextColor = QColor(204, 204, 204);
+        m_currentEditorTextColor = QColor(212, 212, 212);
         break;
     }
     case Theme::Sepia: {

--- a/src/nodetreedelegate.cpp
+++ b/src/nodetreedelegate.cpp
@@ -29,10 +29,14 @@ NodeTreeDelegate::NodeTreeDelegate(QTreeView *view, QObject *parent)
       m_titleFont(m_displayFont, 13, QFont::DemiBold),
       m_titleSelectedFont(m_displayFont, 13),
       m_dateFont(m_displayFont, 13),
+      m_separatorFont(m_displayFont, 12, QFont::Normal),
+      m_numberOfNotesFont(m_displayFont, 12, QFont::DemiBold),
 #else
       m_titleFont(m_displayFont, 10, QFont::DemiBold),
       m_titleSelectedFont(m_displayFont, 10),
       m_dateFont(m_displayFont, 10),
+      m_separatorFont(m_displayFont, 9, QFont::Normal),
+      m_numberOfNotesFont(m_displayFont, 9, QFont::DemiBold),
 #endif
       m_titleColor(26, 26, 26),
       m_titleSelectedColor(255, 255, 255),
@@ -45,6 +49,8 @@ NodeTreeDelegate::NodeTreeDelegate(QTreeView *view, QObject *parent)
       m_defaultColor(247, 247, 247),
       m_separatorTextColor(143, 143, 143),
       m_currentBackgroundColor(255, 255, 255),
+      m_numberOfNotesColor(26, 26, 26, 127),
+      m_numberOfNotesSelectedColor(255, 255, 255),
       m_view(view),
       m_theme(Theme::Light)
 {
@@ -62,16 +68,18 @@ void NodeTreeDelegate::setTheme(Theme theme)
         m_notActiveColor = QColor(175, 212, 228);
         m_hoverColor = QColor(207, 207, 207);
         m_currentBackgroundColor = QColor(247, 247, 247);
+        m_numberOfNotesColor = QColor(26, 26, 26, 127);
         break;
     }
     case Theme::Dark: {
-        m_titleColor = QColor(204, 204, 204);
-        m_dateColor = QColor(204, 204, 204);
-        m_defaultColor = QColor(30, 30, 30);
+        m_titleColor = QColor(212, 212, 212);
+        m_dateColor = QColor(212, 212, 212);
+        m_defaultColor = QColor(25, 25, 25);
         //        m_ActiveColor = QColor(0, 59, 148);
-        m_notActiveColor = QColor(0, 59, 148);
+        m_notActiveColor = QColor(35, 52, 69);
         m_hoverColor = QColor(15, 45, 90);
-        m_currentBackgroundColor = QColor(30, 30, 30);
+        m_currentBackgroundColor = QColor(25, 25, 25);
+        m_numberOfNotesColor = QColor(212, 212, 212, 127);
         break;
     }
     case Theme::Sepia: {
@@ -82,6 +90,7 @@ void NodeTreeDelegate::setTheme(Theme theme)
         m_notActiveColor = QColor(175, 212, 228);
         m_hoverColor = QColor(207, 207, 207);
         m_currentBackgroundColor = QColor(251, 240, 217);
+        m_numberOfNotesColor = QColor(26, 26, 26, 127);
         break;
     }
     }
@@ -129,11 +138,11 @@ void NodeTreeDelegate::paint(QPainter *painter, const QStyleOptionViewItem &opti
         childCountRect.setWidth(childCountRect.width() - 5);
         auto childCount = index.data(NodeItem::Roles::ChildCount).toInt();
         if ((option.state & QStyle::State_Selected) == QStyle::State_Selected) {
-            painter->setPen(m_titleSelectedColor);
+            painter->setPen(m_numberOfNotesSelectedColor);
         } else {
-            painter->setPen(m_titleColor);
+            painter->setPen(m_numberOfNotesColor);
         }
-        painter->setFont(m_titleFont);
+        painter->setFont(m_numberOfNotesFont);
         painter->drawText(childCountRect, Qt::AlignHCenter | Qt::AlignVCenter,
                           QString::number(childCount));
         break;
@@ -144,7 +153,7 @@ void NodeTreeDelegate::paint(QPainter *painter, const QStyleOptionViewItem &opti
         textRect.moveLeft(textRect.x() + 5);
         auto displayName = index.data(NodeItem::Roles::DisplayText).toString();
         painter->setPen(m_separatorColor);
-        painter->setFont(m_titleFont);
+        painter->setFont(m_separatorFont);
         painter->drawText(textRect, Qt::AlignLeft | Qt::AlignVCenter, displayName);
         break;
     }
@@ -187,11 +196,11 @@ void NodeTreeDelegate::paint(QPainter *painter, const QStyleOptionViewItem &opti
         childCountRect.setWidth(childCountRect.width() - 5);
         auto childCount = index.data(NodeItem::Roles::ChildCount).toInt();
         if ((option.state & QStyle::State_Selected) == QStyle::State_Selected) {
-            painter->setPen(m_titleSelectedColor);
+            painter->setPen(m_numberOfNotesSelectedColor);
         } else {
-            painter->setPen(m_titleColor);
+            painter->setPen(m_numberOfNotesColor);
         }
-        painter->setFont(m_titleFont);
+        painter->setFont(m_numberOfNotesFont);
         painter->drawText(childCountRect, Qt::AlignHCenter | Qt::AlignVCenter,
                           QString::number(childCount));
         break;
@@ -224,7 +233,7 @@ void NodeTreeDelegate::paint(QPainter *painter, const QStyleOptionViewItem &opti
         painter->setBrush(Qt::black);
         painter->setPen(Qt::black);
         QRect nameRect(option.rect);
-        nameRect.setLeft(iconRect.x() + iconRect.width() + 5);
+        nameRect.setLeft(iconRect.x() + iconRect.width() + 11);
         nameRect.setWidth(nameRect.width() - 5 - 40);
         auto displayName = index.data(NodeItem::Roles::DisplayText).toString();
         QFontMetrics fm(m_titleFont);
@@ -241,11 +250,11 @@ void NodeTreeDelegate::paint(QPainter *painter, const QStyleOptionViewItem &opti
         childCountRect.setWidth(childCountRect.width() - 5);
         auto childCount = index.data(NodeItem::Roles::ChildCount).toInt();
         if ((option.state & QStyle::State_Selected) == QStyle::State_Selected) {
-            painter->setPen(m_titleSelectedColor);
+            painter->setPen(m_numberOfNotesSelectedColor);
         } else {
-            painter->setPen(m_titleColor);
+            painter->setPen(m_numberOfNotesColor);
         }
-        painter->setFont(m_titleFont);
+        painter->setFont(m_numberOfNotesFont);
         painter->drawText(childCountRect, Qt::AlignHCenter | Qt::AlignVCenter,
                           QString::number(childCount));
         break;
@@ -307,7 +316,7 @@ QWidget *NodeTreeDelegate::createEditor(QWidget *parent, const QStyleOptionViewI
                                      .arg(QString::number(m_separatorTextColor.red()),
                                           QString::number(m_separatorTextColor.green()),
                                           QString::number(m_separatorTextColor.blue())));
-        label->setFont(m_titleFont);
+        label->setFont(m_separatorFont);
         label->setText(displayName);
         layout->addWidget(label);
         auto addButton = new PushButtonType(parent);

--- a/src/nodetreedelegate.h
+++ b/src/nodetreedelegate.h
@@ -36,6 +36,8 @@ private:
     QFont m_titleFont;
     QFont m_titleSelectedFont;
     QFont m_dateFont;
+    QFont m_separatorFont;
+    QFont m_numberOfNotesFont;
     QColor m_titleColor;
     QColor m_titleSelectedColor;
     QColor m_dateColor;
@@ -47,6 +49,8 @@ private:
     QColor m_defaultColor;
     QColor m_separatorTextColor;
     QColor m_currentBackgroundColor;
+    QColor m_numberOfNotesColor;
+    QColor m_numberOfNotesSelectedColor;
     QTreeView *m_view;
     Theme m_theme;
 };

--- a/src/noteeditorlogic.cpp
+++ b/src/noteeditorlogic.cpp
@@ -331,7 +331,7 @@ void NoteEditorLogic::setTheme(Theme theme, QColor textColor, qreal fontSize)
         break;
     }
     case Theme::Dark: {
-        m_spacerColor = QColor(204, 204, 204);
+        m_spacerColor = QColor(212, 212, 212);
         break;
     }
     case Theme::Sepia: {

--- a/src/notelistdelegate.cpp
+++ b/src/notelistdelegate.cpp
@@ -236,7 +236,11 @@ QSize NoteListDelegate::sizeHint(const QStyleOptionViewItem &option, const QMode
     }
 
     int yOffsets = secondYOffset + thirdYOffset + fourthYOffset + fifthYOffset;
-    result.setHeight(result.height() - 10 + NoteListConstant::lastElSepSpace + yOffsets);
+    if (m_isInAllNotes) {
+        result.setHeight(result.height() - 2 + NoteListConstant::lastElSepSpace + yOffsets);
+    } else {
+        result.setHeight(result.height() - 10 + NoteListConstant::lastElSepSpace + yOffsets);
+    }
     return result;
 }
 
@@ -304,7 +308,11 @@ QSize NoteListDelegate::bufferSizeHint(const QStyleOptionViewItem &option,
     //    }
 
     int yOffsets = secondYOffset + thirdYOffset + fourthYOffset; // + fifthYOffset;
-    result.setHeight(result.height() - 10 + NoteListConstant::lastElSepSpace + yOffsets);
+    if (m_isInAllNotes) {
+        result.setHeight(result.height() - 2 + NoteListConstant::lastElSepSpace + yOffsets);
+    } else {
+        result.setHeight(result.height() - 10 + NoteListConstant::lastElSepSpace + yOffsets);
+    }
     return result;
 }
 
@@ -776,7 +784,7 @@ void NoteListDelegate::paintSeparator(QPainter *painter, QRect rect, const QMode
 {
     Q_UNUSED(index);
     painter->setPen(QPen(m_separatorColor));
-    const int leftOffsetX = 11;
+    const int leftOffsetX = NoteListConstant::leftOffsetX;
     int posX1 = rect.x() + leftOffsetX;
     int posX2 = rect.x() + rect.width() - leftOffsetX - 1;
     int posY = rect.y() + rect.height() - 1;
@@ -998,31 +1006,37 @@ void NoteListDelegate::setTheme(Theme theme)
     case Theme::Light: {
         m_titleColor = QColor(26, 26, 26);
         m_dateColor = QColor(26, 26, 26);
+        m_contentColor = QColor(142, 146, 150);
         m_defaultColor = QColor(247, 247, 247);
         m_ActiveColor = QColor(218, 233, 239);
         m_notActiveColor = QColor(175, 212, 228);
         m_hoverColor = QColor(207, 207, 207);
         m_applicationInactiveColor = QColor(207, 207, 207);
+        m_separatorColor = QColor(191, 191, 191);
         break;
     }
     case Theme::Dark: {
-        m_titleColor = QColor(204, 204, 204);
-        m_dateColor = QColor(204, 204, 204);
-        m_defaultColor = QColor(30, 30, 30);
-        m_ActiveColor = QColor(0, 59, 148);
-        m_notActiveColor = QColor(0, 59, 148);
-        m_hoverColor = QColor(15, 45, 90);
-        m_applicationInactiveColor = QColor(15, 45, 90);
+        m_titleColor = QColor(255, 255, 255);
+        m_dateColor = QColor(255, 255, 255);
+        m_contentColor = QColor(255, 255, 255, 127);
+        m_defaultColor = QColor(25, 25, 25);
+        m_ActiveColor = QColor(35, 52, 69, 127);
+        m_notActiveColor = QColor(35, 52, 69);
+        m_hoverColor = QColor(35, 52, 69, 127);
+        m_applicationInactiveColor = QColor(35, 52, 69);
+        m_separatorColor = QColor(255, 255, 255, 127);
         break;
     }
     case Theme::Sepia: {
         m_titleColor = QColor(26, 26, 26);
         m_dateColor = QColor(26, 26, 26);
+        m_contentColor = QColor(142, 146, 150);
         m_defaultColor = QColor(251, 240, 217);
         m_ActiveColor = QColor(218, 233, 239);
         m_notActiveColor = QColor(175, 212, 228);
         m_hoverColor = QColor(207, 207, 207);
         m_applicationInactiveColor = QColor(207, 207, 207);
+        m_separatorColor = QColor(191, 191, 191);
         break;
     }
     }

--- a/src/notelistdelegateeditor.cpp
+++ b/src/notelistdelegateeditor.cpp
@@ -389,7 +389,7 @@ void NoteListDelegateEditor::paintSeparator(QPainter *painter, const QStyleOptio
     Q_UNUSED(option);
 
     painter->setPen(QPen(m_separatorColor));
-    const int leftOffsetX = 11;
+    const int leftOffsetX = NoteListConstant::leftOffsetX;
     int posX1 = rect().x() + leftOffsetX;
     int posX2 = rect().x() + rect().width() - leftOffsetX - 1;
     int posY = rect().y() + rect().height() - 1;
@@ -470,7 +470,8 @@ void NoteListDelegateEditor::resizeEvent(QResizeEvent *event)
 
             y += yOffsets;
         }
-        m_tagListView->setGeometry(10, y - 5, rect().width() - 15, m_tagListView->height());
+        m_tagListView->setGeometry(NoteListConstant::leftOffsetX - 5, y + 5, rect().width() - 15,
+                                   m_tagListView->height());
     } else {
         int y = 70;
         auto model = dynamic_cast<NoteListModel *>(m_view->model());
@@ -493,7 +494,8 @@ void NoteListDelegateEditor::resizeEvent(QResizeEvent *event)
 
             y += yOffsets;
         }
-        m_tagListView->setGeometry(10, y - 5, rect().width() - 15, m_tagListView->height());
+        m_tagListView->setGeometry(NoteListConstant::leftOffsetX - 5, y, rect().width() - 15,
+                                   m_tagListView->height());
     }
     recalculateSize();
 }
@@ -592,7 +594,11 @@ void NoteListDelegateEditor::recalculateSize()
         }
 
         int yOffsets = secondYOffset + thirdYOffset + fourthYOffset + fifthYOffset;
-        result.setHeight(result.height() - 10 + NoteListConstant::lastElSepSpace + yOffsets);
+        if (m_delegate->isInAllNotes()) {
+            result.setHeight(result.height() - 2 + NoteListConstant::lastElSepSpace + yOffsets);
+        } else {
+            result.setHeight(result.height() - 10 + NoteListConstant::lastElSepSpace + yOffsets);
+        }
         emit updateSizeHint(m_id, result, m_index);
     }
 }
@@ -624,16 +630,18 @@ void NoteListDelegateEditor::setTheme(Theme theme)
         m_notActiveColor = QColor(175, 212, 228);
         m_hoverColor = QColor(207, 207, 207);
         m_applicationInactiveColor = QColor(207, 207, 207);
+        m_separatorColor = QColor(191, 191, 191);
         break;
     }
     case Theme::Dark: {
-        m_titleColor = QColor(204, 204, 204);
-        m_dateColor = QColor(204, 204, 204);
-        m_defaultColor = QColor(30, 30, 30);
-        m_ActiveColor = QColor(0, 59, 148);
-        m_notActiveColor = QColor(0, 59, 148);
-        m_hoverColor = QColor(15, 45, 90);
-        m_applicationInactiveColor = QColor(15, 45, 90);
+        m_titleColor = QColor(212, 212, 212);
+        m_dateColor = QColor(212, 212, 212);
+        m_defaultColor = QColor(25, 25, 25);
+        m_ActiveColor = QColor(35, 52, 69, 127);
+        m_notActiveColor = QColor(35, 52, 69);
+        m_hoverColor = QColor(35, 52, 69);
+        m_applicationInactiveColor = QColor(35, 52, 69);
+        m_separatorColor = QColor(255, 255, 255, 127);
         break;
     }
     case Theme::Sepia: {
@@ -644,6 +652,7 @@ void NoteListDelegateEditor::setTheme(Theme theme)
         m_notActiveColor = QColor(175, 212, 228);
         m_hoverColor = QColor(207, 207, 207);
         m_applicationInactiveColor = QColor(207, 207, 207);
+        m_separatorColor = QColor(191, 191, 191);
         break;
     }
     }

--- a/src/notelistdelegateeditor.h
+++ b/src/notelistdelegateeditor.h
@@ -12,12 +12,12 @@ class TagListDelegate;
 class NoteListModel;
 struct NoteListConstant
 {
-    static constexpr int leftOffsetX = 10;
-    static constexpr int topOffsetY = 5; // space on top of title
-    static constexpr int titleDateSpace = 1; // space between title and date
-    static constexpr int dateDescSpace = 4; // space between date and description
-    static constexpr int descFolderSpace = 9; // space between description and folder name
-    static constexpr int lastElSepSpace = 10; // space between the last element and the separator
+    static constexpr int leftOffsetX = 20;
+    static constexpr int topOffsetY = 10; // space on top of title
+    static constexpr int titleDateSpace = 2; // space between title and date
+    static constexpr int dateDescSpace = 5; // space between date and description
+    static constexpr int descFolderSpace = 14; // space between description and folder name
+    static constexpr int lastElSepSpace = 12; // space between the last element and the separator
     static constexpr int nextNoteOffset =
             0; // space between the separator and the next note underneath it
     static constexpr int pinnedHeaderToNoteSpace =

--- a/src/styles/about-window.css
+++ b/src/styles/about-window.css
@@ -1,15 +1,14 @@
 QTextBrowser#aboutText.light {
-    background-color: rgb(247, 247, 247);
-    color: rgb(26, 26, 26);
+  background-color: rgb(247, 247, 247);
+  color: rgb(26, 26, 26);
 }
 
 QTextBrowser#aboutText.dark {
-    background-color: rgb(30, 30, 30);
-    color: rgb(204, 204, 204);
+  background-color: rgb(25, 25, 25);
+  color: rgb(212, 212, 212);
 }
 
 QTextBrowser#aboutText.sepia {
-    background-color: rgb(251, 240, 217);
-    color: rgb(26, 26, 26);
+  background-color: rgb(251, 240, 217);
+  color: rgb(26, 26, 26);
 }
-

--- a/src/styles/main-window.css
+++ b/src/styles/main-window.css
@@ -139,7 +139,7 @@ QFrame#verticalSplitterLine_middle.light {
 QMainWindow.dark,
 QFrame#verticalSplitterLine_left.dark,
 QFrame#verticalSplitterLine_middle.dark {
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid rgb(68, 68, 68);
 }
 QMainWindow.sepia,
 QFrame#verticalSplitterLine_left.sepia,

--- a/src/styles/main-window.css
+++ b/src/styles/main-window.css
@@ -6,7 +6,7 @@ QFrame#frameRightTop.light,
 QFrame#frameRight.light,
 QListView#tagListView.light,
 QTextEdit#textEdit.light {
-	background-color: rgb(247, 247, 247);
+  background-color: rgb(247, 247, 247);
 }
 
 QMainWindow.dark,
@@ -17,7 +17,7 @@ QFrame#frameRightTop.dark,
 QFrame#frameRight.dark,
 QListView#tagListView.dark,
 QTextEdit#textEdit.dark {
-	background-color: rgb(30, 30, 30);
+  background-color: rgb(25, 25, 25);
 }
 
 QMainWindow.sepia,
@@ -28,88 +28,88 @@ QFrame#frameRightTop.sepia,
 QFrame#frameRight.sepia,
 QListView#tagListView.sepia,
 QTextEdit#textEdit.sepia {
-	background-color: rgb(251, 240, 217);
+  background-color: rgb(251, 240, 217);
 }
 
 QFrame#frameRight,
 QFrame#frameRightTop {
-	border: none;
+  border: none;
 }
 
 /* Main editor */
 QTextEdit#textEdit {
-	selection-background-color: rgb(63, 99, 139);
+  selection-background-color: rgb(63, 99, 139);
 }
 
 QTextEdit#textEdit.light {
-	color: rgb(26, 26, 26);
+  color: rgb(26, 26, 26);
 }
 
 QTextEdit#textEdit.dark {
-	color: rgb(204, 204, 204);
+  color: rgb(212, 212, 212);
 }
 
 QTextEdit#textEdit.sepia {
-	color: rgb(95, 74, 50);
+  color: rgb(95, 74, 50);
 }
 
 /* Label showing the name of the selected folder */
 QLabel#listviewLabel1.light {
-	color: rgb(26, 26, 26);
+  color: rgb(26, 26, 26);
 }
 
 QLabel#listviewLabel1.dark {
-	color: rgb(204, 204, 204);
+  color: rgb(212, 212, 212);
 }
 
 QLabel#listviewLabel1.sepia {
-	color: rgb(26, 26, 26);
+  color: rgb(26, 26, 26);
 }
 
 /* Label showing the amount of notes in the selected folder/tags */
 QLabel#listviewLabel2 {
-	color: rgb(132, 132, 132);
+  color: rgb(132, 132, 132);
 }
 
 /* Aa Style Editor  Button */
 QPushButton#styleEditorButton {
-	color: rgb(68, 138, 201);
+  color: rgb(68, 138, 201);
 }
 
 QPushButton#styleEditorButton:hover {
-	color: rgb(51, 110, 162);
+  color: rgb(51, 110, 162);
 }
 
 QPushButton#styleEditorButton:pressed {
-	color: rgb(39, 85, 125);
+  color: rgb(39, 85, 125);
 }
 
 /* Search bar */
 QLineEdit#searchEdit {
-	padding-left: 21px;
-	padding-right: 19px;
-	border: 1px solid rgb(205, 205, 205);
-	border-radius: 3px;
-	selection-background-color: rgb(61, 155, 218);
+  padding-left: 21px;
+  padding-right: 19px;
+  border: 1px solid rgb(205, 205, 205);
+  border-radius: 3px;
+  selection-background-color: rgb(61, 155, 218);
 }
 
 QLineEdit#searchEdit.light {
-	background-color: rgb(247, 247, 247);
-	color: rgb(26, 26, 26);
+  background-color: rgb(247, 247, 247);
+  color: rgb(26, 26, 26);
 }
 
 QLineEdit#searchEdit.dark {
-	background-color: rgb(30, 30, 30);
-	color: rgb(204, 204, 204);
+  background-color: rgb(25, 25, 25);
+  color: rgb(212, 212, 212);
 }
 
 QLineEdit#searchEdit.sepia {
-	background-color: rgb(251, 240, 217);
-	color: rgb(95, 74, 50);
+  background-color: rgb(251, 240, 217);
+  color: rgb(95, 74, 50);
 }
 
 QLineEdit#searchEdit:focus {
-	border: 2px solid rgb(61, 155, 218);
+  border: 2px solid rgb(61, 155, 218);
 }
 
 /* Buttons */
@@ -125,23 +125,34 @@ QPushButton#dotsButton,
 QPushButton#toggleTreeViewButton,
 /* The Aa button to open the style editor */
 QPushButton#styleEditorButton {
-	border: none;
-	padding: 0px;
-	outline: none;
+  border: none;
+  padding: 0px;
+  outline: none;
 }
 
 /* The two vertical lines that seperate 3 MainWindow frames */
-QFrame#verticalSplitterLine_left,
-QFrame#verticalSplitterLine_middle {
-	border: 1px solid rgb(191, 191, 191);
+QMainWindow.light,
+QFrame#verticalSplitterLine_left.light,
+QFrame#verticalSplitterLine_middle.light {
+  border: 1px solid rgb(191, 191, 191);
+}
+QMainWindow.dark,
+QFrame#verticalSplitterLine_left.dark,
+QFrame#verticalSplitterLine_middle.dark {
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+QMainWindow.sepia,
+QFrame#verticalSplitterLine_left.sepia,
+QFrame#verticalSplitterLine_middle.sepia {
+  border: 1px solid rgb(191, 191, 191);
 }
 
 /* Main menu */
 QMenu.menu {
-	background-color: rgb(255, 255, 255);
-	border: 1px solid #C7C7C7;
+  background-color: rgb(255, 255, 255);
+  border: 1px solid #c7c7c7;
 }
 
 QMenu::item:selected {
-	background: 1px solid rgb(48, 140, 198);
+  background: 1px solid rgb(48, 140, 198);
 }

--- a/src/styles/nodetreeview.css
+++ b/src/styles/nodetreeview.css
@@ -1,24 +1,24 @@
 QTreeView {
-	border-style: none;
+  border-style: none;
 
-	selection-color: white;
+  selection-color: white;
 }
 
 QTreeView.light {
-	background-color: rgb(247, 247, 247);
-	selection-background-color: rgb(247, 247, 247);
+  background-color: rgb(247, 247, 247);
+  selection-background-color: rgb(247, 247, 247);
 }
 
 QTreeView.dark {
-	background-color: rgb(30, 30, 30);
-	selection-background-color: rgb(30, 30, 30);
+  background-color: rgb(25, 25, 25);
+  selection-background-color: rgb(25, 25, 25);
 }
 
 QTreeView.sepia {
-	background-color: rgb(251, 240, 217);
-	selection-background-color: rgb(251, 240, 217);
+  background-color: rgb(251, 240, 217);
+  selection-background-color: rgb(251, 240, 217);
 }
 
 QTreeView::branch {
-	border-image: url(none.png);
+  border-image: url(none.png);
 }

--- a/src/styles/notelistview.css
+++ b/src/styles/notelistview.css
@@ -1,13 +1,11 @@
 QListView.light {
-	background-color: rgb(247, 247, 247);
+  background-color: rgb(247, 247, 247);
 }
 
 QListView.dark {
-	background-color: rgb(30, 30, 30);
+  background-color: rgb(25, 25, 25);
 }
 
 QListView.sepia {
-	background-color: rgb(251, 240, 217);
+  background-color: rgb(251, 240, 217);
 }
-
-

--- a/src/styles/style-editor-window.css
+++ b/src/styles/style-editor-window.css
@@ -1,46 +1,46 @@
 StyleEditorWindow QPushButton {
-	padding: 0px;
-	border: none;
+  padding: 0px;
+  border: none;
 }
 
 StyleEditorWindow QPushButton.light {
-	background-color: rgb(247, 247, 247);
-	color: rgb(26, 26, 26);
+  background-color: rgb(247, 247, 247);
+  color: rgb(26, 26, 26);
 }
 
 StyleEditorWindow QPushButton.light:hover:!pressed {
-	background-color: rgb(207, 207, 207);
+  background-color: rgb(207, 207, 207);
 }
 
 StyleEditorWindow QPushButton.light:pressed,
 StyleEditorWindow QPushButton.light.selected {
-	background-color: rgb(218, 233, 239);
+  background-color: rgb(218, 233, 239);
 }
 
 StyleEditorWindow QPushButton.dark {
-	background-color: rgb(30, 30, 30);
-	color: rgb(204, 204, 204);
+  background-color: rgb(25, 25, 25);
+  color: rgb(212, 212, 212);
 }
 
 StyleEditorWindow QPushButton.dark:hover:!pressed {
-	background-color: rgb(43, 43, 43);
+  background-color: rgb(43, 43, 43);
 }
 
 StyleEditorWindow QPushButton.dark:pressed,
 StyleEditorWindow QPushButton.dark.selected {
-	background-color: rgb(0, 59, 148);
+  background-color: rgb(0, 59, 148);
 }
 
 StyleEditorWindow QPushButton.sepia {
-	background-color: rgb(251, 240, 217);
-	color: rgb(26, 26, 26);
+  background-color: rgb(251, 240, 217);
+  color: rgb(26, 26, 26);
 }
 
 StyleEditorWindow QPushButton.sepia:hover:!pressed {
-	background-color: rgb(207, 207, 207);
+  background-color: rgb(207, 207, 207);
 }
 
 StyleEditorWindow QPushButton.sepia:pressed,
 StyleEditorWindow QPushButton.sepia.selected {
-	background-color: rgb(218, 233, 239);
+  background-color: rgb(218, 233, 239);
 }

--- a/src/styles/taglistview.css
+++ b/src/styles/taglistview.css
@@ -1,15 +1,15 @@
 QListView#tagListView {
-	border: none;
+  border: none;
 }
 
 QListView#tagListView.light {
-	background: rgb(247, 247, 247);
+  background: rgb(247, 247, 247);
 }
 
 QListView#tagListView.dark {
-	background: rgb(30, 30, 30);
+  background: rgb(25, 25, 25);
 }
 
 QListView#tagListView.sepia {
-	background: rgb(251, 240, 217);
+  background: rgb(251, 240, 217);
 }

--- a/src/taglistdelegate.cpp
+++ b/src/taglistdelegate.cpp
@@ -75,7 +75,7 @@ void TagListDelegate::setTheme(Theme theme)
         break;
     }
     case Theme::Dark: {
-        m_titleColor = QColor(204, 204, 204);
+        m_titleColor = QColor(212, 212, 212);
         break;
     }
     case Theme::Sepia: {


### PR DESCRIPTION
This PR create more "white space" in the app, makes it look slicker and clearer.

Changed:

- Dark background color from rgb(30,30,30) to rgb(25,25,25)
- Text color in dark mode from rgb(204,204,204) to rgb(212,212,212)
- Number of notes in folders pane to be half the alpha of m_titleColor
- Note highlighter color to rgb(35, 52, 69)
- Change the weight and size of 
`"Folders" and  "Tags"`
`"Pinned" and "Notes`
- Spacing between tag's color and text
- Separators colors - less strong in dark mode
- Spacing in notesList - more whitespace.

Before:

![Screen Shot 2023-05-16 at 7 57 14 PM](https://github.com/nuttyartist/notes/assets/16375940/67056395-4ce9-40ee-9663-2a8b1f0f96a2)

After:

![Screen Shot 2023-05-16 at 7 57 38 PM](https://github.com/nuttyartist/notes/assets/16375940/89ce90e0-62b7-4634-af72-f0efc56f3c85)

Let me know what you think, and if you have any suggestions.

