### PR TITLE
CI/Linux: Update to Fedora 38

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -122,7 +122,7 @@ jobs:
         include:
           - os: ubuntu-20.04
             # Fedora's release cycle: https://docs.fedoraproject.org/en-US/releases/lifecycle/
-            container: fedora:37
+            container: fedora:38
             qt-version-major: 6
             build-type: release
 


### PR DESCRIPTION
Fedora 37 reached end-of-life in December 5th, 2023.

https://lists.fedoraproject.org/archives/list/devel-announce@lists.fedoraproject.org/thread/BOMYDF5U3FVAQSOGM6NZEZCTRBMQQJ56/