### PR TITLE
Linux: Set app id without `.desktop` suffix

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,7 +17,7 @@ int main(int argc, char *argv[])
     app.setApplicationVersion(APP_VERSION);
 
 #if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
-    app.setDesktopFileName(QString(APP_ID) + ".desktop");
+    app.setDesktopFileName(APP_ID);
 #endif
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0) && QT_VERSION < QT_VERSION_CHECK(6, 0, 0)


### PR DESCRIPTION
Silences this startup warning given by Qt 6.5.2:

`QGuiApplication::setDesktopFileName: the specified desktop file name
ends with .desktop. For compatibility reasons, the .desktop suffix will
be removed. Please specify a desktop file name without .desktop suffix`

Here's the rationale, according to a Qt dev:

>The desktop file name should not contain ".desktop" suffix, but some applications still specify it anyway because of the ambiguity in the documentation that was fixed in [0c5135a9dfa6140d23d86b001c3054891c22dcb9](https://codereview.qt-project.org/c/qt/qtbase/+/477797).

Source: https://codereview.qt-project.org/c/qt/qtbase/+/480688