### PR TITLE
[qt5 branch] CI: Only generate Qt 5 build artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,9 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - qt5
     tags:
-      - v*
+      - v2.3.*
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   deb:
-    name: deb (${{ matrix.build-type }}, Qt ${{ matrix.qt-version-major }}, ${{ matrix.image }})
+    name: deb (${{ matrix.build-type }}, Qt 5, ${{ matrix.image }})
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -21,17 +21,6 @@ jobs:
           # Ubuntu's release cycle: https://wiki.ubuntu.com/Releases
           - image: ubuntu-20_04
             build-script: ubuntu_deb_entrypoint.sh
-            qt-version-major: 5
-            build-type: release
-
-          - image: ubuntu-22_04
-            build-script: ubuntu_deb_entrypoint.sh
-            qt-version-major: 6
-            build-type: release
-
-          - image: ubuntu-23_10
-            build-script: ubuntu_deb_entrypoint.sh
-            qt-version-major: 6
             build-type: release
     steps:
       - name: Checkout code
@@ -44,11 +33,11 @@ jobs:
         run: |
           set -ex
           git remote add upstream https://github.com/nuttyartist/notes.git
-          git fetch --unshallow upstream master
+          git fetch --unshallow upstream qt5
           # NOTE: The following should give us the previous commit hash of the base branch, but that will
           #       only work reliably for 'push' and pull_request events. For workflow_dispatch events, we
-          #       have to fallback to the default branch ('master'), until a better solution is found...
-          previous_ref=${{ github.event.pull_request.base.sha || github.event.before || 'upstream/master' }}
+          #       have to fallback to the default branch ('qt5'), until a better solution is found...
+          previous_ref=${{ github.event.pull_request.base.sha || github.event.before || 'upstream/qt5' }}
           if ! git diff --compact-summary --exit-code "${previous_ref}" -- 'Dockerfiles/${{ matrix.image }}' 'Dockerfiles/${{ matrix.build-script }}'
           then
               needs_rebuild=true
@@ -75,11 +64,11 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
-          name: ${{ steps.build.outputs.deb_name }}-qt${{ matrix.qt-version-major }}-${{ steps.build.outputs.distro_name }}-${{ matrix.build-type }}
+          name: ${{ steps.build.outputs.deb_name }}-qt5-${{ steps.build.outputs.distro_name }}-${{ matrix.build-type }}
           path: ${{ steps.build.outputs.deb_path }}
 
       - name: Login to GitHub Container Registry
-        if: ${{ steps.docker_image.outputs.needs_rebuild == 'true' && github.repository == 'nuttyartist/notes' && github.event_name != 'pull_request' && github.ref_name == 'master' }}
+        if: ${{ steps.docker_image.outputs.needs_rebuild == 'true' && github.repository == 'nuttyartist/notes' && github.event_name != 'pull_request' && github.ref_name == 'qt5' }}
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -87,102 +76,14 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
-        if: ${{ steps.docker_image.outputs.needs_rebuild == 'true' && github.repository == 'nuttyartist/notes' && github.event_name != 'pull_request' && github.ref_name == 'master' }}
+        if: ${{ steps.docker_image.outputs.needs_rebuild == 'true' && github.repository == 'nuttyartist/notes' && github.event_name != 'pull_request' && github.ref_name == 'qt5' }}
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/nuttyartist/notes:${{ matrix.image }}
 
       - name: Build and push Docker image
