### PR TITLE
CI/Linux: Update Ubuntu 23.10 image to Ubuntu 24.10

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -22,7 +22,7 @@ jobs:
             build-script: ubuntu_deb_entrypoint.sh
             build-type: release
 
-          - image: ubuntu-23_10
+          - image: ubuntu-24_10
             build-script: ubuntu_deb_entrypoint.sh
             build-type: release
     steps:

--- a/Dockerfiles/ubuntu-24_10
+++ b/Dockerfiles/ubuntu-24_10
@@ -1,10 +1,13 @@
 # vim: set syntax=dockerfile:
-FROM ubuntu:23.10
+FROM ubuntu:24.10
 
-LABEL org.opencontainers.image.description="Base image used to build and DEB-package Notes on Ubuntu 23.10"
+LABEL org.opencontainers.image.description="Base image used to build and DEB-package Notes on Ubuntu 24.10"
 
 # Prevent tzdata from asking for input.
 ENV DEBIAN_FRONTEND=noninteractive
+
+# Silences a locale-related warning from AutoUic.
+ENV LANG=C.UTF-8
 
 # Install dependencies.
 RUN apt-get update && \


### PR DESCRIPTION
23.10 (non-LTS) has been deprecated since July 11, 2024. This updates to 23.10 (also non-LTS).

Meta issue: #736