### PR TITLE
Fix memory leak, prevent corrupt database, fix typos in qml, various other fixes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -106,3 +106,7 @@ AlignEscapedNewlines: Left
 # initializer list in list-initialization.
 SpaceBeforeCpp11BracedList: false
 
+# Custom styles added by this project
+
+# fix for https://bugreports.qt.io/browse/QTCREATORBUG-31858
+StatementAttributeLikeMacros: [emit, Q_EMIT]

--- a/.github/workflows/format-lint.yml
+++ b/.github/workflows/format-lint.yml
@@ -7,7 +7,9 @@ on:
 jobs:
   lint:
     name: Format / Lint
-    runs-on: ubuntu-latest
+    # FIXME: ubuntu-latest has clang-format v18 which contains a bug: # https://bugreports.qt.io/browse/QTCREATORBUG-31858. 
+    # Update this once ubuntu ships clang-format v19
+    runs-on: ubuntu-22.04 
     strategy:
       fail-fast: false
     steps:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -266,7 +266,7 @@ jobs:
 
   snap:
     name: snap
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04 # FIXME: See this issue before updating to ubuntu-24.08: https://github.com/actions/runner-images/issues/9932
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ option(GIT_REVISION
 option(UPDATE_CHECKER
        "Enable or disable both the update checker and auto-updater" ON)
 option(PRO_VERSION "Enable or disable Notes Pro features" ON)
+option(ENABLE_ASAN "Enable address sanitizer" OFF)
 
 project(
   Notes
@@ -31,6 +32,13 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
+
+# address sanitizer can be enabled by running cmake with -DENABLE_ASAN=ON
+if(ENABLE_ASAN AND (CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
+                    OR CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
+  set(ADDRESS_SANITIZER_FLAGS "-fsanitize=address -fno-omit-frame-pointer")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${ADDRESS_SANITIZER_FLAGS}")
+endif()
 
 if(POLICY CMP0083)
   cmake_policy(SET CMP0083 NEW)
@@ -72,6 +80,10 @@ if(CMAKE_BUILD_TYPE STREQUAL "")
   message(STATUS "Build type: (not set)")
 else()
   message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
+endif()
+
+if(ENABLE_ASAN)
+  message(STATUS "Enabling AddressSanitizer")
 endif()
 
 set(GIT_REV "")

--- a/docs/build_options.md
+++ b/docs/build_options.md
@@ -10,6 +10,7 @@ You should set those while invoking CMake to build the project. See the [example
 | `GIT_REVISION`                             | `OFF`         | `ON` / `OFF`        | Append the current git revision to the app's version string |
 | `UPDATE_CHECKER`                           | `ON`          | `ON` / `OFF`        | Enable or disable both the update checker and auto-updater  |
 | `PRO_VERSION`                              | `ON`          | `ON` / `OFF`        | Enable or disable Notes Pro features                        |
+| `ENABLE_ASAN`                              | `OFF`         | `ON` / `OFF`        | Enable AddressSanitizer (ASan) for debugging                |
 
 ### Examples
 

--- a/src/dbmanager.cpp
+++ b/src/dbmanager.cpp
@@ -2502,9 +2502,8 @@ void DBManager::exportNotes(const QString &baseExportPath, const QString &extens
         counter = 1;
         while (directory.exists(filePath)) {
             filePath = QStringLiteral("%1%2%3 %4%5")
-                               .arg(notePath, QDir::separator(), safeTitle)
-                               .arg(counter++)
-                               .arg(extension);
+                               .arg(notePath, QDir::separator(), safeTitle,
+                                    QString::number(counter++), extension);
         }
 
         // qDebug() << "Exporting note:" << filePath;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1047,7 +1047,7 @@ void MainWindow::setupEditorSettings()
     m_editorSettingsQuickView.setResizeMode(QQuickView::SizeViewToRootObject);
     m_editorSettingsQuickView.setFlags(Qt::FramelessWindowHint);
     m_editorSettingsQuickView.setColor(Qt::transparent);
-    m_editorSettingsWidget = QWidget::createWindowContainer(&m_editorSettingsQuickView, nullptr);
+    m_editorSettingsWidget = QWidget::createWindowContainer(&m_editorSettingsQuickView, this);
 #if defined(Q_OS_MACOS)
 #  if QT_VERSION >= QT_VERSION_CHECK(6, 2, 0)
     m_editorSettingsWidget->setWindowFlags(Qt::Popup | Qt::FramelessWindowHint
@@ -1291,7 +1291,7 @@ void MainWindow::setupKanbanView()
     m_kanbanQuickView.rootContext()->setContextProperty("mainWindow", this);
     m_kanbanQuickView.setSource(source);
     m_kanbanQuickView.setResizeMode(QQuickView::SizeRootObjectToView);
-    m_kanbanWidget = QWidget::createWindowContainer(&m_kanbanQuickView);
+    m_kanbanWidget = QWidget::createWindowContainer(&m_kanbanQuickView, this);
     m_kanbanWidget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     m_kanbanWidget->hide();
     ui->verticalLayout_textEdit->insertWidget(ui->verticalLayout_textEdit->indexOf(m_textEdit),

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3918,10 +3918,7 @@ bool MainWindow::eventFilter(QObject *object, QEvent *event)
     }
     case QEvent::ActivationChange: {
         if (m_editorSettingsWidget->isHidden()) {
-            QApplication::setActiveWindow(
-                    this); // TODO: The docs say this function is deprecated but it's the only one
-                           // that works in returning the user input from m_editorSettingsWidget
-                           // Qt::Popup
+            QWidget::activateWindow();
             m_textEdit->setFocus();
         }
         break;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -129,7 +129,7 @@ MainWindow::MainWindow(QWidget *parent)
                                         "master/notes_purchase_data.json")),
       m_purchaseDataAlt2(
               QStringLiteral("https://www.rubymamistvalove.com/notes/notes_purchase_data.json")),
-      m_dataBuffer(new QByteArray()),
+      m_dataBuffer(std::make_unique<QByteArray>()),
       m_netManager(new QNetworkAccessManager(this)),
       m_reqAlt1(QNetworkRequest(QUrl(m_purchaseDataAlt1))),
       m_reqAlt2(QNetworkRequest(QUrl(m_purchaseDataAlt2))),
@@ -1737,12 +1737,12 @@ void MainWindow::setupDatabases()
 void MainWindow::setupModelView()
 {
     m_listView = ui->listView;
-    m_tagPool = new TagPool(m_dbManager);
+    m_tagPool = new TagPool(m_dbManager, this);
     m_listModel = new NoteListModel(m_listView);
     m_listView->setTagPool(m_tagPool);
     m_listView->setModel(m_listModel);
     m_listViewLogic = new ListViewLogic(m_listView, m_listModel, m_searchEdit, m_clearButton,
-                                        m_tagPool, m_dbManager, this);
+                                        m_tagPool, m_dbManager, m_listView);
     m_treeView = ui->treeView;
     m_treeView->setModel(m_treeModel);
     m_treeViewLogic = new TreeViewLogic(m_treeView, m_treeModel, m_dbManager, m_listView, this);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -262,7 +262,7 @@ private:
     QWindow *m_subscriptionWindow;
     QString m_purchaseDataAlt1;
     QString m_purchaseDataAlt2;
-    QByteArray *m_dataBuffer;
+    std::unique_ptr<QByteArray> m_dataBuffer;
     QNetworkAccessManager *m_netManager;
     QNetworkRequest m_reqAlt1;
     QNetworkRequest m_reqAlt2;

--- a/src/qml/EditorSettings.qml
+++ b/src/qml/EditorSettings.qml
@@ -47,7 +47,7 @@ Item {
             var settingsPaneHeightByParentWindow = 0.80 * data.parentWindowHeight; // 80 percent of the parent window's height
             settingsPane.height = scrollViewControl.contentHeight > settingsPaneHeightByParentWindow ? settingsPaneHeightByParentWindow : scrollViewControl.contentHeight;
             revealSettingsAnimation.start();
-            settingsContainer.upadteScrollBarPosition();
+            settingsContainer.updateScrollBarPosition();
         }
 
         function onMainWindowResized (data) {
@@ -164,7 +164,7 @@ Item {
         easing.type: Easing.InOutQuad
     }
 
-    function upadteScrollBarPosition () {
+    function updateScrollBarPosition () {
         editorSettingsVerticalScrollBar.position = settingsContainer.latestScrollBarPosition;
     }
 

--- a/src/qml/Utilities.js
+++ b/src/qml/Utilities.js
@@ -1,3 +1,4 @@
+.pragma library
 // It takes four arguments. The verb, which defines the HTTP verb to be used (GET, POST, PUT, DELETE).
 // The second paramater is the BASE address (e.g. ‘http://localhost:5000 (opens new window)’).
 // The third parameter is the endpoint to be used as a postfix to the BASE address

--- a/src/qml/kanbanMain.qml
+++ b/src/qml/kanbanMain.qml
@@ -789,7 +789,7 @@ Item {
 
                             onVisibleChanged: {
                                 if (editorSettingsPopupContainer.visible) {
-                                    editorSettings.upadteScrollBarPosition();
+                                    editorSettings.updateScrollBarPosition();
                                 }
                             }
                         }

--- a/src/treeviewlogic.cpp
+++ b/src/treeviewlogic.cpp
@@ -384,8 +384,22 @@ void TreeViewLogic::onMoveNodeRequested(int nodeId, int targetId)
     NodeData target;
     QMetaObject::invokeMethod(m_dbManager, "getNode", Qt::BlockingQueuedConnection,
                               Q_RETURN_ARG(NodeData, target), Q_ARG(int, targetId));
+    // only allow moving a node into a folder
     if (target.nodeType() != NodeData::Folder) {
         qDebug() << __FUNCTION__ << "Target is not folder!";
+        return;
+    }
+    // don't allow moving a node into itself (not sure how this can ever happen but just in case)
+    if (nodeId == targetId) {
+        qDebug() << __FUNCTION__ << "Can't move a node into itself";
+        return;
+    }
+    // don't allow moving a node into the same parent
+    NodeData node;
+    QMetaObject::invokeMethod(m_dbManager, "getNode", Qt::BlockingQueuedConnection,
+                              Q_RETURN_ARG(NodeData, node), Q_ARG(int, nodeId));
+    if (node.parentId() == targetId) {
+        qDebug() << __FUNCTION__ << "Can't move a node into the same parent";
         return;
     }
     emit requestMoveNodeInDB(nodeId, target);


### PR DESCRIPTION
I added an option to CMakeLists.txt to enable address sanitizer (first commit). I ran it and noticed the following memory leak when closing the main window:

```
=================================================================
==143229==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 24 byte(s) in 1 object(s) allocated from:
    #0 0x56a6832241b2 in operator new(unsigned long) (/home/zjeffer/git/notes/build/notes+0x2521b2) (BuildId: f3febbdce0342b087d8f64ae39d11f58ce6cd95c)
    #1 0x56a6833aadfb in MainWindow::MainWindow(QWidget*) /home/zjeffer/git/notes/src/mainwindow.cpp:132:20
    #2 0x56a6833a8184 in main /home/zjeffer/git/notes/src/main.cpp:96:16
    #3 0x7a8a82a34e07 in __libc_start_call_main /usr/src/debug/glibc/glibc/csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #4 0x7a8a82a34ecb in __libc_start_main /usr/src/debug/glibc/glibc/csu/../csu/libc-start.c:360:3
    #5 0x56a6830e5584 in _start (/home/zjeffer/git/notes/build/notes+0x113584) (BuildId: f3febbdce0342b087d8f64ae39d11f58ce6cd95c)

SUMMARY: AddressSanitizer: 24 byte(s) leaked in 1 allocation(s).
```
It's not much but it should be fixed either way, so I did that in the 3rd commit. We have lots more (and much bigger) memory leaks btw, will take a look at the others too.

* In the 2nd commit, I fixed a deprecation warning (setActiveWindow)
* In the 4th commit, I just fixed some typos in qml files.
* In the 5th commit, I fixed an issue where the folder structure can get corrupted in the database when moving a note into the same folder it's already in,  by simply returning early. I followed @guihkx [steps](https://github.com/nuttyartist/notes/issues/504#issuecomment-1595822308) with a non-empty note and could not reproduce the issue after this commit. It is still reproducable when moving an *empty* note into a folder.
* In the 6th commit, I fixed clang-formatting of the emit keyword
* In the 7th commit, I fixed some possible injection with .arg() chains
* In the 8th commit, I fixed a cmake warning
* In the 9th commit, I fixed a crash on exit (#730)

Closes #234
Closes #730 
Closes #727 