-        if: ${{ steps.docker_image.outputs.needs_rebuild == 'true' && github.repository == 'nuttyartist/notes' && github.event_name != 'pull_request' && github.ref_name == 'master' }}
-        uses: docker/build-push-action@v6
-        env:
-          DOCKER_BUILD_SUMMARY: false
-        with:
-          file: Dockerfiles/${{ matrix.image }}
-          push: true
-          tags: ${{ env.REGISTRY }}/nuttyartist/notes:${{ matrix.image }}
-
-  rpm:
-    name: rpm (${{ matrix.build-type }}, Qt ${{ matrix.qt-version-major }}, ${{ matrix.image }})
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # Fedora's release cycle: https://endoflife.date/fedora
-          - image: fedora-38
-            build-script: rpm_entrypoint.sh
-            qt-version-major: 6
-            build-type: release
-
-          # openSUSE's release cycle: https://endoflife.date/opensuse
-          - image: opensuse-15_5
-            build-script: rpm_entrypoint.sh
-            qt-version-major: 6
-            build-type: release
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Check if Dockerfile or build script has been modified
-        id: docker_image
-        run: |
-          set -ex
-          git remote add upstream https://github.com/nuttyartist/notes.git
-          git fetch --unshallow upstream master
-          # NOTE: The following should give us the previous commit hash of the base branch, but that will
-          #       only work reliably for 'push' and pull_request events. For workflow_dispatch events, we
-          #       have to fallback to the default branch ('master'), until a better solution is found...
-          previous_ref=${{ github.event.pull_request.base.sha || github.event.before || 'upstream/master' }}
-          if ! git diff --compact-summary --exit-code "${previous_ref}" -- 'Dockerfiles/${{ matrix.image }}' 'Dockerfiles/${{ matrix.build-script }}'
-          then
-              needs_rebuild=true
-          elif ! docker pull '${{ env.REGISTRY }}/nuttyartist/notes:${{ matrix.image }}'
-          then
-              needs_rebuild=true
-          else
-              needs_rebuild=false
-          fi
-          echo "needs_rebuild=${needs_rebuild}" >> "${GITHUB_OUTPUT}"
-
-      - name: Build and tag Docker image
-        if: steps.docker_image.outputs.needs_rebuild == 'true'
-        run: docker build -f 'Dockerfiles/${{ matrix.image }}' -t '${{ env.REGISTRY }}/nuttyartist/notes:${{ matrix.image }}' .
-
-      - name: Setup GCC problem matcher
-        uses: ammaraskar/gcc-problem-matcher@0.3.0
-
-      - name: Build, package and lint
-        id: build
-        run: docker run --rm -v "${GITHUB_OUTPUT}:/GITHUB_OUTPUT" -v "$(pwd):/src" -t '${{ env.REGISTRY }}/nuttyartist/notes:${{ matrix.image }}' -t ${{ matrix.build-type }} ${{ github.ref_type == 'tag' && '-n' || ' ' }}
-
-      - name: Upload rpm package
-        uses: actions/upload-artifact@v4
-        with:
-          if-no-files-found: error
-          name: ${{ steps.build.outputs.rpm_name }}-qt${{ matrix.qt-version-major }}-${{ steps.build.outputs.distro_name }}-${{ matrix.build-type }}
-          path: ${{ steps.build.outputs.rpm_path }}
-
-      - name: Login to GitHub Container Registry
-        if: ${{ steps.docker_image.outputs.needs_rebuild == 'true' && github.repository == 'nuttyartist/notes' && github.event_name != 'pull_request' && github.ref_name == 'master' }}
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        if: ${{ steps.docker_image.outputs.needs_rebuild == 'true' && github.repository == 'nuttyartist/notes' && github.event_name != 'pull_request' && github.ref_name == 'master' }}
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/nuttyartist/notes:${{ matrix.image }}
-
-      - name: Build and push Docker image
-        if: ${{ steps.docker_image.outputs.needs_rebuild == 'true' && github.repository == 'nuttyartist/notes' && github.event_name != 'pull_request' && github.ref_name == 'master' }}
+        if: ${{ steps.docker_image.outputs.needs_rebuild == 'true' && github.repository == 'nuttyartist/notes' && github.event_name != 'pull_request' && github.ref_name == 'qt5' }}
         uses: docker/build-push-action@v6
         env:
           DOCKER_BUILD_SUMMARY: false
@@ -192,7 +93,7 @@ jobs:
           tags: ${{ env.REGISTRY }}/nuttyartist/notes:${{ matrix.image }}
 
   appimage:
