### PR TITLE
CI/macOS: Update to macOS 12 runner for Homebrew build jobs

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,11 +15,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-11
+          - os: macos-12
             qt-version-major: 5
             build-type: debug
 
-          - os: macos-11
+          - os: macos-12
             qt-version-major: 6
             build-type: debug
     steps:


### PR DESCRIPTION
macOS 11 isn't [officially supported by Homebrew](https://docs.brew.sh/Installation#macos-requirements) anymore, which means they have stopped distributing Qt binaries for that version.

This made some of our macOS jobs to timeout in the "Install Qt" step, because Qt was being built from source...

Please note that this change will not have any impact on macOS users, since we distribute official binaries from Qt, not from Homebrew.

Closes #654