### PR TITLE
Fixed loading of custom font icons

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,8 @@ set(SOURCES
     ${PROJECT_SOURCE_DIR}/src/elidedlabel.h
     ${PROJECT_SOURCE_DIR}/src/foldertreedelegateeditor.cpp
     ${PROJECT_SOURCE_DIR}/src/foldertreedelegateeditor.h
+    ${PROJECT_SOURCE_DIR}/src/fontloader.cpp
+    ${PROJECT_SOURCE_DIR}/src/fontloader.h
     ${PROJECT_SOURCE_DIR}/src/labeledittype.cpp
     ${PROJECT_SOURCE_DIR}/src/labeledittype.h
     ${PROJECT_SOURCE_DIR}/src/listviewlogic.cpp

--- a/src/allnotebuttontreedelegateeditor.cpp
+++ b/src/allnotebuttontreedelegateeditor.cpp
@@ -6,6 +6,7 @@
 #include "nodetreeview.h"
 #include "notelistview.h"
 #include "editorsettingsoptions.h"
+#include "fontloader.h"
 
 AllNoteButtonTreeDelegateEditor::AllNoteButtonTreeDelegateEditor(QTreeView *view,
                                                                  const QStyleOptionViewItem &option,
@@ -75,7 +76,8 @@ void AllNoteButtonTreeDelegateEditor::paintEvent(QPaintEvent *event)
 #else
     int iconPointSizeOffset = -4;
 #endif
-    painter.setFont(QFont("Material Symbols Outlined", 16 + iconPointSizeOffset));
+    painter.setFont(FontLoader::getInstance().loadFont("Material Symbols Outlined", "",
+                                                       16 + iconPointSizeOffset));
     painter.drawText(iconRect, iconPath); // folder
 
     if (m_view->selectionModel()->isSelected(m_index)) {

--- a/src/defaultnotefolderdelegateeditor.cpp
+++ b/src/defaultnotefolderdelegateeditor.cpp
@@ -5,6 +5,7 @@
 #include "nodetreemodel.h"
 #include "notelistview.h"
 #include "editorsettingsoptions.h"
+#include "fontloader.h"
 
 DefaultNoteFolderDelegateEditor::DefaultNoteFolderDelegateEditor(QTreeView *view,
                                                                  const QStyleOptionViewItem &option,
@@ -74,7 +75,8 @@ void DefaultNoteFolderDelegateEditor::paintEvent(QPaintEvent *event)
 #else
     int iconPointSizeOffset = -4;
 #endif
-    painter.setFont(QFont("Material Symbols Outlined", 16 + iconPointSizeOffset));
+    painter.setFont(FontLoader::getInstance().loadFont("Material Symbols Outlined", "",
+                                                       16 + iconPointSizeOffset));
     painter.drawText(folderIconRect, u8"\ue2c7"); // folder
 
     QRect nameRect(rect());

--- a/src/foldertreedelegateeditor.cpp
+++ b/src/foldertreedelegateeditor.cpp
@@ -10,6 +10,7 @@
 #include "nodetreeview.h"
 #include "notelistview.h"
 #include "labeledittype.h"
+#include "fontloader.h"
 
 FolderTreeDelegateEditor::FolderTreeDelegateEditor(QTreeView *view,
                                                    const QStyleOptionViewItem &option,
@@ -62,7 +63,8 @@ FolderTreeDelegateEditor::FolderTreeDelegateEditor(QTreeView *view,
 #else
     int iconPointSizeOffset = -4;
 #endif
-    m_expandIcon->setFont(QFont("Font Awesome 6 Free Solid", 10 + iconPointSizeOffset));
+    m_expandIcon->setFont(FontLoader::getInstance().loadFont("Font Awesome 6 Free Solid", "",
+                                                             10 + iconPointSizeOffset));
 
     m_expandIcon->setScaledContents(true);
     layout->addWidget(m_expandIcon);
@@ -136,7 +138,8 @@ FolderTreeDelegateEditor::FolderTreeDelegateEditor(QTreeView *view,
 #else
     int pointSizeOffset = -4;
 #endif
-    m_contextButton->setFont(QFont("Font Awesome 6 Free Solid", 14 + pointSizeOffset));
+    m_contextButton->setFont(FontLoader::getInstance().loadFont("Font Awesome 6 Free Solid", "",
+                                                                14 + pointSizeOffset));
     m_contextButton->setText(u8"\uf141"); // fa-ellipsis-h
 
     connect(m_contextButton, &QPushButton::clicked, m_view, [this](bool) {

--- a/src/fontloader.cpp
+++ b/src/fontloader.cpp
@@ -1,0 +1,14 @@
+#include "fontloader.h"
+
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+FontLoader::FontLoader() : m_fontDatabase() { }
+#endif
+
+QFont FontLoader::loadFont(const QString &family, const QString &style, int pointSize)
+{
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    return m_fontDatabase.font(family, style, pointSize);
+#else
+    return QFontDatabase::font(family, style, pointSize);
+#endif
+}

--- a/src/fontloader.h
+++ b/src/fontloader.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <QFont>
+#include <QString>
+#include <QFontDatabase>
+
+class FontLoader
+{
+public:
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    QFontDatabase m_fontDatabase;
+    FontLoader();
+#else
+    FontLoader() = default;
+#endif
+
+    ~FontLoader() = default;
+
+    static FontLoader &getInstance()
+    {
+        static FontLoader instance;
+        return instance;
+    }
+
+    QFont loadFont(const QString &family, const QString &style, int pointSize);
+};

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -13,6 +13,7 @@
 #include "tagpool.h"
 #include "splitterstyle.h"
 #include "editorsettingsoptions.h"
+#include "fontloader.h"
 
 #include <QScrollBar>
 #include <QShortcut>
@@ -683,8 +684,9 @@ void MainWindow::setupButtons()
     m_yellowMinimizeButton->installEventFilter(this);
     m_greenMaximizeButton->installEventFilter(this);
 
-    QFont fontAwesomeIcon("Font Awesome 6 Free Solid");
-    QFont materialSymbols("Material Symbols Outlined");
+    QFont fontAwesomeIcon = FontLoader::getInstance().loadFont("Font Awesome 6 Free Solid", "", 16);
+    QFont materialSymbols = FontLoader::getInstance().loadFont("Material Symbols Outlined", "", 30);
+
 #if defined(Q_OS_MACOS)
     int pointSizeOffset = 0;
 #else

--- a/src/nodetreedelegate.cpp
+++ b/src/nodetreedelegate.cpp
@@ -13,6 +13,7 @@
 #include "defaultnotefolderdelegateeditor.h"
 #include "allnotebuttontreedelegateeditor.h"
 #include <QFontMetrics>
+#include "fontloader.h"
 
 NodeTreeDelegate::NodeTreeDelegate(QTreeView *view, QObject *parent, QListView *listView)
     : QStyledItemDelegate{ parent },
@@ -130,21 +131,25 @@ void NodeTreeDelegate::paint(QPainter *painter, const QStyleOptionViewItem &opti
         }
         if (m_theme == Theme::Dark) {
             if (itemType == NodeItem::Type::AllNoteButton) {
-                painter->setFont(QFont("Material Symbols Outlined", 16 + iconPointSizeOffset));
+                painter->setFont(FontLoader::getInstance().loadFont("Material Symbols Outlined", "",
+                                                                    16 + iconPointSizeOffset));
                 painter->drawText(iconRect, u8"\ue2c7"); // folder
             } else if (itemType == NodeItem::Type::TrashButton) {
                 iconRect.setY(iconRect.y() + 2);
-                painter->setFont(QFont("Font Awesome 6 Free Solid", 16 + iconPointSizeOffset));
+                painter->setFont(FontLoader::getInstance().loadFont("Font Awesome 6 Free Solid", "",
+                                                                    16 + iconPointSizeOffset));
                 painter->drawText(iconRect, u8"\uf1f8"); // fa-trash
             }
         } else {
             auto iconPath = index.data(NodeItem::Roles::Icon).toString();
             if (itemType == NodeItem::Type::AllNoteButton) {
-                painter->setFont(QFont("Material Symbols Outlined", 16 + iconPointSizeOffset));
+                painter->setFont(FontLoader::getInstance().loadFont("Material Symbols Outlined", "",
+                                                                    16 + iconPointSizeOffset));
                 painter->drawText(iconRect, iconPath); // folder
             } else if (itemType == NodeItem::Type::TrashButton) {
                 iconRect.setY(iconRect.y() + 2);
-                painter->setFont(QFont("Font Awesome 6 Free Solid", 16 + iconPointSizeOffset));
+                painter->setFont(FontLoader::getInstance().loadFont("Font Awesome 6 Free Solid", "",
+                                                                    16 + iconPointSizeOffset));
                 painter->drawText(iconRect, iconPath); // fa-trash
             }
         }
@@ -190,7 +195,8 @@ void NodeTreeDelegate::paint(QPainter *painter, const QStyleOptionViewItem &opti
         auto iconRect = QRect(option.rect.x() + 10,
                               option.rect.y() + (option.rect.height() - 12) / 2, 12, 12);
         QString iconPath;
-        painter->setFont(QFont("Font Awesome 6 Free Solid", 10 + iconPointSizeOffset));
+        painter->setFont(FontLoader::getInstance().loadFont("Font Awesome 6 Free Solid", "",
+                                                            10 + iconPointSizeOffset));
         if (m_theme == Theme::Dark) {
             painter->setPen(QColor(169, 160, 172));
             if ((option.state & QStyle::State_Open) == QStyle::State_Open) {
@@ -221,7 +227,8 @@ void NodeTreeDelegate::paint(QPainter *painter, const QStyleOptionViewItem &opti
         } else {
             painter->setPen(m_folderIconColor);
         }
-        painter->setFont(QFont("Material Symbols Outlined", 16 + iconPointSizeOffset));
+        painter->setFont(FontLoader::getInstance().loadFont("Material Symbols Outlined", "",
+                                                            16 + iconPointSizeOffset));
         painter->drawText(folderIconRect, u8"\ue2c7"); // folder
 
         QRect nameRect(option.rect);
@@ -274,7 +281,8 @@ void NodeTreeDelegate::paint(QPainter *painter, const QStyleOptionViewItem &opti
                               option.rect.y() + (option.rect.height() - 14) / 2, 16, 16);
         auto tagColor = index.data(NodeItem::Roles::TagColor).toString();
         painter->setPen(QColor(tagColor));
-        painter->setFont(QFont("Font Awesome 6 Free Solid", 16 + iconPointSizeOffset));
+        painter->setFont(FontLoader::getInstance().loadFont("Font Awesome 6 Free Solid", "",
+                                                            16 + iconPointSizeOffset));
         painter->drawText(iconRect, u8"\uf111"); // fa-circle
         painter->setBrush(Qt::black);
         painter->setPen(Qt::black);
@@ -375,7 +383,8 @@ QWidget *NodeTreeDelegate::createEditor(QWidget *parent, const QStyleOptionViewI
 #else
         int iconPointSizeOffset = -4;
 #endif
-        addButton->setFont(QFont("Font Awesome 6 Free Solid", 16 + iconPointSizeOffset));
+        addButton->setFont(FontLoader::getInstance().loadFont("Font Awesome 6 Free Solid", "",
+                                                              16 + iconPointSizeOffset));
         addButton->setText(u8"\uf067"); // fa_plus
         addButton->setStyleSheet(QStringLiteral(R"(QPushButton { )"
                                                 R"(    border: none; )"

--- a/src/notelistdelegate.cpp
+++ b/src/notelistdelegate.cpp
@@ -3,7 +3,6 @@
 #include <QEvent>
 #include <QDebug>
 #include <QApplication>
-#include <QFontDatabase>
 #include <QtMath>
 #include <QPainterPath>
 #include "notelistmodel.h"
@@ -11,6 +10,7 @@
 #include "tagpool.h"
 #include "nodepath.h"
 #include "notelistdelegateeditor.h"
+#include "fontloader.h"
 
 NoteListDelegate::NoteListDelegate(NoteListView *view, TagPool *tagPool, QObject *parent)
     : QStyledItemDelegate(parent),
@@ -632,7 +632,8 @@ void NoteListDelegate::paintLabels(QPainter *painter, const QStyleOptionViewItem
 #else
                 int iconPointSizeOffset = -4;
 #endif
-                painter->setFont(QFont("Font Awesome 6 Free Solid", 14 + iconPointSizeOffset));
+                painter->setFont(FontLoader::getInstance().loadFont("Font Awesome 6 Free Solid", "",
+                                                                    14 + iconPointSizeOffset));
                 painter->setPen(QColor(68, 138, 201));
                 if (m_view->isPinnedNotesCollapsed()) {
                     painter->drawText(QRect(headerRect.right() - 25, headerRect.y() + 5, 16, 16),
@@ -691,7 +692,8 @@ void NoteListDelegate::paintLabels(QPainter *painter, const QStyleOptionViewItem
 #else
                 int iconPointSizeOffset = -4;
 #endif
-                painter->setFont(QFont("Font Awesome 6 Free Solid", 14 + iconPointSizeOffset));
+                painter->setFont(FontLoader::getInstance().loadFont("Font Awesome 6 Free Solid", "",
+                                                                    14 + iconPointSizeOffset));
                 painter->setPen(QColor(68, 138, 201));
                 if (m_view->isPinnedNotesCollapsed()) {
                     painter->drawText(QRect(headerRect.right() - 25, headerRect.y() + 5, 16, 16),
@@ -841,7 +843,8 @@ void NoteListDelegate::paintTagList(int top, QPainter *painter, const QStyleOpti
 #else
         int iconPointSizeOffset = -4;
 #endif
-        painter->setFont(QFont("Font Awesome 6 Free Solid", 14 + iconPointSizeOffset));
+        painter->setFont(FontLoader::getInstance().loadFont("Font Awesome 6 Free Solid", "",
+                                                            14 + iconPointSizeOffset));
         painter->drawText(iconRect, u8"\uf111"); // fa-circle
         painter->setBrush(m_titleColor);
         painter->setPen(m_titleColor);

--- a/src/notelistdelegateeditor.cpp
+++ b/src/notelistdelegateeditor.cpp
@@ -3,7 +3,6 @@
 #include <QEvent>
 #include <QDebug>
 #include <QApplication>
-#include <QFontDatabase>
 #include <QtMath>
 #include <QPainterPath>
 #include <QScrollBar>
@@ -17,6 +16,7 @@
 #include "taglistview.h"
 #include "taglistmodel.h"
 #include "taglistdelegate.h"
+#include "fontloader.h"
 
 NoteListDelegateEditor::NoteListDelegateEditor(const NoteListDelegate *delegate, NoteListView *view,
                                                const QStyleOptionViewItem &option,
@@ -290,7 +290,8 @@ void NoteListDelegateEditor::paintLabels(QPainter *painter, const QStyleOptionVi
 #else
             int iconPointSizeOffset = -4;
 #endif
-            painter->setFont(QFont("Font Awesome 6 Free Solid", 14 + iconPointSizeOffset));
+            painter->setFont(FontLoader::getInstance().loadFont("Font Awesome 6 Free Solid", "",
+                                                                14 + iconPointSizeOffset));
             painter->setPen(QColor(68, 138, 201));
             if (m_view->isPinnedNotesCollapsed()) {
                 painter->drawText(QRect(headerRect.right() - 25, headerRect.y() + 5, 16, 16),

--- a/src/notelistview.cpp
+++ b/src/notelistview.cpp
@@ -21,6 +21,7 @@
 #include "dbmanager.h"
 #include "notelistview_p.h"
 #include "notelistdelegateeditor.h"
+#include "fontloader.h"
 
 NoteListView::NoteListView(QWidget *parent)
     : QListView(parent),
@@ -720,7 +721,8 @@ void NoteListView::onCustomContextMenu(QPoint point)
 #else
                 int iconPointSizeOffset = -4;
 #endif
-                painter.setFont(QFont("Font Awesome 6 Free Solid", 24 + iconPointSizeOffset));
+                painter.setFont(FontLoader::getInstance().loadFont("Font Awesome 6 Free Solid", "",
+                                                                   24 + iconPointSizeOffset));
                 painter.drawText(iconRect, u8"\uf111"); // fa-circle
                 return QIcon{ pix };
             };

--- a/src/taglistdelegate.cpp
+++ b/src/taglistdelegate.cpp
@@ -2,6 +2,7 @@
 #include "taglistmodel.h"
 #include <QPainter>
 #include <QPainterPath>
+#include "fontloader.h"
 
 TagListDelegate::TagListDelegate(QObject *parent)
     : QStyledItemDelegate(parent),
@@ -48,7 +49,8 @@ void TagListDelegate::paint(QPainter *painter, const QStyleOptionViewItem &optio
 #else
     int iconPointSizeOffset = -4;
 #endif
-    painter->setFont(QFont("Font Awesome 6 Free Solid", 12 + iconPointSizeOffset));
+    painter->setFont(FontLoader::getInstance().loadFont("Font Awesome 6 Free Solid", "",
+                                                        12 + iconPointSizeOffset));
     painter->drawText(iconRect, u8"\uf111"); // fa-circle
     painter->setBrush(m_titleColor);
     painter->setPen(m_titleColor);

--- a/src/tagtreedelegateeditor.cpp
+++ b/src/tagtreedelegateeditor.cpp
@@ -10,6 +10,7 @@
 #include "nodetreeview.h"
 #include "labeledittype.h"
 #include "notelistview.h"
+#include "fontloader.h"
 
 TagTreeDelegateEditor::TagTreeDelegateEditor(QTreeView *view, const QStyleOptionViewItem &option,
                                              const QModelIndex &index, QListView *listView,
@@ -100,7 +101,8 @@ TagTreeDelegateEditor::TagTreeDelegateEditor(QTreeView *view, const QStyleOption
 #else
     int pointSizeOffset = -4;
 #endif
-    m_contextButton->setFont(QFont("Font Awesome 6 Free Solid", 14 + pointSizeOffset));
+    m_contextButton->setFont(FontLoader::getInstance().loadFont("Font Awesome 6 Free Solid", "",
+                                                                14 + pointSizeOffset));
     m_contextButton->setText(u8"\uf141"); // fa-ellipsis-h
 
     connect(m_contextButton, &QPushButton::clicked, m_view, [this](bool) {
@@ -163,7 +165,8 @@ void TagTreeDelegateEditor::paintEvent(QPaintEvent *event)
 #else
     int iconPointSizeOffset = -4;
 #endif
-    painter.setFont(QFont("Font Awesome 6 Free Solid", 16 + iconPointSizeOffset));
+    painter.setFont(FontLoader::getInstance().loadFont("Font Awesome 6 Free Solid", "",
+                                                       16 + iconPointSizeOffset));
     painter.drawText(iconRect, u8"\uf111"); // fa-circle
     QWidget::paintEvent(event);
 }

--- a/src/trashbuttondelegateeditor.cpp
+++ b/src/trashbuttondelegateeditor.cpp
@@ -5,6 +5,7 @@
 #include "nodetreemodel.h"
 #include "nodetreeview.h"
 #include "notelistview.h"
+#include "fontloader.h"
 
 TrashButtonDelegateEditor::TrashButtonDelegateEditor(QTreeView *view,
                                                      const QStyleOptionViewItem &option,
@@ -73,7 +74,8 @@ void TrashButtonDelegateEditor::paintEvent(QPaintEvent *event)
 #else
     int iconPointSizeOffset = -4;
 #endif
-    painter.setFont(QFont("Font Awesome 6 Free Solid", 16 + iconPointSizeOffset));
+    painter.setFont(FontLoader::getInstance().loadFont("Font Awesome 6 Free Solid", "",
+                                                       16 + iconPointSizeOffset));
     painter.drawText(iconRect, iconPath); // fa-trash
 
     if (m_view->selectionModel()->isSelected(m_index)) {


### PR DESCRIPTION
Fixes #620 

Apparently the QFont constructor doesn't load fonts from the application's database. We have to use `QFontDatabase::font`, which does load the fonts properly when `otf-font-awesome` is installed.

I replaced every occurence of QFont when loading our custom fonts, with the QFontDatabase::font constructor. 