### PR TITLE
CI/Linux: Update openSUSE Leap 15.5 to 15.6

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -112,7 +112,7 @@ jobs:
             build-type: release
 
           # openSUSE's release cycle: https://endoflife.date/opensuse
-          - image: opensuse-15_5
+          - image: opensuse-15_6
             build-script: rpm_entrypoint.sh
             build-type: release
     steps:

--- a/Dockerfiles/opensuse-15_6
+++ b/Dockerfiles/opensuse-15_6
@@ -1,7 +1,7 @@
 # vim: set syntax=dockerfile:
-FROM opensuse/leap:15.5
+FROM opensuse/leap:15.6
 
-LABEL org.opencontainers.image.description="Base image used to build and RPM-package Notes on openSUSE 15.5"
+LABEL org.opencontainers.image.description="Base image used to build and RPM-package Notes on openSUSE 15.6"
 
 # Install dependencies.
 RUN zypper install -y --no-recommends cmake gcc10-c++ git \
@@ -11,6 +11,9 @@ RUN zypper install -y --no-recommends cmake gcc10-c++ git \
 # Because openSUSE allows multiple versions of GCC to be installed, we need to tell CMake which version to use.
 ENV CC=gcc-10
 ENV CXX=g++-10
+
+# Silences locale-related warnings from AutoUic.
+ENV LANG=C.UTF-8
 
 # Prevent a fatal error from git: "detected dubious ownership in repository at '/src'".
 RUN git config --global --add safe.directory /src


### PR DESCRIPTION
openSUSE Leap 15.5 has been deprecated since December of 2024.

Version 15.6 is the newest and support is expected until December of 2025.

Meta issue: #736