### PR TITLE
refactor: replace non-empty QString constructors with QStringLiteral()

### DIFF
--- a/src/customdocument.cpp
+++ b/src/customdocument.cpp
@@ -198,7 +198,7 @@ bool CustomDocument::openLinkAtCursorPosition()
         }
 
         if (isLocalFilePath && convertLocalFilepathsToURLs) {
-            openUrl(QString("file://") + urlString);
+            openUrl(QStringLiteral("file://") + urlString);
         } else {
             openUrl(urlString);
         }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1076,11 +1076,11 @@ void MainWindow::setupEditorSettings()
     emit displayFontSet(QVariant(dataToSendToView));
 
 #if defined(Q_OS_WINDOWS)
-    emit platformSet(QVariant(QString("Windows")));
+    emit platformSet(QVariant(QStringLiteral("Windows")));
 #elif defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
-    emit platformSet(QVariant(QString("Unix")));
+    emit platformSet(QVariant(QStringLiteral("Unix")));
 #elif defined(Q_OS_MACOS)
-    emit platformSet(QVariant(QString("Apple")));
+    emit platformSet(QVariant(QStringLiteral("Apple")));
 #endif
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 2, 0)
@@ -1198,9 +1198,9 @@ void MainWindow::alignTextEditText()
     }
 
     QFontMetricsF fm(m_currentSelectedFont);
-    QString limitingStringSample =
-            QString("The quick brown fox jumps over the lazy dog the quick brown fox jumps over "
-                    "the lazy dog the quick brown fox jumps over the lazy dog");
+    QString limitingStringSample = QStringLiteral(
+            "The quick brown fox jumps over the lazy dog the quick brown fox jumps over "
+            "the lazy dog the quick brown fox jumps over the lazy dog");
     limitingStringSample.truncate(m_textEdit->lineWrapColumnOrWidth());
     qreal textSamplePixelsWidth = fm.horizontalAdvance(limitingStringSample);
     m_noteEditorLogic->setCurrentAdaptableEditorPadding(
@@ -1297,11 +1297,11 @@ void MainWindow::setupKanbanView()
     ui->verticalLayout_textEdit->insertWidget(ui->verticalLayout_textEdit->indexOf(m_textEdit),
                                               m_kanbanWidget);
 #  if defined(Q_OS_WINDOWS)
-    emit platformSet(QVariant(QString("Windows")));
+    emit platformSet(QVariant(QStringLiteral("Windows")));
 #  elif defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
-    emit platformSet(QVariant(QString("Unix")));
+    emit platformSet(QVariant(QStringLiteral("Unix")));
 #  elif defined(Q_OS_MACOS)
-    emit platformSet(QVariant(QString("Apple")));
+    emit platformSet(QVariant(QStringLiteral("Apple")));
 #  endif
 
     QJsonObject dataToSendToView{ { "displayFont",
@@ -4195,9 +4195,9 @@ void MainWindow::setHeading(int level)
             new_text.clear();
         }
         selected_text = selected_text.trimmed().remove(QRegularExpression("^#*\\s?"));
-        new_text += QString("#").repeated(level) + ((level == 0) ? "" : " ") + selected_text;
+        new_text += QStringLiteral("#").repeated(level) + ((level == 0) ? "" : " ") + selected_text;
     } else {
-        new_text = QString("#").repeated(level) + " ";
+        new_text = QStringLiteral("#").repeated(level) + " ";
     }
     cursor.insertText(new_text);
 }

--- a/src/notelistview.cpp
+++ b/src/notelistview.cpp
@@ -741,7 +741,7 @@ void NoteListView::onCustomContextMenu(QPoint point)
             }
             for (auto id : std::as_const(tagInNote)) {
                 auto tag = m_tagPool->getTag(id);
-                auto tagAction = new QAction(QString("✓ Remove tag ") + tag.name(), this);
+                auto tagAction = new QAction(QStringLiteral("✓ Remove tag ") + tag.name(), this);
                 connect(tagAction, &QAction::triggered, this,
                         [this, id, notes] { removeNotesFromTag(notes, id); });
                 tagAction->setIcon(createTagIcon(tag.color()));
@@ -754,7 +754,7 @@ void NoteListView::onCustomContextMenu(QPoint point)
                     continue;
                 }
                 auto tag = m_tagPool->getTag(id);
-                auto tagAction = new QAction(QString(" ") + tag.name(), this);
+                auto tagAction = new QAction(QStringLiteral(" ") + tag.name(), this);
                 connect(tagAction, &QAction::triggered, this,
                         [this, id, notes] { addNotesToTag(notes, id); });
                 tagAction->setIcon(createTagIcon(tag.color()));

--- a/src/updaterwindow.cpp
+++ b/src/updaterwindow.cpp
@@ -294,7 +294,7 @@ void UpdaterWindow::startDownload(const QUrl &url)
     /* Set file name */
     m_fileName = m_updater->getDownloadUrl(UPDATES_URL).split("/").last();
     if (m_fileName.isEmpty()) {
-        m_fileName = QString("%1_Update_%2.bin")
+        m_fileName = QStringLiteral("%1_Update_%2.bin")
                              .arg(QCoreApplication::applicationName(),
                                   m_updater->getLatestVersion(UPDATES_URL));
     }


### PR DESCRIPTION
- Qt provides a macro `QStringLiteral()`, which makes constructing QString objects from string literals more efficient.