### PR TITLE
CI/Linux: Update Fedora 38 to 41

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -107,7 +107,7 @@ jobs:
       matrix:
         include:
           # Fedora's release cycle: https://endoflife.date/fedora
-          - image: fedora-38
+          - image: fedora-41
             build-script: rpm_entrypoint.sh
             build-type: release
 

--- a/Dockerfiles/fedora-41
+++ b/Dockerfiles/fedora-41
@@ -1,7 +1,7 @@
 # vim: set syntax=dockerfile:
-FROM fedora:38
+FROM fedora:41
 
-LABEL org.opencontainers.image.description="Base image used to build and RPM-package Notes on Fedora 38"
+LABEL org.opencontainers.image.description="Base image used to build and RPM-package Notes on Fedora 41"
 
 # Install dependencies.
 RUN dnf install -y --nodocs --noplugins --setopt=install_weak_deps=False \


### PR DESCRIPTION
Fedora 38 has been deprecated since May of 2024.

This updates to Fedora 41, which is the current version with planned official support until November of 2025.

Meta issue: #736