-    name: AppImage (${{ matrix.build-type }}, Qt ${{ matrix.qt-version-major }}, ${{ matrix.image }})
+    name: AppImage (${{ matrix.build-type }}, Qt 5, ${{ matrix.image }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -200,12 +101,6 @@ jobs:
         include:
           - image: appimage-qt5
             build-script: appimage_entrypoint.sh
-            qt-version-major: 5
-            build-type: release
-
-          - image: appimage-qt6
-            build-script: appimage_entrypoint.sh
-            qt-version-major: 6
             build-type: release
     steps:
       - name: Checkout code
@@ -218,11 +113,11 @@ jobs:
         run: |
           set -ex
           git remote add upstream https://github.com/nuttyartist/notes.git
-          git fetch --unshallow upstream master
+          git fetch --unshallow upstream qt5
           # NOTE: The following should give us the previous commit hash of the base branch, but that will
           #       only work reliably for 'push' and pull_request events. For workflow_dispatch events, we
-          #       have to fallback to the default branch ('master'), until a better solution is found...
-          previous_ref=${{ github.event.pull_request.base.sha || github.event.before || 'upstream/master' }}
+          #       have to fallback to the default branch ('qt5'), until a better solution is found...
+          previous_ref=${{ github.event.pull_request.base.sha || github.event.before || 'upstream/qt5' }}
           if ! git diff --compact-summary --exit-code "${previous_ref}" -- 'Dockerfiles/${{ matrix.image }}' 'Dockerfiles/${{ matrix.build-script }}'
           then
               needs_rebuild=true
@@ -245,10 +140,6 @@ jobs:
         id: build
         run: docker run --rm -v "${GITHUB_OUTPUT}:/GITHUB_OUTPUT" -v "$(pwd):/src" -t '${{ env.REGISTRY }}/nuttyartist/notes:${{ matrix.image }}' -t ${{ matrix.build-type }} ${{ github.ref_type == 'tag' && '-n' || ' ' }}
 
-      - name: (FIXME) Run qmllint
-        if: endsWith(matrix.image, 'qt6')
-        run: docker run --rm -v "$(pwd):/src" --entrypoint '' -t '${{ env.REGISTRY }}/nuttyartist/notes:${{ matrix.image }}' cmake --build build --target all_qmllint || true
-
       - name: Upload AppImage artifact
         uses: actions/upload-artifact@v4
         with:
@@ -257,7 +148,7 @@ jobs:
           path: ${{ steps.build.outputs.appimage_path }}
 
       - name: Login to GitHub Container Registry
-        if: ${{ steps.docker_image.outputs.needs_rebuild == 'true' && github.repository == 'nuttyartist/notes' && github.event_name != 'pull_request' && github.ref_name == 'master' }}
+        if: ${{ steps.docker_image.outputs.needs_rebuild == 'true' && github.repository == 'nuttyartist/notes' && github.event_name != 'pull_request' && github.ref_name == 'qt5' }}
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -265,14 +156,14 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
-        if: ${{ steps.docker_image.outputs.needs_rebuild == 'true' && github.repository == 'nuttyartist/notes' && github.event_name != 'pull_request' && github.ref_name == 'master' }}
+        if: ${{ steps.docker_image.outputs.needs_rebuild == 'true' && github.repository == 'nuttyartist/notes' && github.event_name != 'pull_request' && github.ref_name == 'qt5' }}
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/nuttyartist/notes:${{ matrix.image }}
 
       - name: Build and push Docker image
-        if: ${{ steps.docker_image.outputs.needs_rebuild == 'true' && github.repository == 'nuttyartist/notes' && github.event_name != 'pull_request' && github.ref_name == 'master' }}
+        if: ${{ steps.docker_image.outputs.needs_rebuild == 'true' && github.repository == 'nuttyartist/notes' && github.event_name != 'pull_request' && github.ref_name == 'qt5' }}
         uses: docker/build-push-action@v6
         env:
           DOCKER_BUILD_SUMMARY: false
@@ -280,46 +171,3 @@ jobs:
           file: Dockerfiles/${{ matrix.image }}
           push: true
           tags: ${{ env.REGISTRY }}/nuttyartist/notes:${{ matrix.image }}
-
-  snap:
-    name: snap
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Install snapcraft
-        run: |
-          sudo snap install snapcraft --classic
-
-      - name: Set up LXD
-        run: |
-          sudo usermod -a -G lxd "${USER}"
-          sudo lxd init --auto
-          sudo iptables -P FORWARD ACCEPT
-
-      - name: Build
-        run: |
-          sg lxd -c 'snap run snapcraft -v'
-
-      - name: Grab snap package name
-        id: snap
-        shell: bash
-        run: |
-          set -x
-          if ! path=$(find . -maxdepth 1 -name '*.snap' -print -quit)
-          then
-              echo 'Fatal: Unable to find snap package'
-              exit 1
-          fi
-          echo "name=$(basename "${path%.*}")" >> "${GITHUB_OUTPUT}"
-          echo "path=${path}" >> "${GITHUB_OUTPUT}"
-
-      - name: Upload snap package
-        uses: actions/upload-artifact@v4
-        with:
-          if-no-files-found: error
-          name: ${{ steps.snap.outputs.name }}.snap
-          path: ${{ steps.snap.outputs.path }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -9,7 +9,7 @@ jobs:
   # So it doesn't make much sense to have different build types other than 'debug' here.
   # The release dmg is built using aqtinstall instead (the job below this one).
   build-homebrew:
-    name: Build (${{ matrix.build-type }}, homebrew (qt${{ matrix.qt-version-major }}), ${{ matrix.os }})
+    name: Build (${{ matrix.build-type }}, homebrew (qt5), ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -18,28 +18,23 @@ jobs:
           - os: macos-13
             qt-version-major: 5
             build-type: debug
-
-          - os: macos-13
-            qt-version-major: 6
-            build-type: debug
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           submodules: recursive
 
-      - name: Install Qt ${{ matrix.qt-version-major }} (homebrew)
+      - name: Install Qt 5 (homebrew)
         run: |
-          brew install ninja qt@${{ matrix.qt-version-major }} 
+          brew install ninja qt@5
 
-      - name: Configure Qt ${{ matrix.qt-version-major }} (homebrew)
-        if: matrix.qt-version-major == 5
+      - name: Configure Qt 5 (homebrew)
         run: |
-          brew link qt@${{ matrix.qt-version-major }}
+          brew link qt@5
           cat << EOF
-          LDFLAGS="-L/usr/local/opt/qt@${{ matrix.qt-version-major }}/lib"
-          export CPPFLAGS="-I/usr/local/opt/qt@${{ matrix.qt-version-major }}/include"
-          export PATH="/usr/local/opt/qt@${{ matrix.qt-version-major }}/bin:$PATH"
+          LDFLAGS="-L/usr/local/opt/qt@5/lib"
+          export CPPFLAGS="-I/usr/local/opt/qt@5/include"
+          export PATH="/usr/local/opt/qt@5/bin:$PATH"
           EOF >> ~/.bashrc
 
       - name: Setup CLang problem matcher
@@ -74,10 +69,6 @@ jobs:
           - os: macos-13
             qt-version: 5.15.2
             build-type: release
-
-          - os: macos-13
-            qt-version: 6.5.2
-            build-type: release
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -98,12 +89,7 @@ jobs:
           then
               version="${version}+g${GITHUB_SHA::7}"
           fi
-          arches='x86_64'
-          if [[ '${{ matrix.qt-version }}' == 6.* ]]
-          then
-              arches+='-arm64'
-          fi
-          artifact_name="Notes_${version}-Qt${{ matrix.qt-version }}-${arches}"
+          artifact_name="Notes_${version}-Qt${{ matrix.qt-version }}-x86_64"
           if [ '${{ matrix.build-type }}' == 'debug' ]
           then
               file_name="${artifact_name}-debug.dmg"
@@ -126,25 +112,17 @@ jobs:
 
       - name: Build (${{ matrix.build-type }})
         env:
-          # Only commercial Qt 5 supports targeting Apple Silicon at the moment:
-          # https://www.qt.io/blog/qt-on-apple-silicon
-          TARGET_ARCH: ${{ startsWith(matrix.qt-version, '6.') && 'x86_64;arm64' || 'x86_64' }}
           VERBOSE: 1
         run: |
           export CMAKE_BUILD_PARALLEL_LEVEL=$(sysctl -n hw.logicalcpu)
           cmake . --warn-uninitialized --warn-unused-vars \
               -B build -G Ninja \
-              -DCMAKE_OSX_DEPLOYMENT_TARGET=${{ startsWith(matrix.qt-version, '6.') && '11.0' || '10.15' }} \
+              -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 \
               -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
               -DGIT_REVISION=${{ github.ref_type != 'tag' && 'ON' || 'OFF' }} \
-              -DCMAKE_OSX_ARCHITECTURES="${{ env.TARGET_ARCH }}" \
+              -DCMAKE_OSX_ARCHITECTURES=x86_64 \
               -DPRO_VERSION=OFF
           cmake --build build
-
-      - name: (FIXME) Run qmllint
-        if: startsWith(matrix.qt-version, '6.')
-        run: |
-          cmake --build build --target all_qmllint || true
 
       - name: Install (${{ matrix.build-type }})
         run: |
@@ -163,11 +141,8 @@ jobs:
           set -x
           set -e
           cd 'build/Notes Better.app'
-          if [[ '${{ matrix.qt-version }}' == 5.* ]]
-          then
-              # The bearer plugin has caused problems for us in the past. Plus, it was removed altogether in Qt 6.
-              rm -rv Contents/PlugIns/bearer
-          fi
+          # The bearer plugin has caused problems for us in the past. Plus, it was removed altogether in Qt 6.
+          rm -rv Contents/PlugIns/bearer
 
       - name: Import signing certificate
         if: github.repository == 'nuttyartist/notes' && github.event_name != 'pull_request'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -8,25 +8,14 @@ jobs:
   # NOTE: This job uses a fixed Qt version (set in the 'qt-version' key below)!
   # So, remember to keep it updated whenever a new Qt version is available on aqtinstall.
   build-aqtinstall:
-    name: Build (${{ matrix.arch }}, ${{ matrix.build-type }}, Qt ${{ matrix.qt-version }}, ${{ matrix.os }})
+    name: Build (x86, ${{ matrix.build-type }}, Qt ${{ matrix.qt-version }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - os: windows-2019
-            arch: x64
             qt-version: 5.15.2
-            build-type: release
-
-          - os: windows-2019
-            arch: x86
-            qt-version: 5.15.2
-            build-type: release
-
-          - os: windows-2019
-            arch: x64
-            qt-version: 6.4.3
             build-type: release
     outputs:
       version: ${{ steps.vars.outputs.version }}
@@ -46,26 +35,25 @@ jobs:
           if ('${{ github.ref_type }}' -ne 'tag') {
               $version += "+g$($env:GITHUB_SHA.Substring(0,7))"
           }
-          $artifact_name = "Notes_$version-Qt${{ matrix.qt-version }}-${{ matrix.arch }}"
+          $artifact_name = "Notes_$version-Qt${{ matrix.qt-version }}-x86"
           Write-Output "version=$version" >> $env:GITHUB_OUTPUT
           Write-Output "artifact_name=$artifact_name" >> $env:GITHUB_OUTPUT
 
-      - name: Setup MSVC (${{ matrix.arch }})
+      - name: Setup MSVC
         uses: ilammy/msvc-dev-cmd@v1
         with:
-          arch: ${{ matrix.arch }}
+          arch: x86
 
-      - name: Install Qt ${{ matrix.qt-version }} (aqtinstall, ${{ matrix.arch }})
+      - name: Install Qt ${{ matrix.qt-version }} (aqtinstall)
         uses: jurplel/install-qt-action@v4
         with:
           version: ${{ matrix.qt-version }}
           cache: true
-          arch: ${{ matrix.arch == 'x86' && 'win32_msvc2019' || 'win64_msvc2019_64' }}
+          arch: win32_msvc2019
 
       # Details about this OpenSSL build: https://kb.firedaemon.com/support/solutions/articles/4000121705
       # TODO: Remove/tweak this step if/when we get rid of the x86 build or upgrade to Qt 6.5+.
       - name: Download OpenSSL 1.x binaries from FireDaemon
-        if: ${{ startsWith(matrix.qt-version, '5.') || startsWith(matrix.qt-version, '6.4.') }}
         run: |
           $out_file = "openssl-1.1.1w.zip"
           Invoke-WebRequest -Uri https://download.firedaemon.com/FireDaemon-OpenSSL/openssl-1.1.1w.zip -OutFile $env:Temp\$out_file
@@ -75,7 +63,7 @@ jobs:
       - name: Setup MSVC problem matcher
         uses: ammaraskar/msvc-problem-matcher@0.3.0
 
-      - name: Build (${{ matrix.build-type }}, ${{ matrix.arch }})
+      - name: Build (${{ matrix.build-type }})
         env:
           VERBOSE: 1
         run: |
@@ -87,50 +75,37 @@ jobs:
               -DPRO_VERSION=OFF
           cmake --build build
 
-      - name: (FIXME) Run qmllint
-        if: startsWith(matrix.qt-version, '6.')
-        run: |
-          cmake --build build --target all_qmllint || $(exit 0)
-
-      - name: Install (${{ matrix.build-type }}, ${{ matrix.arch }})
+      - name: Install (${{ matrix.build-type }})
         run: |
           cmake --install build --prefix build
 
-      - name: Deploy (${{ matrix.build-type }}, ${{ matrix.arch }})
+      - name: Deploy (${{ matrix.build-type }})
         run: |
-          windeployqt ${{ startsWith(matrix.qt-version, '5.') && '--no-qmltooling' || ' ' }} --qmldir src\qml build\bin
+          windeployqt --no-qmltooling --qmldir src\qml build\bin
 
       - name: Remove unnecessary Qt plugins and libraries
         run: |
           Set-Location build\bin
           # We ship all required runtime DLLs individually.
           Remove-Item -Verbose vc_redist.*.exe
-          if ('${{ matrix.qt-version }}'.StartsWith('5.')) {
-              # The bearer plugin has caused problems for us in the past. Plus, it was removed altogether in Qt 6.
-              Remove-Item -Verbose -Recurse bearer
-          }
+          # The bearer plugin has caused problems for us in the past. Plus, it was removed altogether in Qt 6.
+          Remove-Item -Verbose -Recurse bearer
           # We only use the SQLite Qt driver, so it's fine to delete others.
           Remove-Item -Verbose sqldrivers\qsqlodbc.dll
           Remove-Item -Verbose sqldrivers\qsqlpsql.dll
 
-      - name: Include required runtime libraries (${{ matrix.build-type }}, ${{ matrix.arch }})
+      - name: Include required runtime libraries (${{ matrix.build-type }})
         run: |
           Set-Location build\bin
 
-          if ('${{ matrix.arch }}' -ieq 'x64') {
-              $openssl_lib_suffix = '-x64'
-          } else {
-              $openssl_lib_suffix = ''
-          }
-
           # Include OpenSSL libraries.
-          Copy-Item $env:Temp\OpenSSL\${{ matrix.arch }}\bin\libcrypto-1_1$openssl_lib_suffix.dll
-          Copy-Item $env:Temp\OpenSSL\${{ matrix.arch }}\bin\libssl-1_1$openssl_lib_suffix.dll
+          Copy-Item $env:Temp\OpenSSL\x86\bin\libcrypto-1_1.dll
+          Copy-Item $env:Temp\OpenSSL\x86\bin\libssl-1_1.dll
 
           # Also include OpenSSL debug symbols (when building Notes in debug mode).
           if ('${{ matrix.build-type }}' -ieq 'debug') {
-              Copy-Item $env:Temp\OpenSSL\${{ matrix.arch }}\bin\libcrypto-1_1$openssl_lib_suffix.pdb
-              Copy-Item $env:Temp\OpenSSL\${{ matrix.arch }}\bin\libssl-1_1$openssl_lib_suffix.pdb
+              Copy-Item $env:Temp\OpenSSL\x86\bin\libcrypto-1_1.pdb
+              Copy-Item $env:Temp\OpenSSL\x86\bin\libssl-1_1.pdb
           }
 
           # Include MSVC 2019 runtime libraries.
@@ -139,33 +114,24 @@ jobs:
                   # XXX: Hack to work around this issue: https://github.com/actions/runner-images/issues/10819
                   $env:VCToolsRedistDir = -join ($env:VCINSTALLDIR, "Redist\MSVC\", $env:VCToolsVersion, "\")
               }
-              Copy-Item $env:VCToolsRedistDir\${{ matrix.arch }}\Microsoft.VC142.CRT\msvcp140.dll
-              Copy-Item $env:VCToolsRedistDir\${{ matrix.arch }}\Microsoft.VC142.CRT\msvcp140_1.dll
+              Copy-Item $env:VCToolsRedistDir\x86\Microsoft.VC142.CRT\msvcp140.dll
+              Copy-Item $env:VCToolsRedistDir\x86\Microsoft.VC142.CRT\msvcp140_1.dll
 
-              # Only Qt 6 builds also need msvcp140_2.dll
-              if ('${{ matrix.qt-version }}'.StartsWith('6')) {
-                  Copy-Item $env:VCToolsRedistDir\${{ matrix.arch }}\Microsoft.VC142.CRT\msvcp140_2.dll
-              }
-
-              Copy-Item $env:VCToolsRedistDir\${{ matrix.arch }}\Microsoft.VC142.CRT\vcruntime140.dll
-              if ('${{ matrix.arch }}' -ieq 'x64') {
-                  # Only 64-bit builds also need 'vcruntime140_1.dll' (tested on Windows 7)
-                  Copy-Item $env:VCToolsRedistDir\${{ matrix.arch }}\Microsoft.VC142.CRT\vcruntime140_1.dll
-              }
+              Copy-Item $env:VCToolsRedistDir\x86\Microsoft.VC142.CRT\vcruntime140.dll
           } else {
               # On debug builds, the libraries above are included automatically, so we only need 'urtcbased.dll'.
-              Copy-Item $env:WindowsSdkBinPath\${{ matrix.arch }}\ucrt\ucrtbased.dll
+              Copy-Item $env:WindowsSdkBinPath\x86\ucrt\ucrtbased.dll
           }
 
-      - name: Upload artifacts (${{ matrix.build-type }}, ${{ matrix.arch }})
+      - name: Upload artifacts (${{ matrix.build-type }})
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
           name: ${{ steps.vars.outputs.artifact_name }}-${{ runner.os }}-${{ matrix.build-type }}
           path: build\bin
 
-  unified-installer:
-    name: Unified x64-x86 Installer
+  installer:
+    name: x86 Installer (Qt 5 only)
     needs: build-aqtinstall
     runs-on: windows-2019
     steps:
@@ -178,29 +144,18 @@ jobs:
           path: artifacts
           pattern: '*Windows*'
 
-      - name: Ensure a 64-bit Qt 6 build is present
-        run: |
-          Set-Location artifacts
-          $x64_build = Get-ChildItem -Filter '*Qt6*-x64-Windows-release' -Attributes Directory |
-              Sort-Object -Property @{Expression = "Name"; Descending = $true} |
-              Select-Object -First 1
-          if (!$x64_build) {
-              Throw 'Could not find a 64-bit Qt 6 build.'
-          }
-          Move-Item $x64_build Notes64
-
-      - name: Ensure a 32-bit Qt 5 build is present
+      - name: Ensure a x86 Qt 5 build is present
         run: |
           Set-Location artifacts
           $x86_build = Get-ChildItem -Filter '*Qt5*-x86-Windows-release' -Attributes Directory |
               Sort-Object -Property @{Expression = "Name"; Descending = $true} |
               Select-Object -First 1
           if (!$x86_build) {
-              Throw 'Could not find a 32-bit Qt 5 build.'
+              Throw 'Could not find a x86 Qt 5 build.'
           }
           Move-Item $x86_build Notes32
 
-      - name: Create unified installer
+      - name: Create installer
         run: |
           Set-Location artifacts
           Copy-Item ..\packaging\windows\Notes_Inno_Script_Github.iss
@@ -214,7 +169,7 @@ jobs:
         run: |
           Set-Location artifacts
           $inno_setup_manifest = ".\installer\Setup-Manifest.txt"
-          $windeployqt_paths = @(".\Notes32", ".\Notes64")
+          $windeployqt_paths = @(".\Notes32")
 
           $inno_setup_files = @()
           Get-Content -LiteralPath $inno_setup_manifest -ErrorAction Stop | Select-Object -Skip 1 | Foreach-Object {
@@ -244,7 +199,7 @@ jobs:
           }
           Write-Host "SUCCESS: List of files in the installer matches the ones copied by windeployqt."
 
-      - name: Upload unified installer artifact
+      - name: Upload installer artifact
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error

--- a/Dockerfiles/appimage-qt5
+++ b/Dockerfiles/appimage-qt5
@@ -32,11 +32,11 @@ ARG DEBIAN_FRONTEND=noninteractive
 # - libxcb-xkb1: Used as dependency of the resulting AppImage.
 # - libxkbcommon-x11-0: Used as dependency of the resulting AppImage.
 # - make: Used to help build the application.
-# - python3/python3-pip: Used to install and run aqtinstall.
+# - python3/python3-dev/python3-pip: Used to install and run aqtinstall.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends appstream cmake desktop-file-utils file git g++ libdbus-1-3 \
     libegl1 libfontconfig1 libglib2.0-0 libgl-dev libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 \
-    libxcb-render-util0 libxcb-shape0 libxcb-xinerama0 libxcb-xkb1 libxkbcommon-x11-0 make python3 python3-pip && \
+    libxcb-render-util0 libxcb-shape0 libxcb-xinerama0 libxcb-xkb1 libxkbcommon-x11-0 make python3 python3-dev python3-pip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists
 

--- a/packaging/windows/Notes_Inno_Script_Github.iss
+++ b/packaging/windows/Notes_Inno_Script_Github.iss
@@ -19,8 +19,8 @@ OutputBaseFilename=NotesSetup_{#Version}
 Compression=lzma
 SolidCompression=yes
 ; Inno Setup can't seem to calculate the required disk space correctly, and asks for only 3.1 MB.
-; Let's use an approximate value to represent the size of the Qt 6 build while installed on disk (100 MiB).
-ExtraDiskSpaceRequired=104857600
+; Let's use an approximate value to represent the size of the Qt 5 build while installed on disk (73 MiB).
+ExtraDiskSpaceRequired=76546048
 OutputManifestFile=Setup-Manifest.txt
 
 [Code]
@@ -141,53 +141,6 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}";
 
 [Files]
-; Qt 6 build (64-bit)
-; Minimum supported OS:
-; - Windows 10 21H2 (1809 or later)
-; Source: https://doc.qt.io/qt-6/supported-platforms.html#windows
-Source: "{#SourcePath}\Notes64\iconengines\*"; DestDir: "{app}\iconengines"; Flags: ignoreversion recursesubdirs createallsubdirs; Check: IsWin64; MinVersion: 10.0.17763
-Source: "{#SourcePath}\Notes64\imageformats\*"; DestDir: "{app}\imageformats"; Flags: ignoreversion recursesubdirs createallsubdirs; Check: IsWin64; MinVersion: 10.0.17763
-Source: "{#SourcePath}\Notes64\networkinformation\*"; DestDir: "{app}\networkinformation"; Flags: ignoreversion recursesubdirs createallsubdirs; Check: IsWin64; MinVersion: 10.0.17763
-Source: "{#SourcePath}\Notes64\platforms\*"; DestDir: "{app}\platforms"; Flags: ignoreversion recursesubdirs createallsubdirs; Check: IsWin64; MinVersion: 10.0.17763
-Source: "{#SourcePath}\Notes64\QtQml\*"; DestDir: "{app}\QtQml"; Flags: ignoreversion recursesubdirs createallsubdirs; Check: IsWin64; MinVersion: 10.0.17763
-Source: "{#SourcePath}\Notes64\QtQuick\*"; DestDir: "{app}\QtQuick"; Flags: ignoreversion recursesubdirs createallsubdirs; Check: IsWin64; MinVersion: 10.0.17763
-Source: "{#SourcePath}\Notes64\sqldrivers\*"; DestDir: "{app}\sqldrivers"; Flags: ignoreversion recursesubdirs createallsubdirs; Check: IsWin64; MinVersion: 10.0.17763
-Source: "{#SourcePath}\Notes64\styles\*"; DestDir: "{app}\styles"; Flags: ignoreversion recursesubdirs createallsubdirs; Check: IsWin64; MinVersion: 10.0.17763
-Source: "{#SourcePath}\Notes64\tls\*"; DestDir: "{app}\tls"; Flags: ignoreversion recursesubdirs createallsubdirs; Check: IsWin64; MinVersion: 10.0.17763
-Source: "{#SourcePath}\Notes64\translations\*"; DestDir: "{app}\translations"; Flags: ignoreversion recursesubdirs createallsubdirs; Check: IsWin64; MinVersion: 10.0.17763
-Source: "{#SourcePath}\Notes64\d3dcompiler_47.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: IsWin64; MinVersion: 10.0.17763
-Source: "{#SourcePath}\Notes64\libcrypto-1_1-x64.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: IsWin64; MinVersion: 10.0.17763
-Source: "{#SourcePath}\Notes64\libssl-1_1-x64.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: IsWin64; MinVersion: 10.0.17763
-Source: "{#SourcePath}\Notes64\msvcp140.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: IsWin64; MinVersion: 10.0.17763
-Source: "{#SourcePath}\Notes64\msvcp140_1.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: IsWin64; MinVersion: 10.0.17763
-Source: "{#SourcePath}\Notes64\msvcp140_2.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: IsWin64; MinVersion: 10.0.17763
-Source: "{#SourcePath}\Notes64\Notes.exe"; DestDir: "{app}"; Flags: ignoreversion; Check: IsWin64; MinVersion: 10.0.17763
-Source: "{#SourcePath}\Notes64\opengl32sw.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: IsWin64; MinVersion: 10.0.17763
-Source: "{#SourcePath}\Notes64\Qt6Core.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: IsWin64; MinVersion: 10.0.17763
-Source: "{#SourcePath}\Notes64\Qt6Gui.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: IsWin64; MinVersion: 10.0.17763
-Source: "{#SourcePath}\Notes64\Qt6Network.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: IsWin64; MinVersion: 10.0.17763
-Source: "{#SourcePath}\Notes64\Qt6OpenGL.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: IsWin64; MinVersion: 10.0.17763
-Source: "{#SourcePath}\Notes64\Qt6Qml.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: IsWin64; MinVersion: 10.0.17763
-Source: "{#SourcePath}\Notes64\Qt6QmlLocalStorage.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: IsWin64; MinVersion: 10.0.17763
-Source: "{#SourcePath}\Notes64\Qt6QmlModels.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: IsWin64; MinVersion: 10.0.17763
-Source: "{#SourcePath}\Notes64\Qt6QmlWorkerScript.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: IsWin64; MinVersion: 10.0.17763
-Source: "{#SourcePath}\Notes64\Qt6QmlXmlListModel.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: IsWin64; MinVersion: 10.0.17763
-Source: "{#SourcePath}\Notes64\Qt6Quick.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: IsWin64; MinVersion: 10.0.17763
-Source: "{#SourcePath}\Notes64\Qt6QuickControls2.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: IsWin64; MinVersion: 10.0.17763
-Source: "{#SourcePath}\Notes64\Qt6QuickControls2Impl.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: IsWin64; MinVersion: 10.0.17763
-Source: "{#SourcePath}\Notes64\Qt6QuickDialogs2.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: IsWin64; MinVersion: 10.0.17763
-Source: "{#SourcePath}\Notes64\Qt6QuickDialogs2QuickImpl.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: IsWin64; MinVersion: 10.0.17763
-Source: "{#SourcePath}\Notes64\Qt6QuickDialogs2Utils.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: IsWin64; MinVersion: 10.0.17763
-Source: "{#SourcePath}\Notes64\Qt6QuickLayouts.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: IsWin64; MinVersion: 10.0.17763
-Source: "{#SourcePath}\Notes64\Qt6QuickParticles.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: IsWin64; MinVersion: 10.0.17763
-Source: "{#SourcePath}\Notes64\Qt6QuickShapes.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: IsWin64; MinVersion: 10.0.17763
-Source: "{#SourcePath}\Notes64\Qt6QuickTemplates2.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: IsWin64; MinVersion: 10.0.17763
-Source: "{#SourcePath}\Notes64\Qt6Sql.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: IsWin64; MinVersion: 10.0.17763
-Source: "{#SourcePath}\Notes64\Qt6Svg.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: IsWin64; MinVersion: 10.0.17763
-Source: "{#SourcePath}\Notes64\Qt6Widgets.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: IsWin64; MinVersion: 10.0.17763
-Source: "{#SourcePath}\Notes64\vcruntime140.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: IsWin64; MinVersion: 10.0.17763
-Source: "{#SourcePath}\Notes64\vcruntime140_1.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: IsWin64; MinVersion: 10.0.17763
-
 ; Qt 5 build (32-bit)
 ; Minimum supported OS:
 ; - Windows 7 (x86 and x86_64)


### PR DESCRIPTION
We're on the "qt5" branch, it doesn't make sense to generate Qt 6 build artifacts anymore.

This also drops the x64 build for Windows, leaving only the x86 build.