### PR TITLE
fixed the issue where the original name of a node would be truncated when the name was too long.

### DIFF
--- a/src/elidedlabel.cpp
+++ b/src/elidedlabel.cpp
@@ -6,7 +6,7 @@
 ElidedLabel::ElidedLabel(QWidget *parent, Qt::WindowFlags f) : ElidedLabel("", parent, f) { }
 
 ElidedLabel::ElidedLabel(const QString &text, QWidget *parent, Qt::WindowFlags f)
-    : QLabel(text, parent, f), defaultType(Qt::ElideRight), eliding(false), original("")
+    : QLabel(text, parent, f), original(""), defaultType(Qt::ElideRight), eliding(false)
 {
     setText(text);
 }

--- a/src/elidedlabel.cpp
+++ b/src/elidedlabel.cpp
@@ -3,18 +3,11 @@
 #include <QResizeEvent>
 #include <QTimer>
 
-ElidedLabel::ElidedLabel(QWidget *parent, Qt::WindowFlags f) : QLabel(parent, f)
-{
-    defaultType = Qt::ElideRight;
-    eliding = false;
-    original = "";
-}
+ElidedLabel::ElidedLabel(QWidget *parent, Qt::WindowFlags f) : ElidedLabel("", parent, f) { }
 
 ElidedLabel::ElidedLabel(const QString &text, QWidget *parent, Qt::WindowFlags f)
-    : QLabel(text, parent, f)
+    : QLabel(text, parent, f), defaultType(Qt::ElideRight), eliding(false), original("")
 {
-    defaultType = Qt::ElideRight;
-    eliding = false;
     setText(text);
 }
 
@@ -22,6 +15,11 @@ void ElidedLabel::setType(const Qt::TextElideMode type)
 {
     defaultType = type;
     elide();
+}
+
+QString ElidedLabel::text() const
+{
+    return original;
 }
 
 void ElidedLabel::resizeEvent(QResizeEvent *event)

--- a/src/elidedlabel.h
+++ b/src/elidedlabel.h
@@ -11,6 +11,7 @@ public:
     explicit ElidedLabel(const QString &text, QWidget *parent = nullptr,
                          Qt::WindowFlags f = Qt::WindowFlags());
     void setType(const Qt::TextElideMode type);
+    QString text() const;
 
 public slots:
     void setText(const QString &text);

--- a/src/foldertreedelegateeditor.cpp
+++ b/src/foldertreedelegateeditor.cpp
@@ -157,7 +157,6 @@ void FolderTreeDelegateEditor::updateDelegate()
 {
     auto displayName = m_index.data(NodeItem::Roles::DisplayText).toString();
     QFontMetrics fm(m_titleFont);
-    displayName = fm.elidedText(displayName, Qt::ElideRight, m_label->contentsRect().width());
     QString labelStyle;
     QString folderIconStyle;
 

--- a/src/labeledittype.cpp
+++ b/src/labeledittype.cpp
@@ -3,7 +3,7 @@
 #include <QBoxLayout>
 #include <QDebug>
 
-LabelEditType::LabelEditType(QWidget *parent) : QLabel(parent)
+LabelEditType::LabelEditType(QWidget *parent) : ElidedLabel(parent)
 {
     setContentsMargins(0, 0, 0, 0);
     m_editor = new QLineEdit(this);

--- a/src/labeledittype.h
+++ b/src/labeledittype.h
@@ -1,10 +1,10 @@
 #ifndef LABELEDITTYPE_H
 #define LABELEDITTYPE_H
 
-#include <QLabel>
+#include "elidedlabel.h"
 
 class QLineEdit;
-class LabelEditType : public QLabel
+class LabelEditType : public ElidedLabel
 {
     Q_OBJECT
 public:


### PR DESCRIPTION
fixed #647 