### PR TITLE
Remove unused CI badges from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # Notes
 
 [![Discord](https://dcbadge.vercel.app/api/server/RP6ReXRn5j?style=flat)](https://discord.gg/RP6ReXRn5j)
-[![GitHub Actions status on Linux](https://github.com/nuttyartist/notes/actions/workflows/linux.yml/badge.svg?branch=master)](https://github.com/nuttyartist/notes/actions/workflows/linux.yml?query=branch%3Amaster)
-[![GitHub Actions status on macOS](https://github.com/nuttyartist/notes/actions/workflows/macos.yml/badge.svg?branch=master)](https://github.com/nuttyartist/notes/actions/workflows/macos.yml?query=branch%3Amaster)
-[![GitHub Actions status on Windows](https://github.com/nuttyartist/notes/actions/workflows/windows.yml/badge.svg?branch=master)](https://github.com/nuttyartist/notes/actions/workflows/windows.yml?query=branch%3Amaster)
+[![GitHub Actions build status](https://github.com/nuttyartist/notes/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/nuttyartist/notes/actions/workflows/ci.yml?query=branch%3Amaster)
 
 Notes is an open source and cross-platform note-taking app that is both beautiful and powerful.
 


### PR DESCRIPTION
It's been a while that we moved to a single GitHub Actions workflow.