### PR TITLE
CI: Unify build jobs with reusable workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  format-lint:
+    name: Code Linting
+    uses: ./.github/workflows/format-lint.yml
+
+  linux:
+    name: Linux
+    needs:
+      - format-lint
+    uses: ./.github/workflows/linux.yml
+
+  macos:
+    name: macOS
+    needs:
+      - format-lint
+    uses: ./.github/workflows/macos.yml
+
+  windows:
+    name: Windows
+    needs:
+      - format-lint
+    uses: ./.github/workflows/windows.yml

--- a/.github/workflows/format-lint.yml
+++ b/.github/workflows/format-lint.yml
@@ -1,10 +1,7 @@
 name: Code Linting
 
 on:
-  push:
-    branches:
-      - master
-  pull_request:
+  workflow_call:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,10 +1,7 @@
 name: Linux
 
 on:
-  push:
-    branches:
-      - master
-  pull_request:
+  workflow_call:
   workflow_dispatch:
 
 env:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,10 +1,7 @@
 name: macOS
 
 on:
-  push:
-    branches:
-      - master
-  pull_request:
+  workflow_call:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,10 +1,7 @@
 name: Windows
 
 on:
-  push:
-    branches:
-      - master
-  pull_request:
+  workflow_call:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Instead of having individual workflow runs for every git operation, we can instead make them ['reusable'](https://docs.github.com/en/actions/using-workflows/reusing-workflows) and then bundle all of them into a single, central workflow (which we will call `CI`).

Having them unified into a single workflow like that has several advantages:

- Build jobs will only run if the `Code Linting` workflow passes first: Previously, build jobs would run in parallel with the linting workflow, which is probably undesired.

- Build artifacts for every OS will be all in the same job.

- This makes release automation much easier, which I intend to do next.

Finally, if for some reason we want to run a specific workflow individually (instead of running of all them), I've kept the [`workflow_dispatch` option](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow) in each workflow, so we can always dispatch them manually.