### PR TITLE
CI/macOS: Update to macOS 12

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -134,6 +134,7 @@ jobs:
           export CMAKE_BUILD_PARALLEL_LEVEL=$(sysctl -n hw.logicalcpu)
           cmake . --warn-uninitialized --warn-unused-vars \
               -B build -G Ninja \
+              -DCMAKE_OSX_DEPLOYMENT_TARGET=${{ startsWith(matrix.qt-version, '6.') && '11.0' || '10.15' }} \
               -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
               -DGIT_REVISION=${{ github.ref_type != 'tag' && 'ON' || 'OFF' }} \
               -DCMAKE_OSX_ARCHITECTURES="${{ env.TARGET_ARCH }}" \

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -33,6 +33,7 @@ jobs:
           brew install ninja qt@${{ matrix.qt-version-major }} 
 
       - name: Configure Qt ${{ matrix.qt-version-major }} (homebrew)
+        if: matrix.qt-version-major == 5
         run: |
           brew link qt@${{ matrix.qt-version-major }}
           cat << EOF

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -115,7 +115,7 @@ jobs:
           echo "file_name=${file_name}" >> "${GITHUB_OUTPUT}"
 
       - name: Install Qt ${{ matrix.qt-version }} (aqtinstall)
-        uses: jurplel/install-qt-action@v3
+        uses: jurplel/install-qt-action@v4
         with:
           version: ${{ matrix.qt-version }}
           cache: true

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -29,11 +29,7 @@ jobs:
           submodules: recursive
 
       - name: Install Qt ${{ matrix.qt-version-major }} (homebrew)
-        env:
-          # TODO: remove once https://github.com/actions/setup-python/issues/577 gets fixed.
-          HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
         run: |
-          brew update
           brew install ninja qt@${{ matrix.qt-version-major }} 
 
       - name: Configure Qt ${{ matrix.qt-version-major }} (homebrew)
@@ -125,7 +121,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          brew update
           brew install create-dmg ninja
 
       - name: Build (${{ matrix.build-type }})

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -71,11 +71,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-11
+          - os: macos-12
             qt-version: 5.15.2
             build-type: release
 
-          - os: macos-11
+          - os: macos-12
             qt-version: 6.5.2
             build-type: release
     steps:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -56,7 +56,7 @@ jobs:
           arch: ${{ matrix.arch }}
 
       - name: Install Qt ${{ matrix.qt-version }} (aqtinstall, ${{ matrix.arch }})
-        uses: jurplel/install-qt-action@v3
+        uses: jurplel/install-qt-action@v4
         with:
           version: ${{ matrix.qt-version }}
           cache: true


### PR DESCRIPTION
The macOS 11 runner was removed by GitHub Actions in June:

https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/

@nuttyartist Can you please check if the Qt 5 build still runs on macOS 10.15?