### PR TITLE
CI: Only download required build artifacts to make the Windows installer

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -96,7 +96,7 @@ jobs:
           lintian '${{ steps.deb.outputs.path }}'
 
       - name: Upload deb package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
           name: ${{ steps.deb.outputs.name }}-qt${{ matrix.qt-version-major }}-${{ steps.vars.outputs.distro_name }}-${{ matrix.build-type }}
@@ -199,7 +199,7 @@ jobs:
           rpmlint '${{ steps.rpm.outputs.path }}'
 
       - name: Upload rpm package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
           name: ${{ steps.rpm.outputs.name }}-qt${{ matrix.qt-version-major }}-${{ steps.vars.outputs.distro_name }}-${{ matrix.build-type }}
@@ -392,7 +392,7 @@ jobs:
           mv -v Notes*.AppImage '${{ steps.vars.outputs.file_name }}'
 
       - name: Upload AppImage artifact (${{ matrix.build-type }})
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
           name: ${{ steps.vars.outputs.artifact_name }}-${{ runner.os }}-${{ matrix.build-type }}
@@ -435,7 +435,7 @@ jobs:
           echo "path=${path}" >> "${GITHUB_OUTPUT}"
 
       - name: Upload snap package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
           name: ${{ steps.snap.outputs.name }}.snap

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -221,7 +221,7 @@ jobs:
           xcrun stapler staple 'build/${{ steps.vars.outputs.file_name }}'
 
       - name: Upload dmg artifact (${{ matrix.build-type }})
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
           name: ${{ steps.vars.outputs.artifact_name }}-${{ runner.os }}-${{ matrix.build-type }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -169,9 +169,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Download build artifacts from previous job
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
+          pattern: '*Windows*'
 
       - name: Ensure a 64-bit Qt 6 build is present
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -154,7 +154,7 @@ jobs:
           }
 
       - name: Upload artifacts (${{ matrix.build-type }}, ${{ matrix.arch }})
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
           name: ${{ steps.vars.outputs.artifact_name }}-${{ runner.os }}-${{ matrix.build-type }}
@@ -240,7 +240,7 @@ jobs:
           Write-Host "SUCCESS: List of files in the installer matches the ones copied by windeployqt."
 
       - name: Upload unified installer artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
           name: NotesSetup_${{ needs.build-aqtinstall.outputs.version }}-${{ runner.os }}-release


### PR DESCRIPTION
Our Windows CI has a separate build job with the sole purpose of creating an installer, by joining three different Windows builds:

- Qt5: x86 and x86_64
- Qt6: x86_64

To accomplish that, this job needs to download these build artifacts from previous jobs.

Until now, we would download all build artifacts, including ones from unrelated jobs such as Linux and macOS, which doesn't make sense, as it's wasteful and slow.

Thankfully, version [4.1.0](https://github.com/actions/download-artifact/releases/tag/v4.1.0) of `actions/download-artifact` now allows us to specify which artifacts to download, which is what this pull request does.