### PR TITLE
CI: Replace Ubuntu 22.10 by 23.04

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -16,6 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Ubuntu's release cycle: https://wiki.ubuntu.com/Releases
           - os: ubuntu-20.04
             qt-version-major: 5
             build-type: release
@@ -25,7 +26,7 @@ jobs:
             build-type: release
 
           - os: ubuntu-20.04
-            container: ubuntu:22.10
+            container: ubuntu:23.04
             qt-version-major: 6
             build-type: release
     steps:

--- a/packaging/linux/debian/changelog.in
+++ b/packaging/linux/debian/changelog.in
@@ -4,6 +4,22 @@
 
  -- @APP_AUTHOR@ <@APP_AUTHOR_EMAIL@>  @DATE_NOW_UTC@
 
+@PROJECT_NAME_LOWERCASE@ (2.2.0) stable; urgency=low
+
+  * You can now turn your Markdown tasks into a beautiful Kanban board
+  * Completely redesigned Editor Settings popup to quickly change the editor's settings
+  * New gear icon for global app settings
+  * Much improved Dark theme colors
+  * Text contrast in Sepia theme is improved
+  * Added alt+up/down keyboard shortcut to move the current line
+  * Toggling fullscreen is now possible with F11 & Esc
+  * Fixed markdown fonts not being resized properly
+  * Native window decoration is now default on Windows and Linux
+  * Fixed X11 linking on BSD systems
+  * Many more fixes and improvements under the hood
+
+ -- @APP_AUTHOR@ <@APP_AUTHOR_EMAIL@>  Thu, 27 Jul 2023 12:09:49 +0000
+
 @PROJECT_NAME_LOWERCASE@ (2.1.0) stable; urgency=low
 
   * You can now open external links by holding Ctrl while clicking them


### PR DESCRIPTION
Ubuntu 22.10 (Kinetic Kudu) [has reached end-of-life](https://wiki.ubuntu.com/Releases) in July 2023, so let's replace it by Ubuntu 23.04 (Lunar Lobster), which will be supported by Canonical until January 2024.