### PR TITLE
CI/macOS: Run `create-dmg` until it succeeds

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -187,22 +187,32 @@ jobs:
       - name: Build dmg (${{ matrix.build-type }})
         run: |
           cd build
-          # FIXME: No, we're not crazy. We invoke create-dmg as root to work around this issue:
-          #       https://github.com/actions/runner-images/issues/7522
-          sudo create-dmg \
-              --no-internet-enable \
-              --format ULFO \
-              --background ../packaging/macos/dmg-background.png \
-              --hide-extension 'Notes Better.app' \
-              --icon 'Notes Better.app' 180 170 \
-              --icon-size 160 \
-              --text-size 12 \
-              --volname Notes \
-              --volicon ../src/images/notes_icon.icns \
-              --window-size 660 400 \
-              --app-drop-link 480 170 \
-              '${{ steps.vars.outputs.file_name }}' \
-              'Notes Better.app'
+          # FIXME: Undo this overengineered crap once the following issue gets figured out:
+          #        https://github.com/actions/runner-images/issues/7522
+          max_tries=10
+          i=0
+          until create-dmg \
+                  --no-internet-enable \
+                  --format ULFO \
+                  --background ../packaging/macos/dmg-background.png \
+                  --hide-extension 'Notes Better.app' \
+                  --icon 'Notes Better.app' 180 170 \
+                  --icon-size 160 \
+                  --text-size 12 \
+                  --volname Notes \
+                  --volicon ../src/images/notes_icon.icns \
+                  --window-size 660 400 \
+                  --app-drop-link 480 170 \
+                  '${{ steps.vars.outputs.file_name }}' \
+                  'Notes Better.app'
+          do
+              if [ $i -eq $max_tries ]
+              then
+                  echo 'Error: create-dmg did not succeed even after 10 tries.'
+                  exit 1
+              fi
+              ((i++))
+          done
 
       - name: Notarize
         if: github.repository == 'nuttyartist/notes' && github.event_name != 'pull_request'


### PR DESCRIPTION
The previous workaround from commit 2d759ce0 did not stop our macOS build jobs from randomly failing.

This stupid approach will continue to invoke `create-dmg` until it succeeds. If it fails to do so after 10 tries, we just give up.

Closes #711