### PR TITLE
Fix launching with Adwaita theme by removing unpolish() call when changing theme

### DIFF
--- a/src/theme.cpp
+++ b/src/theme.cpp
@@ -41,7 +41,6 @@ void setCSSClassesAndUpdate(QWidget *obj, std::string classNames)
     // set the class
     obj->setProperty("class", classNames.c_str());
     // update the widget
-    obj->style()->unpolish(obj);
     obj->style()->polish(obj);
     obj->update();
 }


### PR DESCRIPTION
Solution found by @guihkx. 

Haven't noticed any issues when removing this line. I don't yet know why many examples online always call unpolish first. 

