### PR TITLE
Disable editing inside textEdit when trash folder is selected

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -630,12 +630,9 @@ void MainWindow::setupKeyboardShortcuts()
     connect(new QShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_K), this),
             &QShortcut::activated, this, [=]() {
                 if (m_kanbanWidget->isHidden()) {
-                    emit m_noteEditorLogic->showKanbanView();
-                    updateSelectedOptionsEditorSettings();
+                    setKanbanVisibility(true);
                 } else {
-                    emit m_noteEditorLogic->hideKanbanView();
-                    m_textEdit->setFocus();
-                    updateSelectedOptionsEditorSettings();
+                    setKanbanVisibility(false);
                 }
             });
 #endif
@@ -1686,7 +1683,8 @@ void MainWindow::setButtonsAndFieldsEnabled(bool doEnable)
  */
 void MainWindow::setKanbanVisibility(bool isVisible)
 {
-    if (isVisible) {
+    auto inf = m_listViewLogic->listViewInfo();
+    if (isVisible && inf.parentFolderId != SpecialNodeID::TrashFolder) {
         emit m_noteEditorLogic->showKanbanView();
     } else {
         emit m_noteEditorLogic->hideKanbanView();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3621,17 +3621,25 @@ bool MainWindow::eventFilter(QObject *object, QEvent *event)
 #endif
     case QEvent::FocusIn: {
         if (object == m_textEdit) {
+            auto inf = m_listViewLogic->listViewInfo();
             if (!m_isOperationRunning) {
                 if (m_listModel->rowCount() == 0) {
                     if (!m_searchEdit->text().isEmpty()) {
                         m_listViewLogic->clearSearch(true);
                     } else {
-                        createNewNote();
+                        if (inf.parentFolderId != SpecialNodeID::TrashFolder) {
+                            createNewNote();
+                        }
                     }
                 }
             }
             m_listView->setCurrentRowActive(true);
-            m_textEdit->setFocus();
+            if (inf.parentFolderId == SpecialNodeID::TrashFolder) {
+                m_textEdit->setReadOnly(true);
+            } else {
+                m_textEdit->setFocus();
+                m_textEdit->setReadOnly(false);
+            }
         }
         break;
     }

--- a/src/notelistview.cpp
+++ b/src/notelistview.cpp
@@ -852,7 +852,9 @@ void NoteListView::onCustomContextMenu(QPoint point)
             }
             contextMenu->addSeparator();
         }
-        contextMenu->addAction(newNoteAction);
+        if (!m_isInTrash) {
+            contextMenu->addAction(newNoteAction);
+        }
         contextMenu->exec(viewport()->mapToGlobal(point));
     }
 }


### PR DESCRIPTION
Following @rubenromani PR https://github.com/nuttyartist/notes/pull/588, I decided it's better to just disable editing when the trash folder is selected. It only makes sense that a user should restore his data before editing it. This fixes issue #537.