### PR TITLE
CI/Windows: Work around unset `VCToolsRedistDir` environment variable

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -135,6 +135,10 @@ jobs:
 
           # Include MSVC 2019 runtime libraries.
           if ('${{ matrix.build-type }}' -ieq 'release') {
+              if ($env:VCToolsRedistDir -eq $null) {
+                  # XXX: Hack to work around this issue: https://github.com/actions/runner-images/issues/10819
+                  $env:VCToolsRedistDir = -join ($env:VCINSTALLDIR, "Redist\MSVC\", $env:VCToolsVersion, "\")
+              }
               Copy-Item $env:VCToolsRedistDir\${{ matrix.arch }}\Microsoft.VC142.CRT\msvcp140.dll
               Copy-Item $env:VCToolsRedistDir\${{ matrix.arch }}\Microsoft.VC142.CRT\msvcp140_1.dll
 


### PR DESCRIPTION
Recently, the `vcvarsall.bat` batch script from VS 2019 has stopped defining the `VCToolsRedistDir` environment variable, [for reasons unknown so far](https://github.com/actions/runner-images/issues/10819 ).

We rely on that variable in CI to copy MSVC runtime DLLs to our Windows packages, so this adds a workaround for when that variable is not set.