### PR TITLE
CI/Linux: Install `python3-dev` before installing `aqtinstall` (Qt 5 AppImage)

### DIFF
--- a/Dockerfiles/appimage-qt5
+++ b/Dockerfiles/appimage-qt5
@@ -32,11 +32,11 @@ ARG DEBIAN_FRONTEND=noninteractive
 # - libxcb-xkb1: Used as dependency of the resulting AppImage.
 # - libxkbcommon-x11-0: Used as dependency of the resulting AppImage.
 # - make: Used to help build the application.
-# - python3/python3-pip: Used to install and run aqtinstall.
+# - python3/python3-dev/python3-pip: Used to install and run aqtinstall.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends appstream cmake desktop-file-utils file git g++ libdbus-1-3 \
     libegl1 libfontconfig1 libglib2.0-0 libgl-dev libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 \
-    libxcb-render-util0 libxcb-shape0 libxcb-xinerama0 libxcb-xkb1 libxkbcommon-x11-0 make python3 python3-pip && \
+    libxcb-render-util0 libxcb-shape0 libxcb-xinerama0 libxcb-xkb1 libxkbcommon-x11-0 make python3 python3-dev python3-pip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists
 


### PR DESCRIPTION
This dependency is necessary to build the `pyzstd` wheel, as they stopped providing a pre-built wheel for Python 3.8 after they released 0.16.2.

Fixes #716