### PR TITLE
CI: Update actions to get rid of deprecation messages

### DIFF
--- a/.github/workflows/format-lint.yml
+++ b/.github/workflows/format-lint.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up cmake-format
         run: pip install cmakelang

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -59,7 +59,7 @@ jobs:
           echo "distro_name=${distro_id}-${distro_codename}" >> "${GITHUB_OUTPUT}"
 
       - name: Setup GCC problem matcher
-        uses: ammaraskar/gcc-problem-matcher@0.2.0
+        uses: ammaraskar/gcc-problem-matcher@0.3.0
 
       - name: Build (${{ matrix.build-type }})
         env:
@@ -148,7 +148,7 @@ jobs:
           echo "distro_name=${distro_id}-${version_id}" >> "${GITHUB_OUTPUT}"
 
       - name: Setup GCC problem matcher
-        uses: ammaraskar/gcc-problem-matcher@0.2.0
+        uses: ammaraskar/gcc-problem-matcher@0.3.0
 
       - name: Build (${{ matrix.build-type }})
         env:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -35,7 +35,7 @@ jobs:
         run: git config --global --add safe.directory "${PWD}"
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -124,7 +124,7 @@ jobs:
         run: git config --global --add safe.directory "${PWD}"
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -221,7 +221,7 @@ jobs:
             image: ubuntu-aqtinstall-6
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -352,7 +352,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -24,7 +24,7 @@ jobs:
             build-type: debug
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -83,7 +83,7 @@ jobs:
             build-type: release
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Setup CLang problem matcher
         # Technically, this action only supports GCC, but it seems to work well for Clang too.
         if: matrix.build-type == 'debug'
-        uses: ammaraskar/gcc-problem-matcher@0.2.0
+        uses: ammaraskar/gcc-problem-matcher@0.3.0
 
       - name: Build (${{ matrix.build-type }})
         env:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -73,7 +73,7 @@ jobs:
           Rename-Item $env:Temp\openssl-1.1 $env:Temp\OpenSSL
 
       - name: Setup MSVC problem matcher
-        uses: ammaraskar/msvc-problem-matcher@0.2.0
+        uses: ammaraskar/msvc-problem-matcher@0.3.0
 
       - name: Build (${{ matrix.build-type }}, ${{ matrix.arch }})
         env:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -32,7 +32,7 @@ jobs:
       version: ${{ steps.vars.outputs.version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -166,7 +166,7 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout code to grab the ISS script
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download build artifacts from previous job
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Basically, the previous versions of these actions were using Node 16, which is officially EOL and in process of deprecation by GitHub Actions:

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
