### PR TITLE
Fix SplitterStyle destruction causing memory leak

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -491,7 +491,7 @@ void MainWindow::setupMainWindow()
 #endif
     ui->listviewLabel1->setFont(titleFont);
     ui->listviewLabel2->setFont(titleFont);
-    m_splitterStyle = new SplitterStyle();
+    m_splitterStyle = new SplitterStyle(this);
     m_splitter->setStyle(m_splitterStyle);
     m_splitter->setHandleWidth(0);
     setNoteListLoading();

--- a/src/splitterstyle.cpp
+++ b/src/splitterstyle.cpp
@@ -1,6 +1,9 @@
 #include "splitterstyle.h"
 
-SplitterStyle::SplitterStyle() { }
+SplitterStyle::SplitterStyle(QObject *parent) : QProxyStyle()
+{
+    setParent(parent); // to ensure proper object destruction
+}
 
 void SplitterStyle::drawControl(ControlElement element, const QStyleOption *opt, QPainter *p,
                                 const QWidget *w) const

--- a/src/splitterstyle.h
+++ b/src/splitterstyle.h
@@ -5,13 +5,13 @@
 
 class SplitterStyle : public QProxyStyle
 {
+    Q_OBJECT
 public:
-    SplitterStyle();
+    SplitterStyle(QObject *parent);
 
-    // QStyle interface
 public:
-    virtual void drawControl(ControlElement element, const QStyleOption *opt, QPainter *p,
-                             const QWidget *w) const override;
+    void drawControl(ControlElement element, const QStyleOption *opt, QPainter *p,
+                     const QWidget *w) const override;
 };
 
 #endif // SPLITTERSTYLE_H


### PR DESCRIPTION
This is the only non-upstream memory leak left that was detected by address sanitizer, when simply opening and closing notes:

```
Indirect leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0x7a3eea8fe392 in operator new(unsigned long) /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_new_delete.cpp:95
    #1 0x7a3ee7e9d036 in QtSharedPointer::ExternalRefCountData::getAndRef(QObject const*) (/usr/lib/libQt6Core.so.6+0x29d036) (BuildId: d9624381d3e569b524ff85c4304a2ea24f573fd0)
    #2 0x7a3ee979901d in QProxyStyle::setBaseStyle(QStyle*) (/usr/lib/libQt6Widgets.so.6+0x19901d) (BuildId: 59ba6aa258636163a9e568cd20adc15c2deccce9)
    #3 0x7a3ee19fc995  (/usr/lib/qt6/plugins/styles/libqt6ct-style.so+0x3995) (BuildId: 53836c055c7ed35973419c2b26c4bd306ed9fbf8)
    #4 0x7a3ee19fcc7f  (/usr/lib/qt6/plugins/styles/libqt6ct-style.so+0x3c7f) (BuildId: 53836c055c7ed35973419c2b26c4bd306ed9fbf8)
    #5 0x7a3ee19fcd0a  (/usr/lib/qt6/plugins/styles/libqt6ct-style.so+0x3d0a) (BuildId: 53836c055c7ed35973419c2b26c4bd306ed9fbf8)
    #6 0x7a3ee979f243 in QStyleFactory::create(QString const&) (/usr/lib/libQt6Widgets.so.6+0x19f243) (BuildId: 59ba6aa258636163a9e568cd20adc15c2deccce9)
    #7 0x7a3ee979f48d  (/usr/lib/libQt6Widgets.so.6+0x19f48d) (BuildId: 59ba6aa258636163a9e568cd20adc15c2deccce9)
    #8 0x7a3ee979ff69 in QProxyStyle::polish(QWidget*) (/usr/lib/libQt6Widgets.so.6+0x19ff69) (BuildId: 59ba6aa258636163a9e568cd20adc15c2deccce9)
    #9 0x7a3ee97b364e  (/usr/lib/libQt6Widgets.so.6+0x1b364e) (BuildId: 59ba6aa258636163a9e568cd20adc15c2deccce9)
    #10 0x7a3ee973bc02 in QWidgetPrivate::setStyle_helper(QStyle*, bool) (/usr/lib/libQt6Widgets.so.6+0x13bc02) (BuildId: 59ba6aa258636163a9e568cd20adc15c2deccce9)
    #11 0x7a3ee973bd97 in QWidgetPrivate::setStyle_helper(QStyle*, bool) (/usr/lib/libQt6Widgets.so.6+0x13bd97) (BuildId: 59ba6aa258636163a9e568cd20adc15c2deccce9)
    #12 0x582dfc7b37e6 in MainWindow::setupMainWindow() /home/zjeffer/git/notes/src/mainwindow.cpp:495
    #13 0x582dfc7ad0b0 in MainWindow::MainWindow(QWidget*) /home/zjeffer/git/notes/src/mainwindow.cpp:145
    #14 0x582dfc7a98e9 in main /home/zjeffer/git/notes/src/main.cpp:96
    #15 0x7a3ee8235487  (/usr/lib/libc.so.6+0x27487) (BuildId: 695cfc6aac7d0f77bb7caba0ef01b2e868762b02)
    #16 0x7a3ee823554b in __libc_start_main (/usr/lib/libc.so.6+0x2754b) (BuildId: 695cfc6aac7d0f77bb7caba0ef01b2e868762b02)
    #17 0x582dfc62c194 in _start (/home/zjeffer/git/notes/build/notes+0x13a194) (BuildId: 80553ab0cf2410da235b1083d47a87d948d83e1f)
```