### PR TITLE
Linux: Fix Wayland window associations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,7 +267,7 @@ endif()
 
 target_compile_definitions(
   ${PROJECT_NAME}
-  PUBLIC APP_VERSION="${PROJECT_VERSION}${GIT_REV}"
+  PUBLIC APP_VERSION="${PROJECT_VERSION}${GIT_REV}" APP_ID="${APP_ID}"
          QT_DISABLE_DEPRECATED_BEFORE=0x050900 QSU_INCLUDE_MOC=1)
 
 # Enable useful compiler warnings (except on third-party code).

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,6 +16,10 @@ int main(int argc, char *argv[])
     app.setApplicationName("Notes");
     app.setApplicationVersion(APP_VERSION);
 
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
+    app.setDesktopFileName(QString(APP_ID) + ".desktop");
+#endif
+
 #if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0) && QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     app.setAttribute(Qt::AA_DisableWindowContextHelpButton);
 #endif


### PR DESCRIPTION
Wayland compositors use the desktopFileName window property to associate native Wayland windows with their .desktop launcher.

This was previously set to "notes" when qt launched as a native Wayland window (the default in Wayland sessions), which could cause various inconsistencies.

Notably, KDE Plasma would display the generic Wayland icon in task view for Notes instead of the icon referenced in the .desktop file.

Fix this by propagating the APP_ID property (which is used to name the .desktop file during packaging) to main.cpp so that we can call setDesktopFileName with it.

After this change KDE Plasma correctly displays the Notes icon in task view.

Before:
![image](https://github.com/nuttyartist/notes/assets/4309817/6c7b6424-0f67-4da9-8d98-07ba50d80fca)

After:
![image](https://github.com/nuttyartist/notes/assets/4309817/68cf9a4a-b2fd-4bb0-9504-4727483eb700)
