### PR TITLE
Fix #652: option window doesnt work

### DIFF
--- a/src/qml/OptionItemButton.qml
+++ b/src/qml/OptionItemButton.qml
@@ -12,9 +12,9 @@ MouseArea {
     property bool isContainingMouse: optionItemMouseArea.containsMouse
     property bool checked: false
     property var themeData: {{thme: "Light"}}
-    property bool enabled: true
     property int pointSizeOffset: -4
 
+    enabled: true
     hoverEnabled: true
     width: innerRectangle.width
     height: innerRectangle.height


### PR DESCRIPTION
The issue was that `enabled` is a built-in QML property, and we were overwriting it. It seems that since 6.6, this overwriting actually causes an error, as opposed to previous versions. 

Fixed by not redefining the `enabled` property, but simply setting to `true` in the constructor.

Thanks to @dmytrovoytko for pointing us closer to the solution!

Tested and works on Qt 6.6.1
