### PR TITLE
Cppcheck & clang-tidy fixes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -11,12 +11,11 @@
 # Webkit style was loosely based on the Qt style
 BasedOnStyle: WebKit
 
-Standard: c++14
+Standard: c++17
 
-# Column width is limited to 100 in accordance with Qt Coding Style.
+# Column width is normally 100 in the Qt Coding Style, but this is way too low.
 # https://wiki.qt.io/Qt_Coding_Style
-# Note that this may be changed at some point in the future.
-ColumnLimit: 100
+ColumnLimit: 160
 # How much weight do extra characters after the line length limit have.
 # PenaltyExcessCharacter: 4
 
@@ -82,7 +81,16 @@ AllowShortFunctionsOnASingleLine: Inline
 SortIncludes: false
 
 # macros for which the opening brace stays attached.
-ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH, forever, Q_FOREVER, QBENCHMARK, QBENCHMARK_ONCE ]
+ForEachMacros:
+    [
+        foreach,
+        Q_FOREACH,
+        BOOST_FOREACH,
+        forever,
+        Q_FOREVER,
+        QBENCHMARK,
+        QBENCHMARK_ONCE,
+    ]
 
 # Break constructor initializers before the colon and after the commas.
 BreakConstructorInitializers: BeforeColon

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,7 +129,6 @@ set(SOURCES
     ${PROJECT_SOURCE_DIR}/src/elidedlabel.h
     ${PROJECT_SOURCE_DIR}/src/foldertreedelegateeditor.cpp
     ${PROJECT_SOURCE_DIR}/src/foldertreedelegateeditor.h
-    ${PROJECT_SOURCE_DIR}/src/fontloader.cpp
     ${PROJECT_SOURCE_DIR}/src/fontloader.h
     ${PROJECT_SOURCE_DIR}/src/labeledittype.cpp
     ${PROJECT_SOURCE_DIR}/src/labeledittype.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,6 +182,7 @@ set(SOURCES
     ${PROJECT_SOURCE_DIR}/src/trashbuttondelegateeditor.h
     ${PROJECT_SOURCE_DIR}/src/treeviewlogic.cpp
     ${PROJECT_SOURCE_DIR}/src/treeviewlogic.h
+    ${PROJECT_SOURCE_DIR}/src/utils.h
     # ui
     ${PROJECT_SOURCE_DIR}/src/aboutwindow.ui
     ${PROJECT_SOURCE_DIR}/src/mainwindow.ui

--- a/src/aboutwindow.cpp
+++ b/src/aboutwindow.cpp
@@ -11,8 +11,7 @@
 /**
  * Initializes the window components and configures the AboutWindow
  */
-AboutWindow::AboutWindow(QWidget *parent)
-    : QDialog(parent), m_ui(new Ui::AboutWindow), m_isProVersion(false)
+AboutWindow::AboutWindow(QWidget *parent) : QDialog(parent), m_ui(new Ui::AboutWindow), m_isProVersion(false)
 {
     m_ui->setupUi(this);
     setWindowTitle(tr("About") + " " + QCoreApplication::applicationName());
@@ -22,13 +21,10 @@ AboutWindow::AboutWindow(QWidget *parent)
     m_ui->aboutText->setTextColor(QColor(26, 26, 26));
 
 #ifdef __APPLE__
-    QFont fontToUse = QFont(QStringLiteral("SF Pro Text")).exactMatch()
-            ? QStringLiteral("SF Pro Text")
-            : QStringLiteral("Roboto");
+    QFont fontToUse = QFont(QStringLiteral("SF Pro Text")).exactMatch() ? QStringLiteral("SF Pro Text") : QStringLiteral("Roboto");
     m_ui->aboutText->setFont(fontToUse);
 #elif _WIN32
-    QFont fontToUse = QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI")
-                                                                     : QStringLiteral("Roboto");
+    QFont fontToUse = QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI") : QStringLiteral("Roboto");
     m_ui->aboutText->setFont(fontToUse);
 #else
     m_ui->aboutText->setFont(QFont(QStringLiteral("Roboto")));
@@ -57,34 +53,33 @@ void AboutWindow::setAboutText()
 {
     QString proVersionText = m_isProVersion ? " (Pro Version)" : "";
 
-    m_ui->aboutText->setText(
-            "<strong>Version:</strong> " + QCoreApplication::applicationVersion() + proVersionText
-            + "<p>Notes was founded by <a href='https://rubymamistvalove.com'>Ruby "
-              "Mamistvalove</a>, "
-              "to create an elegant yet powerful cross-platform and open-source note-taking "
-              "app.</p><a href='https://www.notes-foss.com'>Notes Website"
-              "</a><br/><a href='https://github.com/nuttyartist/notes'>Source code on "
-              "Github</a><br/><a "
-              "href='https://www.notes-foss.com/notes-app-terms-privacy-policy'>Terms and Privacy "
-              "Policy</a><br/><br/><strong>Acknowledgments</strong><br/>This project couldn't "
-              "have "
-              "come this far without the help of these amazing "
-              "people:<br/><br/><strong>Programmers:</strong><br/>Alex Spataru<br/>Ali Diouri"
-              "<br/>David Planella<br/>Diep Ngoc<br/>Guilherme "
-              "Silva<br/>Thorbjørn Lindeijer<br/>Tuur Vanhoutte<br/>Waqar "
-              "Ahmed<br/><br/><strong>Designers:</strong><br/>Kevin Doyle<br/><br/>And to the "
-              "many of our beloved users who keep sending us feedback, you are an essential force "
-              "in "
-              "helping us improve, thank you!<br/><br/><strong>Notes makes use of the following "
-              "third-party libraries:</strong><br/><br/>QMarkdownTextEdit<br/>"
+    m_ui->aboutText->setText("<strong>Version:</strong> " + QCoreApplication::applicationVersion() + proVersionText
+                             + "<p>Notes was founded by <a href='https://rubymamistvalove.com'>Ruby "
+                               "Mamistvalove</a>, "
+                               "to create an elegant yet powerful cross-platform and open-source note-taking "
+                               "app.</p><a href='https://www.notes-foss.com'>Notes Website"
+                               "</a><br/><a href='https://github.com/nuttyartist/notes'>Source code on "
+                               "Github</a><br/><a "
+                               "href='https://www.notes-foss.com/notes-app-terms-privacy-policy'>Terms and Privacy "
+                               "Policy</a><br/><br/><strong>Acknowledgments</strong><br/>This project couldn't "
+                               "have "
+                               "come this far without the help of these amazing "
+                               "people:<br/><br/><strong>Programmers:</strong><br/>Alex Spataru<br/>Ali Diouri"
+                               "<br/>David Planella<br/>Diep Ngoc<br/>Guilherme "
+                               "Silva<br/>Thorbjørn Lindeijer<br/>Tuur Vanhoutte<br/>Waqar "
+                               "Ahmed<br/><br/><strong>Designers:</strong><br/>Kevin Doyle<br/><br/>And to the "
+                               "many of our beloved users who keep sending us feedback, you are an essential force "
+                               "in "
+                               "helping us improve, thank you!<br/><br/><strong>Notes makes use of the following "
+                               "third-party libraries:</strong><br/><br/>QMarkdownTextEdit<br/>"
 #if defined(UPDATE_CHECKER)
-              "QSimpleUpdater<br/>"
+                               "QSimpleUpdater<br/>"
 #endif
-              "QAutostart<br/>QXT<br/><br/><strong>Notes makes use of the following open source "
-              "fonts:</strong><br/><br/>Roboto<br/>Source Sans Pro<br/>Trykker<br/>Mate<br/>iA "
-              "Writer Mono<br/>iA Writer Duo<br/>iA Writer "
-              "Quattro<br/>Font Awesome<br/>Material Symbols<br/><br/><strong>Qt version:</strong> "
-            + qVersion() + " (built with " + QT_VERSION_STR + ")");
+                               "QAutostart<br/>QXT<br/><br/><strong>Notes makes use of the following open source "
+                               "fonts:</strong><br/><br/>Roboto<br/>Source Sans Pro<br/>Trykker<br/>Mate<br/>iA "
+                               "Writer Mono<br/>iA Writer Duo<br/>iA Writer "
+                               "Quattro<br/>Font Awesome<br/>Material Symbols<br/><br/><strong>Qt version:</strong> "
+                             + qVersion() + " (built with " + QT_VERSION_STR + ")");
 }
 
 void AboutWindow::setTheme(Theme::Value theme)

--- a/src/aboutwindow.h
+++ b/src/aboutwindow.h
@@ -4,7 +4,7 @@
 #include <QDialog>
 #include "editorsettingsoptions.h"
 
-namespace Ui {
+namespace Ui { // NOLINT(readability-identifier-naming)
 class AboutWindow;
 }
 
@@ -13,8 +13,8 @@ class AboutWindow : public QDialog
     Q_OBJECT
 
 public:
-    explicit AboutWindow(QWidget *parent = 0);
-    ~AboutWindow();
+    explicit AboutWindow(QWidget *parent = nullptr);
+    ~AboutWindow() override;
     void setTheme(Theme::Value theme);
     void setProVersion(bool isProVersion);
 

--- a/src/allnotebuttontreedelegateeditor.cpp
+++ b/src/allnotebuttontreedelegateeditor.cpp
@@ -76,8 +76,8 @@ void AllNoteButtonTreeDelegateEditor::paintEvent(QPaintEvent *event)
 #else
     int iconPointSizeOffset = -4;
 #endif
-    painter.setFont(FontLoader::getInstance().loadFont("Material Symbols Outlined", "",
-                                                       16 + iconPointSizeOffset));
+    painter.setFont(
+            font_loader::loadFont("Material Symbols Outlined", "", 16 + iconPointSizeOffset));
     painter.drawText(iconRect, iconPath); // folder
 
     if (m_view->selectionModel()->isSelected(m_index)) {

--- a/src/allnotebuttontreedelegateeditor.cpp
+++ b/src/allnotebuttontreedelegateeditor.cpp
@@ -8,21 +8,15 @@
 #include "editorsettingsoptions.h"
 #include "fontloader.h"
 
-AllNoteButtonTreeDelegateEditor::AllNoteButtonTreeDelegateEditor(QTreeView *view,
-                                                                 const QStyleOptionViewItem &option,
-                                                                 const QModelIndex &index,
-                                                                 QListView *listView,
-                                                                 QWidget *parent)
+AllNoteButtonTreeDelegateEditor::AllNoteButtonTreeDelegateEditor(QTreeView *view, const QStyleOptionViewItem &option, const QModelIndex &index,
+                                                                 QListView *listView, QWidget *parent)
     : QWidget(parent),
       m_option(option),
       m_index(index),
 #ifdef __APPLE__
-      m_displayFont(QFont(QStringLiteral("SF Pro Text")).exactMatch()
-                            ? QStringLiteral("SF Pro Text")
-                            : QStringLiteral("Roboto")),
+      m_displayFont(QFont(QStringLiteral("SF Pro Text")).exactMatch() ? QStringLiteral("SF Pro Text") : QStringLiteral("Roboto")),
 #elif _WIN32
-      m_displayFont(QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI")
-                                                                   : QStringLiteral("Roboto")),
+      m_displayFont(QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI") : QStringLiteral("Roboto")),
 #else
       m_displayFont(QStringLiteral("Roboto")),
 #endif
@@ -41,7 +35,8 @@ AllNoteButtonTreeDelegateEditor::AllNoteButtonTreeDelegateEditor(QTreeView *view
       m_numberOfNotesColor(26, 26, 26, 127),
       m_numberOfNotesSelectedColor(255, 255, 255),
       m_view(view),
-      m_listView(listView)
+      m_listView(listView),
+      m_theme(Theme::Light)
 {
     setContentsMargins(0, 0, 0, 0);
 }
@@ -49,7 +44,7 @@ AllNoteButtonTreeDelegateEditor::AllNoteButtonTreeDelegateEditor(QTreeView *view
 void AllNoteButtonTreeDelegateEditor::paintEvent(QPaintEvent *event)
 {
     QPainter painter(this);
-    auto iconRect = QRect(rect().x() + 22, rect().y() + (rect().height() - 20) / 2, 18, 20);
+    auto iconRect = QRect(rect().x() + 22, rect().y() + ((rect().height() - 20) / 2), 18, 20);
     auto iconPath = m_index.data(NodeItem::Roles::Icon).toString();
     auto displayName = m_index.data(NodeItem::Roles::DisplayText).toString();
     QRect nameRect(rect());
@@ -59,7 +54,7 @@ void AllNoteButtonTreeDelegateEditor::paintEvent(QPaintEvent *event)
         painter.fillRect(rect(), QBrush(m_activeColor));
         painter.setPen(m_titleSelectedColor);
     } else {
-        auto listView = dynamic_cast<NoteListView *>(m_listView);
+        auto const *listView = static_cast<NoteListView *>(m_listView);
         if (listView->isDragging()) {
             if (m_theme == Theme::Dark) {
                 painter.fillRect(rect(), QBrush(QColor(35, 52, 69)));
@@ -76,8 +71,7 @@ void AllNoteButtonTreeDelegateEditor::paintEvent(QPaintEvent *event)
 #else
     int iconPointSizeOffset = -4;
 #endif
-    painter.setFont(
-            font_loader::loadFont("Material Symbols Outlined", "", 16 + iconPointSizeOffset));
+    painter.setFont(font_loader::loadFont("Material Symbols Outlined", "", 16 + iconPointSizeOffset));
     painter.drawText(iconRect, iconPath); // folder
 
     if (m_view->selectionModel()->isSelected(m_index)) {
@@ -98,8 +92,7 @@ void AllNoteButtonTreeDelegateEditor::paintEvent(QPaintEvent *event)
         painter.setPen(m_numberOfNotesColor);
     }
     painter.setFont(m_numberOfNotesFont);
-    painter.drawText(childCountRect, Qt::AlignHCenter | Qt::AlignVCenter,
-                     QString::number(childCount));
+    painter.drawText(childCountRect, Qt::AlignHCenter | Qt::AlignVCenter, QString::number(childCount));
     QWidget::paintEvent(event);
 }
 

--- a/src/allnotebuttontreedelegateeditor.h
+++ b/src/allnotebuttontreedelegateeditor.h
@@ -14,8 +14,7 @@ class AllNoteButtonTreeDelegateEditor : public QWidget
 {
     Q_OBJECT
 public:
-    explicit AllNoteButtonTreeDelegateEditor(QTreeView *view, const QStyleOptionViewItem &option,
-                                             const QModelIndex &index, QListView *listView,
+    explicit AllNoteButtonTreeDelegateEditor(QTreeView *view, const QStyleOptionViewItem &option, const QModelIndex &index, QListView *listView,
                                              QWidget *parent = nullptr);
     void setTheme(Theme::Value theme);
 

--- a/src/allnotebuttontreedelegateeditor.h
+++ b/src/allnotebuttontreedelegateeditor.h
@@ -36,7 +36,7 @@ private:
     Theme::Value m_theme;
     // QWidget interface
 protected:
-    virtual void paintEvent(QPaintEvent *event) override;
+    void paintEvent(QPaintEvent *event) override;
 };
 
 #endif // ALLNOTEBUTTONTREEDELEGATEEDITOR_H

--- a/src/customDocument.h
+++ b/src/customDocument.h
@@ -10,9 +10,9 @@ class CustomDocument : public QTextEdit
     Q_OBJECT
 
 public:
-    CustomDocument(QWidget *parent = nullptr);
+    explicit CustomDocument(QWidget *parent);
     void setDocumentPadding(int left, int top, int right, int bottom);
-    bool eventFilter(QObject *obj, QEvent *event);
+    bool eventFilter(QObject *obj, QEvent *event) override;
     bool openLinkAtCursorPosition();
     QString getMarkdownUrlAtPosition(const QString &text, int position);
     bool isValidUrl(const QString &urlString);
@@ -27,8 +27,8 @@ signals:
 
     // QWidget interface
 protected:
-    void resizeEvent(QResizeEvent *event);
-    void mouseMoveEvent(QMouseEvent *event);
+    void resizeEvent(QResizeEvent *event) override;
+    void mouseMoveEvent(QMouseEvent *event) override;
 
     QStringList _ignoredClickUrlSchemata;
 };

--- a/src/customMarkdownHighlighter.cpp
+++ b/src/customMarkdownHighlighter.cpp
@@ -1,8 +1,7 @@
 #include "customMarkdownHighlighter.h"
 #include "editorsettingsoptions.h"
 
-CustomMarkdownHighlighter::CustomMarkdownHighlighter(QTextDocument *parent,
-                                                     HighlightingOptions highlightingOptions)
+CustomMarkdownHighlighter::CustomMarkdownHighlighter(QTextDocument *parent, HighlightingOptions highlightingOptions)
     : MarkdownHighlighter(parent, highlightingOptions)
 {
     setListsColor(QColor(35, 131, 226)); // accent color
@@ -34,16 +33,13 @@ void CustomMarkdownHighlighter::setFontSize(qreal fontSize)
     }
 
     qreal codeBlockFontSize = fontSize - 4;
-    _formats[static_cast<HighlighterState>(HighlighterState::InlineCodeBlock)].setFontPointSize(
-            codeBlockFontSize);
+    _formats[static_cast<HighlighterState>(HighlighterState::InlineCodeBlock)].setFontPointSize(codeBlockFontSize);
 }
 
 void CustomMarkdownHighlighter::setListsColor(QColor color)
 {
-    _formats[static_cast<HighlighterState>(HighlighterState::CheckBoxUnChecked)].setForeground(
-            color);
-    _formats[static_cast<HighlighterState>(HighlighterState::CheckBoxChecked)].setForeground(
-            QColor(90, 113, 140));
+    _formats[static_cast<HighlighterState>(HighlighterState::CheckBoxUnChecked)].setForeground(color);
+    _formats[static_cast<HighlighterState>(HighlighterState::CheckBoxChecked)].setForeground(QColor(90, 113, 140));
     _formats[static_cast<HighlighterState>(HighlighterState::List)].setForeground(color);
     _formats[static_cast<HighlighterState>(HighlighterState::BlockQuote)].setForeground(color);
 }
@@ -53,25 +49,19 @@ void CustomMarkdownHighlighter::setTheme(Theme::Value theme, QColor textColor, q
     setHeaderColors(textColor);
     setFontSize(fontSize);
 
+    auto &icBlock = _formats[static_cast<HighlighterState>(HighlighterState::InlineCodeBlock)];
     switch (theme) {
     case Theme::Light:
-        _formats[static_cast<HighlighterState>(HighlighterState::InlineCodeBlock)].setBackground(
-                QColor(239, 241, 243));
-        _formats[static_cast<HighlighterState>(HighlighterState::InlineCodeBlock)].setForeground(
-                QColor(42, 46, 51));
+        icBlock.setBackground(QColor(239, 241, 243));
+        icBlock.setForeground(QColor(42, 46, 51));
         break;
     case Theme::Dark:
-        _formats[static_cast<HighlighterState>(HighlighterState::InlineCodeBlock)].setBackground(
-                QColor(52, 57, 66));
-        _formats[static_cast<HighlighterState>(HighlighterState::InlineCodeBlock)].setForeground(
-                QColor(230, 237, 243));
+        icBlock.setBackground(QColor(52, 57, 66));
+        icBlock.setForeground(QColor(230, 237, 243));
         break;
     case Theme::Sepia:
-        _formats[static_cast<HighlighterState>(HighlighterState::InlineCodeBlock)].setBackground(
-                QColor(239, 241, 243));
-        _formats[static_cast<HighlighterState>(HighlighterState::InlineCodeBlock)].setForeground(
-                QColor(42, 46, 51));
-        break;
+        icBlock.setBackground(QColor(239, 241, 243));
+        icBlock.setForeground(QColor(42, 46, 51));
         break;
     }
 }

--- a/src/customMarkdownHighlighter.h
+++ b/src/customMarkdownHighlighter.h
@@ -6,8 +6,7 @@
 class CustomMarkdownHighlighter : public MarkdownHighlighter
 {
 public:
-    CustomMarkdownHighlighter(QTextDocument *parent = nullptr,
-                              HighlightingOptions highlightingOptions = HighlightingOption::None);
+    explicit CustomMarkdownHighlighter(QTextDocument *parent, HighlightingOptions highlightingOptions = HighlightingOption::None);
     ~CustomMarkdownHighlighter() override = default;
 
     void setFontSize(qreal fontSize);

--- a/src/customapplicationstyle.cpp
+++ b/src/customapplicationstyle.cpp
@@ -3,8 +3,7 @@
 #include <QStyleOption>
 #include "editorsettingsoptions.h"
 
-void CustomApplicationStyle::drawPrimitive(PrimitiveElement element, const QStyleOption *option,
-                                           QPainter *painter, const QWidget *widget) const
+void CustomApplicationStyle::drawPrimitive(PrimitiveElement element, const QStyleOption *option, QPainter *painter, const QWidget *widget) const
 {
     if (element == QStyle::PE_IndicatorItemViewItemDrop) {
         painter->setRenderHint(QPainter::Antialiasing, true);

--- a/src/customapplicationstyle.h
+++ b/src/customapplicationstyle.h
@@ -9,8 +9,7 @@ class CustomApplicationStyle : public QProxyStyle
 public:
     CustomApplicationStyle();
 
-    void drawPrimitive(PrimitiveElement element, const QStyleOption *option, QPainter *painter,
-                       const QWidget *widget) const;
+    void drawPrimitive(PrimitiveElement element, const QStyleOption *option, QPainter *painter, const QWidget *widget) const;
     void setTheme(Theme::Value theme);
 
 private:

--- a/src/customapplicationstyle.h
+++ b/src/customapplicationstyle.h
@@ -9,7 +9,7 @@ class CustomApplicationStyle : public QProxyStyle
 public:
     CustomApplicationStyle();
 
-    void drawPrimitive(PrimitiveElement element, const QStyleOption *option, QPainter *painter, const QWidget *widget) const;
+    void drawPrimitive(PrimitiveElement element, const QStyleOption *option, QPainter *painter, const QWidget *widget) const override;
     void setTheme(Theme::Value theme);
 
 private:

--- a/src/customdocument.cpp
+++ b/src/customdocument.cpp
@@ -46,8 +46,7 @@ bool CustomDocument::eventFilter(QObject *obj, QEvent *event)
 
     if (event->type() == QEvent::HoverMove) {
         // if hovering and the control key is active, check whether the mouse is over a link
-        if (QGuiApplication::keyboardModifiers() == Qt::ExtraButton24
-            && getUrlUnderMouse().isValid()) {
+        if (QGuiApplication::keyboardModifiers() == Qt::ExtraButton24 && getUrlUnderMouse().isValid()) {
             viewport()->setCursor(Qt::PointingHandCursor);
         } else {
             viewport()->setCursor(Qt::IBeamCursor);
@@ -74,8 +73,7 @@ bool CustomDocument::eventFilter(QObject *obj, QEvent *event)
         auto *mouseEvent = static_cast<QMouseEvent *>(event);
 
         // track `Ctrl + Click` in the text edit
-        if ((obj == viewport()) && (mouseEvent->button() == Qt::LeftButton)
-            && (QGuiApplication::keyboardModifiers() == Qt::ExtraButton24)) {
+        if ((obj == viewport()) && (mouseEvent->button() == Qt::LeftButton) && (QGuiApplication::keyboardModifiers() == Qt::ExtraButton24)) {
             // open the link (if any) at the current position
             // in the noteTextEdit
 
@@ -168,8 +166,7 @@ bool CustomDocument::openLinkAtCursorPosition()
 
     const bool convertLocalFilepathsToURLs = true;
 
-    if ((url.isValid() && isValidUrl(urlString)) || isFileUrl || isLocalFilePath
-        || isLegacyAttachmentUrl) {
+    if ((url.isValid() && isValidUrl(urlString)) || isFileUrl || isLocalFilePath || isLegacyAttachmentUrl) {
 
         if (_ignoredClickUrlSchemata.contains(url.scheme())) {
             qDebug() << __func__ << "ignored URL scheme:" << urlString;
@@ -182,9 +179,7 @@ bool CustomDocument::openLinkAtCursorPosition()
             if (!QFile::exists(trimmed)) {
                 qDebug() << __func__ << ": File does not exist:" << urlString;
                 // show a message box
-                QMessageBox::warning(
-                        nullptr, tr("File not found"),
-                        tr("The file <strong>%1</strong> does not exist.").arg(trimmed));
+                QMessageBox::warning(nullptr, tr("File not found"), tr("The file <strong>%1</strong> does not exist.").arg(trimmed));
                 return false;
             }
         }
@@ -192,8 +187,7 @@ bool CustomDocument::openLinkAtCursorPosition()
         if (isLocalFilePath && !QFile::exists(urlString)) {
             qDebug() << __func__ << ": File does not exist:" << urlString;
             // show a message box
-            QMessageBox::warning(nullptr, tr("File not found"),
-                                 tr("The file <strong>%1</strong> does not exist.").arg(urlString));
+            QMessageBox::warning(nullptr, tr("File not found"), tr("The file <strong>%1</strong> does not exist.").arg(urlString));
             return false;
         }
 
@@ -296,8 +290,7 @@ QMap<QString, QString> CustomDocument::parseMarkdownUrlsFromText(const QString &
         QString linkText = match.captured(1);
         QString referenceId = match.captured(2);
 
-        QRegularExpression refRegExp(
-                QStringLiteral("\\[%1\\]: (.+)").arg(QRegularExpression::escape(referenceId)));
+        QRegularExpression refRegExp(QStringLiteral("\\[%1\\]: (.+)").arg(QRegularExpression::escape(referenceId)));
         QRegularExpressionMatch urlMatch = refRegExp.match(toPlainText());
 
         if (urlMatch.hasMatch()) {

--- a/src/customdocument.cpp
+++ b/src/customdocument.cpp
@@ -63,7 +63,8 @@ bool CustomDocument::eventFilter(QObject *obj, QEvent *event)
             if (keyEvent->key() == Qt::Key_Up) {
                 moveBlockUp();
                 return true;
-            } else if (keyEvent->key() == Qt::Key_Down) {
+            }
+            if (keyEvent->key() == Qt::Key_Down) {
                 moveBlockDown();
                 return true;
             }
@@ -147,7 +148,7 @@ QUrl CustomDocument::getUrlUnderMouse()
     cursor.movePosition(QTextCursor::EndOfBlock, QTextCursor::KeepAnchor);
 
     // get the correct link from the selected text, or an empty URL if none found
-    return QUrl(getMarkdownUrlAtPosition(cursor.selectedText(), indexInBlock));
+    return { getMarkdownUrlAtPosition(cursor.selectedText(), indexInBlock) };
 }
 
 /**

--- a/src/dbmanager.cpp
+++ b/src/dbmanager.cpp
@@ -1228,7 +1228,7 @@ void DBManager::moveNode(int nodeId, const NodeData &target)
     }
 
     if (node.nodeType() == NodeData::Type::Folder) {
-        QString oldAbsolutePath = node.absolutePath();
+        const QString &oldAbsolutePath = node.absolutePath();
         QMap<int, QString> children;
         query.clear();
         if (!query.prepare(R"(SELECT id, absolute_path FROM "node_table" )"
@@ -1415,7 +1415,7 @@ void DBManager::searchForNotes(const QString &keyword, const ListViewInfo &inf)
             }
             nds.append(nd);
         }
-        if (nds.size() == 0) {
+        if (nds.empty()) {
             emit notesListReceived(nodeList, inf);
             return;
         }
@@ -1771,7 +1771,7 @@ void DBManager::onNotesListInTagsRequested(const QSet<int> &tagIds, bool newNote
         }
         nds.append(nd);
     }
-    if (nds.size() == 0) {
+    if (nds.empty()) {
         emit notesListReceived(nodeList, inf);
         return;
     }
@@ -1885,7 +1885,7 @@ void DBManager::onImportNotesRequested(const QString &fileName)
                 qDebug() << __FUNCTION__ << __LINE__ << outQuery.lastError();
             }
             outQuery.finish();
-            std::sort(tagList.begin(), tagList.end(), [](auto a, auto b) { return a.relativePosition() < b.relativePosition(); });
+            std::sort(tagList.begin(), tagList.end(), [](auto const &a, auto const &b) { return a.relativePosition() < b.relativePosition(); });
             for (const auto &tag : std::as_const(tagList)) {
                 QSqlQuery query(m_db);
                 if (!query.prepare(R"(SELECT "id" FROM tag_table WHERE name = :name AND color = :color;)")) {

--- a/src/dbmanager.h
+++ b/src/dbmanager.h
@@ -28,6 +28,13 @@ struct ListViewInfo
     int scrollToId;
 };
 
+struct Folder
+{
+    int id;
+    int parentId;
+    std::vector<Folder *> children;
+};
+
 using FolderListType = QMap<int, QString>;
 
 class DBManager : public QObject
@@ -39,7 +46,7 @@ public:
     Q_INVOKABLE NodeData getNode(int nodeId);
     Q_INVOKABLE void moveFolderToTrash(const NodeData &node);
     Q_INVOKABLE FolderListType getFolderList();
-    void exportNotes(const QString &exportPath, const QString &extension);
+    void exportNotes(const QString &baseExportPath, const QString &extension);
     void addNotesToNewImportedFolder(const QList<QPair<QString, QDateTime>> &fileDatas);
 
 private:
@@ -80,10 +87,8 @@ signals:
 
 public slots:
     void onNodeTagTreeRequested();
-    void onNotesListInFolderRequested(int parentID, bool isRecursive, bool newNote = false,
-                                      int scrollToId = SpecialNodeID::InvalidNodeId);
-    void onNotesListInTagsRequested(const QSet<int> &tagIds, bool newNote = false,
-                                    int scrollToId = SpecialNodeID::InvalidNodeId);
+    void onNotesListInFolderRequested(int parentID, bool isRecursive, bool newNote = false, int scrollToId = SpecialNodeID::InvalidNodeId);
+    void onNotesListInTagsRequested(const QSet<int> &tagIds, bool newNote = false, int scrollToId = SpecialNodeID::InvalidNodeId);
     void onOpenDBManagerRequested(const QString &path, bool doCreate);
     void onCreateUpdateRequestedNoteContent(const NodeData &note);
     void onImportNotesRequested(const QString &fileName);

--- a/src/dbmanager.h
+++ b/src/dbmanager.h
@@ -87,8 +87,8 @@ signals:
 
 public slots:
     void onNodeTagTreeRequested();
-    void onNotesListInFolderRequested(int parentID, bool isRecursive, bool newNote = false, int scrollToId = SpecialNodeID::InvalidNodeId);
-    void onNotesListInTagsRequested(const QSet<int> &tagIds, bool newNote = false, int scrollToId = SpecialNodeID::InvalidNodeId);
+    void onNotesListInFolderRequested(int parentID, bool isRecursive, bool newNote = false, int scrollToId = INVALID_NODE_ID);
+    void onNotesListInTagsRequested(const QSet<int> &tagIds, bool newNote = false, int scrollToId = INVALID_NODE_ID);
     void onOpenDBManagerRequested(const QString &path, bool doCreate);
     void onCreateUpdateRequestedNoteContent(const NodeData &note);
     void onImportNotesRequested(const QString &fileName);

--- a/src/defaultnotefolderdelegateeditor.cpp
+++ b/src/defaultnotefolderdelegateeditor.cpp
@@ -7,21 +7,15 @@
 #include "editorsettingsoptions.h"
 #include "fontloader.h"
 
-DefaultNoteFolderDelegateEditor::DefaultNoteFolderDelegateEditor(QTreeView *view,
-                                                                 const QStyleOptionViewItem &option,
-                                                                 const QModelIndex &index,
-                                                                 QListView *listView,
-                                                                 QWidget *parent)
+DefaultNoteFolderDelegateEditor::DefaultNoteFolderDelegateEditor(QTreeView *view, const QStyleOptionViewItem &option, const QModelIndex &index,
+                                                                 QListView *listView, QWidget *parent)
     : QWidget(parent),
       m_option(option),
       m_index(index),
 #ifdef __APPLE__
-      m_displayFont(QFont(QStringLiteral("SF Pro Text")).exactMatch()
-                            ? QStringLiteral("SF Pro Text")
-                            : QStringLiteral("Roboto")),
+      m_displayFont(QFont(QStringLiteral("SF Pro Text")).exactMatch() ? QStringLiteral("SF Pro Text") : QStringLiteral("Roboto")),
 #elif _WIN32
-      m_displayFont(QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI")
-                                                                   : QStringLiteral("Roboto")),
+      m_displayFont(QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI") : QStringLiteral("Roboto")),
 #else
       m_displayFont(QStringLiteral("Roboto")),
 #endif
@@ -40,7 +34,8 @@ DefaultNoteFolderDelegateEditor::DefaultNoteFolderDelegateEditor(QTreeView *view
       m_numberOfNotesColor(26, 26, 26, 127),
       m_numberOfNotesSelectedColor(255, 255, 255),
       m_view(view),
-      m_listView(listView)
+      m_listView(listView),
+      m_theme(Theme::Light)
 {
     setContentsMargins(0, 0, 0, 0);
 }
@@ -48,7 +43,7 @@ DefaultNoteFolderDelegateEditor::DefaultNoteFolderDelegateEditor(QTreeView *view
 void DefaultNoteFolderDelegateEditor::paintEvent(QPaintEvent *event)
 {
     QPainter painter(this);
-    auto iconRect = QRect(rect().x() + 4, rect().y() + (rect().height() - 20) / 2, 20, 20);
+    auto iconRect = QRect(rect().x() + 4, rect().y() + ((rect().height() - 20) / 2), 20, 20);
 
     QRect folderIconRect(rect());
     folderIconRect.setLeft(iconRect.x() + iconRect.width());
@@ -58,7 +53,7 @@ void DefaultNoteFolderDelegateEditor::paintEvent(QPaintEvent *event)
         painter.fillRect(rect(), QBrush(m_activeColor));
         painter.setPen(m_titleSelectedColor);
     } else {
-        auto listView = dynamic_cast<NoteListView *>(m_listView);
+        auto const *listView = static_cast<NoteListView *>(m_listView);
         if (listView->isDragging()) {
             if (m_theme == Theme::Dark) {
                 painter.fillRect(rect(), QBrush(QColor(35, 52, 69)));
@@ -75,8 +70,7 @@ void DefaultNoteFolderDelegateEditor::paintEvent(QPaintEvent *event)
 #else
     int iconPointSizeOffset = -4;
 #endif
-    painter.setFont(font_loader::loadFont("Material Symbols Outlined", "",
-                                                       16 + iconPointSizeOffset));
+    painter.setFont(font_loader::loadFont("Material Symbols Outlined", "", 16 + iconPointSizeOffset));
     painter.drawText(folderIconRect, u8"\ue2c7"); // folder
 
     QRect nameRect(rect());
@@ -104,8 +98,7 @@ void DefaultNoteFolderDelegateEditor::paintEvent(QPaintEvent *event)
         painter.setPen(m_numberOfNotesColor);
     }
     painter.setFont(m_numberOfNotesFont);
-    painter.drawText(childCountRect, Qt::AlignHCenter | Qt::AlignVCenter,
-                     QString::number(childCount));
+    painter.drawText(childCountRect, Qt::AlignHCenter | Qt::AlignVCenter, QString::number(childCount));
     QWidget::paintEvent(event);
 }
 

--- a/src/defaultnotefolderdelegateeditor.cpp
+++ b/src/defaultnotefolderdelegateeditor.cpp
@@ -75,7 +75,7 @@ void DefaultNoteFolderDelegateEditor::paintEvent(QPaintEvent *event)
 #else
     int iconPointSizeOffset = -4;
 #endif
-    painter.setFont(FontLoader::getInstance().loadFont("Material Symbols Outlined", "",
+    painter.setFont(font_loader::loadFont("Material Symbols Outlined", "",
                                                        16 + iconPointSizeOffset));
     painter.drawText(folderIconRect, u8"\ue2c7"); // folder
 

--- a/src/defaultnotefolderdelegateeditor.h
+++ b/src/defaultnotefolderdelegateeditor.h
@@ -14,8 +14,7 @@ class DefaultNoteFolderDelegateEditor : public QWidget
 {
     Q_OBJECT
 public:
-    explicit DefaultNoteFolderDelegateEditor(QTreeView *view, const QStyleOptionViewItem &option,
-                                             const QModelIndex &index, QListView *listView,
+    explicit DefaultNoteFolderDelegateEditor(QTreeView *view, const QStyleOptionViewItem &option, const QModelIndex &index, QListView *listView,
                                              QWidget *parent = nullptr);
     void setTheme(Theme::Value theme);
 

--- a/src/defaultnotefolderdelegateeditor.h
+++ b/src/defaultnotefolderdelegateeditor.h
@@ -36,7 +36,7 @@ private:
     Theme::Value m_theme;
     // QWidget interface
 protected:
-    virtual void paintEvent(QPaintEvent *event) override;
+    void paintEvent(QPaintEvent *event) override;
 };
 
 #endif // DEFAULTNOTEFOLDERDELEGATEEDITOR_H

--- a/src/editorsettingsoptions.cpp
+++ b/src/editorsettingsoptions.cpp
@@ -4,7 +4,7 @@
 #include <qdebug.h>
 #include <sstream>
 
-EditorSettingsOptions::EditorSettingsOptions(QObject *) { }
+EditorSettingsOptions::EditorSettingsOptions(QObject *parent) : QObject(parent) { }
 
 std::ostream &operator<<(std::ostream &os, const FontTypeface::Value &fontTypeface)
 {

--- a/src/editorsettingsoptions.cpp
+++ b/src/editorsettingsoptions.cpp
@@ -2,6 +2,7 @@
 #include <QStyle>
 #include <QVariant>
 #include <qdebug.h>
+#include <sstream>
 
 EditorSettingsOptions::EditorSettingsOptions(QObject *) { }
 
@@ -56,11 +57,10 @@ void setCSSThemeAndUpdate(QWidget *obj, Theme::Value theme)
     setCSSClassesAndUpdate(obj, QString::fromStdString(to_string(theme)).toLower().toStdString());
 }
 
-void setCSSClassesAndUpdate(QWidget *obj, std::string classNames)
+void setCSSClassesAndUpdate(QWidget *obj, std::string const &classNames)
 {
     if (obj->styleSheet().isEmpty()) {
-        qWarning() << "setCSSClassesAndUpdate: styleSheet is empty for widget with name "
-                   << obj->objectName();
+        qWarning() << "setCSSClassesAndUpdate: styleSheet is empty for widget with name " << obj->objectName();
     }
     // set the class
     obj->setProperty("class", classNames.c_str());

--- a/src/editorsettingsoptions.h
+++ b/src/editorsettingsoptions.h
@@ -3,7 +3,6 @@
 
 #include <QObject>
 #include <QtQml/qqml.h>
-#include <sstream>
 #include <QString>
 #include <QWidget>
 #include "lqtutils_enum.h"
@@ -28,6 +27,6 @@ std::string to_string(FontTypeface::Value fontTypeface);
 std::string to_string(Theme::Value theme);
 
 void setCSSThemeAndUpdate(QWidget *obj, Theme::Value theme);
-void setCSSClassesAndUpdate(QWidget *obj, std::string classNames);
+void setCSSClassesAndUpdate(QWidget *obj, const std::string &classNames);
 
 #endif

--- a/src/elidedlabel.cpp
+++ b/src/elidedlabel.cpp
@@ -6,20 +6,20 @@
 ElidedLabel::ElidedLabel(QWidget *parent, Qt::WindowFlags f) : ElidedLabel("", parent, f) { }
 
 ElidedLabel::ElidedLabel(const QString &text, QWidget *parent, Qt::WindowFlags f)
-    : QLabel(text, parent, f), original(""), defaultType(Qt::ElideRight), eliding(false)
+    : QLabel(text, parent, f), m_original(""), m_defaultType(Qt::ElideRight), m_eliding(false)
 {
     setText(text);
 }
 
-void ElidedLabel::setType(const Qt::TextElideMode type)
+void ElidedLabel::setType(Qt::TextElideMode type)
 {
-    defaultType = type;
+    m_defaultType = type;
     elide();
 }
 
 QString const &ElidedLabel::text() const
 {
-    return original;
+    return m_original;
 }
 
 void ElidedLabel::resizeEvent(QResizeEvent *event)
@@ -31,7 +31,7 @@ void ElidedLabel::resizeEvent(QResizeEvent *event)
 
 void ElidedLabel::setText(const QString &text)
 {
-    original = text;
+    m_original = text;
     QLabel::setText(text);
 
     elide();
@@ -39,12 +39,12 @@ void ElidedLabel::setText(const QString &text)
 
 void ElidedLabel::elide()
 {
-    if (!eliding) {
-        eliding = true;
+    if (!m_eliding) {
+        m_eliding = true;
 
         QFontMetrics metrics(font());
-        QLabel::setText(metrics.elidedText(original, defaultType, width()));
+        QLabel::setText(metrics.elidedText(m_original, m_defaultType, width()));
 
-        eliding = false;
+        m_eliding = false;
     }
 }

--- a/src/elidedlabel.cpp
+++ b/src/elidedlabel.cpp
@@ -17,7 +17,7 @@ void ElidedLabel::setType(const Qt::TextElideMode type)
     elide();
 }
 
-QString ElidedLabel::text() const
+QString const &ElidedLabel::text() const
 {
     return original;
 }
@@ -39,7 +39,7 @@ void ElidedLabel::setText(const QString &text)
 
 void ElidedLabel::elide()
 {
-    if (eliding == false) {
+    if (!eliding) {
         eliding = true;
 
         QFontMetrics metrics(font());

--- a/src/elidedlabel.h
+++ b/src/elidedlabel.h
@@ -8,10 +8,9 @@ class ElidedLabel : public QLabel
     Q_OBJECT
 public:
     explicit ElidedLabel(QWidget *parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
-    explicit ElidedLabel(const QString &text, QWidget *parent = nullptr,
-                         Qt::WindowFlags f = Qt::WindowFlags());
+    explicit ElidedLabel(const QString &text, QWidget *parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
     void setType(const Qt::TextElideMode type);
-    QString text() const;
+    QString const &text() const;
 
 public slots:
     void setText(const QString &text);

--- a/src/elidedlabel.h
+++ b/src/elidedlabel.h
@@ -9,7 +9,7 @@ class ElidedLabel : public QLabel
 public:
     explicit ElidedLabel(QWidget *parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
     explicit ElidedLabel(const QString &text, QWidget *parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
-    void setType(const Qt::TextElideMode type);
+    void setType(Qt::TextElideMode type);
     QString const &text() const;
 
 public slots:
@@ -17,12 +17,12 @@ public slots:
     void elide();
 
 protected:
-    void resizeEvent(QResizeEvent *event);
+    void resizeEvent(QResizeEvent *event) override;
 
 private:
-    QString original;
-    Qt::TextElideMode defaultType;
-    bool eliding;
+    QString m_original;
+    Qt::TextElideMode m_defaultType;
+    bool m_eliding;
 };
 
 #endif // ELIDEDLABEL_H

--- a/src/foldertreedelegateeditor.cpp
+++ b/src/foldertreedelegateeditor.cpp
@@ -12,20 +12,15 @@
 #include "labeledittype.h"
 #include "fontloader.h"
 
-FolderTreeDelegateEditor::FolderTreeDelegateEditor(QTreeView *view,
-                                                   const QStyleOptionViewItem &option,
-                                                   const QModelIndex &index, QListView *listView,
+FolderTreeDelegateEditor::FolderTreeDelegateEditor(QTreeView *view, const QStyleOptionViewItem &option, const QModelIndex &index, QListView *listView,
                                                    QWidget *parent)
     : QWidget(parent),
       m_option(option),
       m_index(index),
 #ifdef __APPLE__
-      m_displayFont(QFont(QStringLiteral("SF Pro Text")).exactMatch()
-                            ? QStringLiteral("SF Pro Text")
-                            : QStringLiteral("Roboto")),
+      m_displayFont(QFont(QStringLiteral("SF Pro Text")).exactMatch() ? QStringLiteral("SF Pro Text") : QStringLiteral("Roboto")),
 #elif _WIN32
-      m_displayFont(QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI")
-                                                                   : QStringLiteral("Roboto")),
+      m_displayFont(QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI") : QStringLiteral("Roboto")),
 #else
       m_displayFont(QStringLiteral("Roboto")),
 #endif
@@ -63,14 +58,12 @@ FolderTreeDelegateEditor::FolderTreeDelegateEditor(QTreeView *view,
 #else
     int iconPointSizeOffset = -4;
 #endif
-    m_expandIcon->setFont(font_loader::loadFont("Font Awesome 6 Free Solid", "",
-                                                             10 + iconPointSizeOffset));
+    m_expandIcon->setFont(font_loader::loadFont("Font Awesome 6 Free Solid", "", 10 + iconPointSizeOffset));
 
     m_expandIcon->setScaledContents(true);
     layout->addWidget(m_expandIcon);
 
-    if (!m_index.data(NodeItem::Roles::IsExpandable).toBool()
-        || (m_index.data(NodeItem::Roles::IsExpandable).toBool() && m_view->isExpanded(m_index))) {
+    if (!m_index.data(NodeItem::Roles::IsExpandable).toBool() || (m_index.data(NodeItem::Roles::IsExpandable).toBool() && m_view->isExpanded(m_index))) {
         layout->addSpacing(2);
     }
 
@@ -92,16 +85,15 @@ FolderTreeDelegateEditor::FolderTreeDelegateEditor(QTreeView *view,
     m_label->setSizePolicy(labelPolicy);
     m_label->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
     connect(m_label, &LabelEditType::editingStarted, this, [this] {
-        auto tree_view = dynamic_cast<NodeTreeView *>(m_view);
-        tree_view->setIsEditing(true);
+        auto *treeView = static_cast<NodeTreeView *>(m_view);
+        treeView->setIsEditing(true);
     });
     connect(m_label, &LabelEditType::editingFinished, this, [this](const QString &label) {
-        auto tree_view = dynamic_cast<NodeTreeView *>(m_view);
-        tree_view->onRenameFolderFinished(label);
-        tree_view->setIsEditing(false);
+        auto *treeView = static_cast<NodeTreeView *>(m_view);
+        treeView->onRenameFolderFinished(label);
+        treeView->setIsEditing(false);
     });
-    connect(dynamic_cast<NodeTreeView *>(m_view), &NodeTreeView::renameFolderRequested, m_label,
-            &LabelEditType::openEditor);
+    connect(static_cast<NodeTreeView *>(m_view), &NodeTreeView::renameFolderRequested, m_label, &LabelEditType::openEditor);
     layout->addWidget(m_label);
     layout->addSpacing(5);
     m_contextButton = new PushButtonType(parent);
@@ -138,15 +130,13 @@ FolderTreeDelegateEditor::FolderTreeDelegateEditor(QTreeView *view,
 #else
     int pointSizeOffset = -4;
 #endif
-    m_contextButton->setFont(font_loader::loadFont("Font Awesome 6 Free Solid", "",
-                                                                14 + pointSizeOffset));
+    m_contextButton->setFont(font_loader::loadFont("Font Awesome 6 Free Solid", "", 14 + pointSizeOffset));
     m_contextButton->setText(u8"\uf141"); // fa-ellipsis-h
 
     connect(m_contextButton, &QPushButton::clicked, m_view, [this](bool) {
-        auto tree_view = dynamic_cast<NodeTreeView *>(m_view);
+        auto *const treeView = static_cast<NodeTreeView *>(m_view);
         //        tree_view->setCurrentIndexC(m_index);
-        tree_view->onCustomContextMenu(tree_view->visualRect(m_index).topLeft()
-                                       + m_contextButton->geometry().bottomLeft());
+        treeView->onCustomContextMenu(treeView->visualRect(m_index).topLeft() + m_contextButton->geometry().bottomLeft());
     });
     layout->addWidget(m_contextButton, 0, Qt::AlignRight);
     layout->addSpacing(5);
@@ -162,33 +152,24 @@ void FolderTreeDelegateEditor::updateDelegate()
 
     if (m_view->selectionModel()->isSelected(m_index)) {
         labelStyle = QStringLiteral("QLabel{color: rgb(%1, %2, %3);}")
-                             .arg(QString::number(m_titleSelectedColor.red()),
-                                  QString::number(m_titleSelectedColor.green()),
+                             .arg(QString::number(m_titleSelectedColor.red()), QString::number(m_titleSelectedColor.green()),
                                   QString::number(m_titleSelectedColor.blue()));
-        folderIconStyle =
-                QStringLiteral("QPushButton{border: none; padding: 0px; color: rgb(%1, %2, %3);}")
-                        .arg(QString::number(m_titleSelectedColor.red()),
-                             QString::number(m_titleSelectedColor.green()),
-                             QString::number(m_titleSelectedColor.blue()));
+        folderIconStyle = QStringLiteral("QPushButton{border: none; padding: 0px; color: rgb(%1, %2, %3);}")
+                                  .arg(QString::number(m_titleSelectedColor.red()), QString::number(m_titleSelectedColor.green()),
+                                       QString::number(m_titleSelectedColor.blue()));
     } else {
         labelStyle = QStringLiteral("QLabel{color: rgb(%1, %2, %3);}")
-                             .arg(QString::number(m_titleColor.red()),
-                                  QString::number(m_titleColor.green()),
-                                  QString::number(m_titleColor.blue()));
+                             .arg(QString::number(m_titleColor.red()), QString::number(m_titleColor.green()), QString::number(m_titleColor.blue()));
         folderIconStyle =
                 QStringLiteral("QPushButton{border: none; padding: 0px; color: rgb(%1, %2, %3);}")
-                        .arg(QString::number(m_folderIconColor.red()),
-                             QString::number(m_folderIconColor.green()),
-                             QString::number(m_folderIconColor.blue()));
+                        .arg(QString::number(m_folderIconColor.red()), QString::number(m_folderIconColor.green()), QString::number(m_folderIconColor.blue()));
     }
     m_label->setText(displayName);
-    auto theme = dynamic_cast<NodeTreeView *>(m_view)->theme();
+    auto theme = static_cast<NodeTreeView *>(m_view)->theme();
 
     QColor chevronColor(theme == Theme::Dark ? QColor(169, 160, 172) : QColor(103, 99, 105));
-    QString expandIconStyle =
-            QStringLiteral("QLabel{color: rgb(%1, %2, %3);}")
-                    .arg(QString::number(chevronColor.red()), QString::number(chevronColor.green()),
-                         QString::number(chevronColor.blue()));
+    QString expandIconStyle = QStringLiteral("QLabel{color: rgb(%1, %2, %3);}")
+                                      .arg(QString::number(chevronColor.red()), QString::number(chevronColor.green()), QString::number(chevronColor.blue()));
 
     if (m_folderIcon->styleSheet() != folderIconStyle) {
         m_folderIcon->setStyleSheet(folderIconStyle);
@@ -218,7 +199,7 @@ void FolderTreeDelegateEditor::paintEvent(QPaintEvent *event)
     if (m_view->selectionModel()->isSelected(m_index)) {
         painter.fillRect(rect(), QBrush(m_activeColor));
     } else {
-        auto listView = dynamic_cast<NoteListView *>(m_listView);
+        auto const *listView = static_cast<NoteListView *>(m_listView);
         if (listView->isDragging()) {
             if (m_theme == Theme::Dark) {
                 painter.fillRect(rect(), QBrush(QColor(35, 52, 69)));

--- a/src/foldertreedelegateeditor.cpp
+++ b/src/foldertreedelegateeditor.cpp
@@ -63,7 +63,7 @@ FolderTreeDelegateEditor::FolderTreeDelegateEditor(QTreeView *view,
 #else
     int iconPointSizeOffset = -4;
 #endif
-    m_expandIcon->setFont(FontLoader::getInstance().loadFont("Font Awesome 6 Free Solid", "",
+    m_expandIcon->setFont(font_loader::loadFont("Font Awesome 6 Free Solid", "",
                                                              10 + iconPointSizeOffset));
 
     m_expandIcon->setScaledContents(true);
@@ -138,7 +138,7 @@ FolderTreeDelegateEditor::FolderTreeDelegateEditor(QTreeView *view,
 #else
     int pointSizeOffset = -4;
 #endif
-    m_contextButton->setFont(FontLoader::getInstance().loadFont("Font Awesome 6 Free Solid", "",
+    m_contextButton->setFont(font_loader::loadFont("Font Awesome 6 Free Solid", "",
                                                                 14 + pointSizeOffset));
     m_contextButton->setText(u8"\uf141"); // fa-ellipsis-h
 

--- a/src/foldertreedelegateeditor.cpp
+++ b/src/foldertreedelegateeditor.cpp
@@ -39,7 +39,7 @@ FolderTreeDelegateEditor::FolderTreeDelegateEditor(QTreeView *view, const QStyle
       m_theme(Theme::Light)
 {
     setContentsMargins(0, 0, 0, 0);
-    auto layout = new QHBoxLayout(this);
+    auto *layout = new QHBoxLayout(this);
     layout->setContentsMargins(10, 0, 0, 0);
     layout->setSpacing(0);
     setLayout(layout);

--- a/src/foldertreedelegateeditor.h
+++ b/src/foldertreedelegateeditor.h
@@ -17,8 +17,7 @@ class FolderTreeDelegateEditor : public QWidget
 {
     Q_OBJECT
 public:
-    explicit FolderTreeDelegateEditor(QTreeView *view, const QStyleOptionViewItem &option,
-                                      const QModelIndex &index, QListView *listView,
+    explicit FolderTreeDelegateEditor(QTreeView *view, const QStyleOptionViewItem &option, const QModelIndex &index, QListView *listView,
                                       QWidget *parent = nullptr);
     void setTheme(Theme::Value theme);
 

--- a/src/foldertreedelegateeditor.h
+++ b/src/foldertreedelegateeditor.h
@@ -44,8 +44,8 @@ private:
 
     // QWidget interface
 protected:
-    virtual void paintEvent(QPaintEvent *event) override;
-    virtual void mouseDoubleClickEvent(QMouseEvent *event) override;
+    void paintEvent(QPaintEvent *event) override;
+    void mouseDoubleClickEvent(QMouseEvent *event) override;
 };
 
 #endif // FOLDERTREEDELEGATEEDITOR_H

--- a/src/fontloader.cpp
+++ b/src/fontloader.cpp
@@ -1,6 +1,0 @@
-#include "fontloader.h"
-
-QFont FontLoader::loadFont(const QString &family, const QString &style, int pointSize)
-{
-    return QFontDatabase::font(family, style, pointSize);
-}

--- a/src/fontloader.h
+++ b/src/fontloader.h
@@ -4,20 +4,10 @@
 #include <QString>
 #include <QFontDatabase>
 
-class FontLoader
+namespace font_loader {
+
+inline QFont loadFont(const QString &family, const QString &style, int pointSize)
 {
-public:
-    static FontLoader &getInstance()
-    {
-        static FontLoader instance;
-        return instance;
-    }
-
-    FontLoader(const FontLoader &) = delete;
-    void operator=(const FontLoader &) = delete;
-    QFont loadFont(const QString &family, const QString &style, int pointSize);
-
-private:
-    FontLoader() = default;
-    ~FontLoader() = default;
-};
+    return QFontDatabase::font(family, style, pointSize);
+}
+} // namespace font_loader

--- a/src/framelesswindow.cpp
+++ b/src/framelesswindow.cpp
@@ -16,12 +16,7 @@
                                        // external symbol __imp__DwmExtendFrameIntoClientArea
 #    pragma comment(lib, "user32.lib")
 
-CFramelessWindow::CFramelessWindow(QWidget *parent)
-    : QMainWindow(parent),
-      m_titlebar(Q_NULLPTR),
-      m_borderWidth(5),
-      m_bJustMaximized(false),
-      m_bResizeable(true)
+CFramelessWindow::CFramelessWindow(QWidget *parent) : QMainWindow(parent), m_titlebar(Q_NULLPTR), m_borderWidth(5), m_bJustMaximized(false), m_bResizeable(true)
 {
     //    setWindowFlag(Qt::Window,true);
     //    setWindowFlag(Qt::FramelessWindowHint, true);
@@ -150,23 +145,19 @@ bool CFramelessWindow::nativeEvent(const QByteArray &eventType, void *message, q
             }
             if (resizeWidth && resizeHeight) {
                 // bottom left corner
-                if (x >= winrect.left && x < winrect.left + border_width && y < winrect.bottom
-                    && y >= winrect.bottom - border_width) {
+                if (x >= winrect.left && x < winrect.left + border_width && y < winrect.bottom && y >= winrect.bottom - border_width) {
                     *result = HTBOTTOMLEFT;
                 }
                 // bottom right corner
-                if (x < winrect.right && x >= winrect.right - border_width && y < winrect.bottom
-                    && y >= winrect.bottom - border_width) {
+                if (x < winrect.right && x >= winrect.right - border_width && y < winrect.bottom && y >= winrect.bottom - border_width) {
                     *result = HTBOTTOMRIGHT;
                 }
                 // top left corner
-                if (x >= winrect.left && x < winrect.left + border_width && y >= winrect.top
-                    && y < winrect.top + border_width) {
+                if (x >= winrect.left && x < winrect.left + border_width && y >= winrect.top && y < winrect.top + border_width) {
                     *result = HTTOPLEFT;
                 }
                 // top right corner
-                if (x < winrect.right && x >= winrect.right - border_width && y >= winrect.top
-                    && y < winrect.top + border_width) {
+                if (x < winrect.right && x >= winrect.right - border_width && y >= winrect.top && y < winrect.top + border_width) {
                     *result = HTTOPRIGHT;
                 }
             }
@@ -210,9 +201,8 @@ bool CFramelessWindow::nativeEvent(const QByteArray &eventType, void *message, q
             m_frames.setRight(abs(frame.right) / dpr + 0.5);
             m_frames.setBottom(abs(frame.bottom) / dpr + 0.5);
 
-            QMainWindow::setContentsMargins(
-                    m_frames.left() + m_margins.left(), m_frames.top() + m_margins.top(),
-                    m_frames.right() + m_margins.right(), m_frames.bottom() + m_margins.bottom());
+            QMainWindow::setContentsMargins(m_frames.left() + m_margins.left(), m_frames.top() + m_margins.top(), m_frames.right() + m_margins.right(),
+                                            m_frames.bottom() + m_margins.bottom());
             m_bJustMaximized = true;
         } else {
             if (m_bJustMaximized) {
@@ -235,8 +225,7 @@ void CFramelessWindow::setContentsMargins(const QMargins &margins)
 }
 void CFramelessWindow::setContentsMargins(int left, int top, int right, int bottom)
 {
-    QMainWindow::setContentsMargins(left + m_frames.left(), top + m_frames.top(),
-                                    right + m_frames.right(), bottom + m_frames.bottom());
+    QMainWindow::setContentsMargins(left + m_frames.left(), top + m_frames.top(), right + m_frames.right(), bottom + m_frames.bottom());
     m_margins.setLeft(left);
     m_margins.setTop(top);
     m_margins.setRight(right);

--- a/src/framelesswindow.h
+++ b/src/framelesswindow.h
@@ -19,7 +19,7 @@ class CFramelessWindow : public QMainWindow
 {
     Q_OBJECT
 public:
-    explicit CFramelessWindow(QWidget *parent = 0);
+    explicit CFramelessWindow(QWidget *parent = nullptr);
 
 public:
     // 设置是否可以通过鼠标调整窗口大小
@@ -77,7 +77,7 @@ class CFramelessWindow : public QMainWindow
 {
     Q_OBJECT
 public:
-    explicit CFramelessWindow(QWidget *parent = 0);
+    explicit CFramelessWindow(QWidget *parent = nullptr);
 
 private:
     void initUI();

--- a/src/framelesswindow.mm
+++ b/src/framelesswindow.mm
@@ -102,16 +102,14 @@ void CFramelessWindow::initUI()
     AppObserver *observer = [[AppObserver alloc] init];
     if (observer) {
         observer.window = this;
-        [[[NSWorkspace sharedWorkspace] notificationCenter]
-                addObserver:observer
-                   selector:@selector(appDidHide:)
-                       name:NSWorkspaceDidHideApplicationNotification
-                     object:nil];
-        [[[NSWorkspace sharedWorkspace] notificationCenter]
-                addObserver:observer
-                   selector:@selector(appDidUnhide:)
-                       name:NSWorkspaceDidUnhideApplicationNotification
-                     object:nil];
+        [[[NSWorkspace sharedWorkspace] notificationCenter] addObserver:observer
+                                                               selector:@selector(appDidHide:)
+                                                                   name:NSWorkspaceDidHideApplicationNotification
+                                                                 object:nil];
+        [[[NSWorkspace sharedWorkspace] notificationCenter] addObserver:observer
+                                                               selector:@selector(appDidUnhide:)
+                                                                   name:NSWorkspaceDidUnhideApplicationNotification
+                                                                 object:nil];
     } else {
         qWarning() << "Failed to set up Notification Observer!";
     }
@@ -140,13 +138,10 @@ void CFramelessWindow::initUI()
     // Currently, doesn't work
     NSButton *closeButton = [window standardWindowButton:NSWindowCloseButton];
     NSButton *minimizeButton = [window standardWindowButton:NSWindowMiniaturizeButton];
-    closeButton.frame = NSMakeRect(closeButton.frame.origin.x + 10, closeButton.frame.origin.y,
-                                   closeButton.frame.size.width, closeButton.frame.size.height);
+    closeButton.frame = NSMakeRect(closeButton.frame.origin.x + 10, closeButton.frame.origin.y, closeButton.frame.size.width, closeButton.frame.size.height);
     minimizeButton.frame =
-            NSMakeRect(minimizeButton.frame.origin.x + 10, minimizeButton.frame.origin.y,
-                       minimizeButton.frame.size.width, minimizeButton.frame.size.height);
-    zoomButton.frame = NSMakeRect(zoomButton.frame.origin.x + 10, zoomButton.frame.origin.y,
-                                  zoomButton.frame.size.width, zoomButton.frame.size.height);
+            NSMakeRect(minimizeButton.frame.origin.x + 10, minimizeButton.frame.origin.y, minimizeButton.frame.size.width, minimizeButton.frame.size.height);
+    zoomButton.frame = NSMakeRect(zoomButton.frame.origin.x + 10, zoomButton.frame.origin.y, zoomButton.frame.size.width, zoomButton.frame.size.height);
 }
 
 void CFramelessWindow::setCloseBtnQuit(bool bQuit)

--- a/src/labeledittype.cpp
+++ b/src/labeledittype.cpp
@@ -7,7 +7,7 @@ LabelEditType::LabelEditType(QWidget *parent) : ElidedLabel(parent)
 {
     setContentsMargins(0, 0, 0, 0);
     m_editor = new QLineEdit(this);
-    auto layout = new QBoxLayout(QBoxLayout::LeftToRight, this);
+    auto *layout = new QBoxLayout(QBoxLayout::LeftToRight, this);
     layout->addWidget(m_editor);
     layout->setContentsMargins(0, 0, 0, 0);
     setLayout(layout);

--- a/src/listviewlogic.cpp
+++ b/src/listviewlogic.cpp
@@ -24,8 +24,7 @@ static bool isInvalidCurrentNotesId(const QSet<int> &currentNotesId)
     return isInvalid;
 }
 
-ListViewLogic::ListViewLogic(NoteListView *noteView, NoteListModel *noteModel,
-                             QLineEdit *searchEdit, QToolButton *clearButton, TagPool *tagPool,
+ListViewLogic::ListViewLogic(NoteListView *noteView, NoteListModel *noteModel, QLineEdit *searchEdit, QToolButton *clearButton, TagPool *tagPool,
                              DBManager *dbManager, QObject *parent)
     : QObject(parent),
       m_listView{ noteView },
@@ -42,87 +41,61 @@ ListViewLogic::ListViewLogic(NoteListView *noteView, NoteListModel *noteModel,
     m_listView->setDbManager(m_dbManager);
     connect(m_dbManager, &DBManager::notesListReceived, this, &ListViewLogic::loadNoteListModel);
     // note model rows moved
-    connect(m_listModel, &NoteListModel::rowsAboutToBeMovedC, m_listView,
-            &NoteListView::rowsAboutToBeMoved);
+    connect(m_listModel, &NoteListModel::rowsAboutToBeMovedC, m_listView, &NoteListView::rowsAboutToBeMoved);
     connect(m_listModel, &NoteListModel::rowsMovedC, m_listView, &NoteListView::rowsMoved);
     // note pressed
-    connect(m_listView, &NoteListView::notePressed, this,
-            [this](const QModelIndexList &indexes) { onNotePressed(indexes); });
+    connect(m_listView, &NoteListView::notePressed, this, [this](const QModelIndexList &indexes) { onNotePressed(indexes); });
     connect(m_listView, &NoteListView::addTagRequested, this, &ListViewLogic::onAddTagRequest);
-    connect(m_listView, &NoteListView::removeTagRequested, this,
-            &ListViewLogic::onRemoveTagRequest);
+    connect(m_listView, &NoteListView::removeTagRequested, this, &ListViewLogic::onRemoveTagRequest);
 
-    connect(this, &ListViewLogic::requestAddTagDb, dbManager, &DBManager::addNoteToTag,
-            Qt::QueuedConnection);
-    connect(this, &ListViewLogic::requestRemoveTagDb, dbManager, &DBManager::removeNoteFromTag,
-            Qt::QueuedConnection);
-    connect(this, &ListViewLogic::requestRemoveNoteDb, dbManager, &DBManager::removeNote,
-            Qt::QueuedConnection);
-    connect(this, &ListViewLogic::requestMoveNoteDb, dbManager, &DBManager::moveNode,
-            Qt::QueuedConnection);
-    connect(this, &ListViewLogic::requestSearchInDb, dbManager, &DBManager::searchForNotes,
-            Qt::QueuedConnection);
-    connect(this, &ListViewLogic::requestClearSearchDb, dbManager, &DBManager::clearSearch,
-            Qt::QueuedConnection);
-    connect(m_listModel, &NoteListModel::requestUpdatePinnedRelPos, dbManager,
-            &DBManager::updateRelPosPinnedNote, Qt::QueuedConnection);
-    connect(m_listModel, &NoteListModel::requestUpdatePinnedRelPosAN, dbManager,
-            &DBManager::updateRelPosPinnedNoteAN, Qt::QueuedConnection);
-    connect(m_listModel, &NoteListModel::requestUpdatePinned, dbManager,
-            &DBManager::setNoteIsPinned, Qt::QueuedConnection);
+    connect(this, &ListViewLogic::requestAddTagDb, dbManager, &DBManager::addNoteToTag, Qt::QueuedConnection);
+    connect(this, &ListViewLogic::requestRemoveTagDb, dbManager, &DBManager::removeNoteFromTag, Qt::QueuedConnection);
+    connect(this, &ListViewLogic::requestRemoveNoteDb, dbManager, &DBManager::removeNote, Qt::QueuedConnection);
+    connect(this, &ListViewLogic::requestMoveNoteDb, dbManager, &DBManager::moveNode, Qt::QueuedConnection);
+    connect(this, &ListViewLogic::requestSearchInDb, dbManager, &DBManager::searchForNotes, Qt::QueuedConnection);
+    connect(this, &ListViewLogic::requestClearSearchDb, dbManager, &DBManager::clearSearch, Qt::QueuedConnection);
+    connect(m_listModel, &NoteListModel::requestUpdatePinnedRelPos, dbManager, &DBManager::updateRelPosPinnedNote, Qt::QueuedConnection);
+    connect(m_listModel, &NoteListModel::requestUpdatePinnedRelPosAN, dbManager, &DBManager::updateRelPosPinnedNoteAN, Qt::QueuedConnection);
+    connect(m_listModel, &NoteListModel::requestUpdatePinned, dbManager, &DBManager::setNoteIsPinned, Qt::QueuedConnection);
 
-    connect(m_listView, &NoteListView::deleteNoteRequested, this,
-            &ListViewLogic::deleteNoteRequestedI);
-    connect(m_listView, &NoteListView::restoreNoteRequested, this,
-            &ListViewLogic::restoreNotesRequestedI);
+    connect(m_listView, &NoteListView::deleteNoteRequested, this, &ListViewLogic::deleteNoteRequestedI);
+    connect(m_listView, &NoteListView::restoreNoteRequested, this, &ListViewLogic::restoreNotesRequestedI);
 
     connect(tagPool, &TagPool::dataUpdated, this, [this](int) {
         if (m_listModel->rowCount() > 0) {
-            emit m_listModel->dataChanged(m_listModel->index(0, 0),
-                                          m_listModel->index(m_listModel->rowCount() - 1, 0));
+            emit m_listModel->dataChanged(m_listModel->index(0, 0), m_listModel->index(m_listModel->rowCount() - 1, 0));
             emit m_listModel->rowCountChanged();
         }
     });
-    connect(m_listModel, &QAbstractItemModel::rowsInserted, this,
-            &ListViewLogic::updateListViewLabel);
-    connect(m_listModel, &QAbstractItemModel::rowsRemoved, this,
-            &ListViewLogic::updateListViewLabel);
+    connect(m_listModel, &QAbstractItemModel::rowsInserted, this, &ListViewLogic::updateListViewLabel);
+    connect(m_listModel, &QAbstractItemModel::rowsRemoved, this, &ListViewLogic::updateListViewLabel);
     connect(m_listView, &NoteListView::newNoteRequested, this, &ListViewLogic::requestNewNote);
     connect(m_listView, &NoteListView::moveNoteRequested, this, &ListViewLogic::moveNoteRequested);
     connect(m_listModel, &NoteListModel::rowCountChanged, this, &ListViewLogic::onRowCountChanged);
     connect(m_listView, &NoteListView::doubleClicked, this, &ListViewLogic::onNoteDoubleClicked);
-    connect(m_listView, &NoteListView::setPinnedNoteRequested, this,
-            &ListViewLogic::onSetPinnedNoteRequested);
-    connect(m_listView, &NoteListView::pinnedCollapseChanged, this,
-            &ListViewLogic::onRowCountChanged);
-    connect(m_listModel, &NoteListModel::requestOpenNoteEditor, this,
-            [this](const QModelIndexList &indexes) {
-                for (const auto &index : indexes) {
-                    if (index.isValid()) {
-                        m_listView->openPersistentEditorC(index);
-                    }
-                }
-            });
-    connect(m_listModel, &NoteListModel::requestCloseNoteEditor, this,
-            [this](const QModelIndexList &indexes) {
-                for (const auto &index : indexes) {
-                    if (index.isValid()) {
-                        m_listView->closePersistentEditorC(index);
-                    }
-                }
-            });
-    connect(m_listDelegate, &NoteListDelegate::animationFinished, m_listView,
-            &NoteListView::onAnimationFinished);
-    connect(m_listModel, &NoteListModel::requestRemoveNotes, m_listView,
-            &NoteListView::onRemoveRowRequested);
-    connect(this, &ListViewLogic::requestNotesListInFolder, m_dbManager,
-            &DBManager::onNotesListInFolderRequested, Qt::QueuedConnection);
-    connect(this, &ListViewLogic::requestNotesListInTags, m_dbManager,
-            &DBManager::onNotesListInTagsRequested, Qt::QueuedConnection);
+    connect(m_listView, &NoteListView::setPinnedNoteRequested, this, &ListViewLogic::onSetPinnedNoteRequested);
+    connect(m_listView, &NoteListView::pinnedCollapseChanged, this, &ListViewLogic::onRowCountChanged);
+    connect(m_listModel, &NoteListModel::requestOpenNoteEditor, this, [this](const QModelIndexList &indexes) {
+        for (const auto &index : indexes) {
+            if (index.isValid()) {
+                m_listView->openPersistentEditorC(index);
+            }
+        }
+    });
+    connect(m_listModel, &NoteListModel::requestCloseNoteEditor, this, [this](const QModelIndexList &indexes) {
+        for (const auto &index : indexes) {
+            if (index.isValid()) {
+                m_listView->closePersistentEditorC(index);
+            }
+        }
+    });
+    connect(m_listDelegate, &NoteListDelegate::animationFinished, m_listView, &NoteListView::onAnimationFinished);
+    connect(m_listModel, &NoteListModel::requestRemoveNotes, m_listView, &NoteListView::onRemoveRowRequested);
+    connect(this, &ListViewLogic::requestNotesListInFolder, m_dbManager, &DBManager::onNotesListInFolderRequested, Qt::QueuedConnection);
+    connect(this, &ListViewLogic::requestNotesListInTags, m_dbManager, &DBManager::onNotesListInTagsRequested, Qt::QueuedConnection);
     connect(m_listModel, &NoteListModel::rowsInsertedC, m_listView, &NoteListView::onRowsInserted);
     connect(m_listModel, &NoteListModel::selectNotes, this, &ListViewLogic::selectNotes);
-    connect(m_listView, &NoteListView::noteListViewClicked, this,
-            &ListViewLogic::onListViewClicked);
+    connect(m_listView, &NoteListView::noteListViewClicked, this, &ListViewLogic::onListViewClicked);
 }
 
 void ListViewLogic::selectNote(const QModelIndex &noteIndex)
@@ -172,8 +145,7 @@ void ListViewLogic::setNoteData(const NodeData &note)
         auto wasTemp = noteIndex.data(NoteListModel::NoteIsTemp).toBool();
         dataValue[NoteListModel::NoteContent] = QVariant::fromValue(note.content());
         dataValue[NoteListModel::NoteFullTitle] = QVariant::fromValue(note.fullTitle());
-        dataValue[NoteListModel::NoteLastModificationDateTime] =
-                QVariant::fromValue(note.lastModificationdateTime());
+        dataValue[NoteListModel::NoteLastModificationDateTime] = QVariant::fromValue(note.lastModificationdateTime());
         dataValue[NoteListModel::NoteIsTemp] = QVariant::fromValue(note.isTempNote());
         dataValue[NoteListModel::NoteScrollbarPos] = QVariant::fromValue(note.scrollBarPosition());
         m_listModel->setItemData(noteIndex, dataValue);
@@ -274,7 +246,7 @@ void ListViewLogic::onSearchEditTextChanged(const QString &keyword)
         clearSearch();
     } else {
         if (!m_listViewInfo.isInSearch) {
-            auto indexes = m_listView->selectedIndex();
+            auto indexes = m_listView->getSelectedIndex();
             m_listViewInfo.currentNotesId.clear();
             for (const auto &index : std::as_const(indexes)) {
                 if (index.isValid()) {
@@ -392,8 +364,7 @@ void ListViewLogic::onNoteMovedOut(int nodeId, int targetId)
 {
     auto index = m_listModel->getNoteIndex(nodeId);
     if (index.isValid()) {
-        if ((!m_listViewInfo.isInTag && m_listViewInfo.parentFolderId != SpecialNodeID::RootFolder
-             && m_listViewInfo.parentFolderId != targetId)
+        if ((!m_listViewInfo.isInTag && m_listViewInfo.parentFolderId != SpecialNodeID::RootFolder && m_listViewInfo.parentFolderId != targetId)
             || targetId == SpecialNodeID::TrashFolder) {
             selectNoteDown();
             m_listModel->removeNotes({ index });
@@ -402,8 +373,7 @@ void ListViewLogic::onNoteMovedOut(int nodeId, int targetId)
             }
         } else {
             NodeData note;
-            QMetaObject::invokeMethod(m_dbManager, "getNode", Qt::BlockingQueuedConnection,
-                                      Q_RETURN_ARG(NodeData, note), Q_ARG(int, nodeId));
+            QMetaObject::invokeMethod(m_dbManager, "getNode", Qt::BlockingQueuedConnection, Q_RETURN_ARG(NodeData, note), Q_ARG(int, nodeId));
             if (note.id() != SpecialNodeID::InvalidNodeId) {
                 m_listView->closePersistentEditorC(index);
                 m_listModel->setNoteData(index, note);
@@ -417,7 +387,7 @@ void ListViewLogic::onNoteMovedOut(int nodeId, int targetId)
 
 void ListViewLogic::setLastSelectedNote()
 {
-    auto indexes = m_listView->selectedIndex();
+    auto indexes = m_listView->getSelectedIndex();
     QSet<int> ids;
     for (const auto &index : std::as_const(indexes)) {
         if (index.isValid()) {
@@ -432,8 +402,7 @@ void ListViewLogic::loadLastSelectedNoteRequested()
     requestLoadSavedState(2);
 }
 
-void ListViewLogic::onNotesListInFolderRequested(int parentID, bool isRecursive, bool newNote,
-                                                 int scrollToId)
+void ListViewLogic::onNotesListInFolderRequested(int parentID, bool isRecursive, bool newNote, int scrollToId)
 {
     if (m_listViewInfo.isInSearch && !m_searchEdit->text().isEmpty()) {
         m_listViewInfo.parentFolderId = parentID;
@@ -449,8 +418,7 @@ void ListViewLogic::onNotesListInFolderRequested(int parentID, bool isRecursive,
     }
 }
 
-void ListViewLogic::onNotesListInTagsRequested(const QSet<int> &tagIds, bool newNote,
-                                               int scrollToId)
+void ListViewLogic::onNotesListInTagsRequested(const QSet<int> &tagIds, bool newNote, int scrollToId)
 {
     if (m_listViewInfo.isInSearch && !m_searchEdit->text().isEmpty()) {
         m_listViewInfo.parentFolderId = SpecialNodeID::InvalidNodeId;
@@ -537,8 +505,7 @@ void ListViewLogic::deleteNoteRequestedI(const QModelIndexList &indexes)
             if (index.isValid()) {
                 auto id = index.data(NoteListModel::NoteID).toInt();
                 NodeData note;
-                QMetaObject::invokeMethod(m_dbManager, "getNode", Qt::BlockingQueuedConnection,
-                                          Q_RETURN_ARG(NodeData, note), Q_ARG(int, id));
+                QMetaObject::invokeMethod(m_dbManager, "getNode", Qt::BlockingQueuedConnection, Q_RETURN_ARG(NodeData, note), Q_ARG(int, id));
                 if (note.parentId() == SpecialNodeID::TrashFolder) {
                     isInTrash = true;
                 }
@@ -547,10 +514,9 @@ void ListViewLogic::deleteNoteRequestedI(const QModelIndexList &indexes)
             }
         }
         if (isInTrash) {
-            auto btn = QMessageBox::question(
-                    nullptr, "Are you sure you want to delete this note permanently",
-                    "Are you sure you want to delete this note permanently? It will not be "
-                    "recoverable.");
+            auto btn = QMessageBox::question(nullptr, "Are you sure you want to delete this note permanently",
+                                             "Are you sure you want to delete this note permanently? It will not be "
+                                             "recoverable.");
             if (btn == QMessageBox::Yes) {
                 selectNoteDown();
                 bool needClose = false;
@@ -590,8 +556,7 @@ void ListViewLogic::restoreNotesRequestedI(const QModelIndexList &indexes)
         if (index.isValid()) {
             auto id = index.data(NoteListModel::NoteID).toInt();
             NodeData note;
-            QMetaObject::invokeMethod(m_dbManager, "getNode", Qt::BlockingQueuedConnection,
-                                      Q_RETURN_ARG(NodeData, note), Q_ARG(int, id));
+            QMetaObject::invokeMethod(m_dbManager, "getNode", Qt::BlockingQueuedConnection, Q_RETURN_ARG(NodeData, note), Q_ARG(int, id));
             if (note.parentId() == SpecialNodeID::TrashFolder) {
                 needRestoredI.append(index);
                 needRestored.insert(note.id());
@@ -609,8 +574,7 @@ void ListViewLogic::restoreNotesRequestedI(const QModelIndexList &indexes)
         emit closeNoteEditor();
     }
     NodeData defaultNotesFolder;
-    QMetaObject::invokeMethod(m_dbManager, "getNode", Qt::BlockingQueuedConnection,
-                              Q_RETURN_ARG(NodeData, defaultNotesFolder),
+    QMetaObject::invokeMethod(m_dbManager, "getNode", Qt::BlockingQueuedConnection, Q_RETURN_ARG(NodeData, defaultNotesFolder),
                               Q_ARG(int, SpecialNodeID::DefaultNotesFolder));
     for (const auto &id : std::as_const(needRestored)) {
         emit requestMoveNoteDb(id, defaultNotesFolder);
@@ -622,13 +586,11 @@ void ListViewLogic::updateListViewLabel()
     QString l1, l2;
     if ((!m_listViewInfo.isInTag) && m_listViewInfo.parentFolderId == SpecialNodeID::RootFolder) {
         l1 = "All Notes";
-    } else if ((!m_listViewInfo.isInTag)
-               && m_listViewInfo.parentFolderId == SpecialNodeID::TrashFolder) {
+    } else if ((!m_listViewInfo.isInTag) && m_listViewInfo.parentFolderId == SpecialNodeID::TrashFolder) {
         l1 = "Trash";
     } else if (!m_listViewInfo.isInTag) {
         NodeData parentFolder;
-        QMetaObject::invokeMethod(m_dbManager, "getNode", Qt::BlockingQueuedConnection,
-                                  Q_RETURN_ARG(NodeData, parentFolder),
+        QMetaObject::invokeMethod(m_dbManager, "getNode", Qt::BlockingQueuedConnection, Q_RETURN_ARG(NodeData, parentFolder),
                                   Q_ARG(int, m_listViewInfo.parentFolderId));
         l1 = parentFolder.fullTitle();
     } else {
@@ -741,13 +703,11 @@ void ListViewLogic::selectAllNotes()
 {
     if (m_listModel->rowCount() > 50) {
 #ifdef Q_OS_MAC
-        auto btn = QMessageBox::question(nullptr,
-                                         "Are you sure you want to select more than 50 notes?",
+        auto btn = QMessageBox::question(nullptr, "Are you sure you want to select more than 50 notes?",
                                          "Selecting more than 50 notes to show in the editor might "
                                          "cause the app to hang.  Do you want to continue?");
 #else
-        auto btn = QMessageBox::question(nullptr,
-                                         "Are you sure you want to select more than 50 notes?",
+        auto btn = QMessageBox::question(nullptr, "Are you sure you want to select more than 50 notes?",
                                          "Selecting more than 50 notes to show in the editor might "
                                          "cause the app to hang. Do you want to continue?");
 #endif
@@ -768,7 +728,7 @@ void ListViewLogic::selectAllNotes()
     //            QItemSelectionModel::SelectCurrent);
     //        }
     //    }
-    onNotePressed(m_listView->selectedIndex());
+    onNotePressed(m_listView->getSelectedIndex());
 }
 
 const ListViewInfo &ListViewLogic::listViewInfo() const

--- a/src/listviewlogic.cpp
+++ b/src/listviewlogic.cpp
@@ -17,7 +17,7 @@ static bool isInvalidCurrentNotesId(const QSet<int> &currentNotesId)
     }
     bool isInvalid = true;
     for (const auto &id : std::as_const(currentNotesId)) {
-        if (id != SpecialNodeID::InvalidNodeId) {
+        if (id != INVALID_NODE_ID) {
             isInvalid = false;
         }
     }
@@ -271,7 +271,7 @@ void ListViewLogic::loadNoteListModel(const QVector<NodeData> &noteList, const L
 {
     auto currentNotesId = m_listViewInfo.currentNotesId;
     m_listViewInfo = inf;
-    if ((!m_listViewInfo.isInTag) && m_listViewInfo.parentFolderId == SpecialNodeID::RootFolder) {
+    if ((!m_listViewInfo.isInTag) && m_listViewInfo.parentFolderId == ROOT_FOLDER_ID) {
         m_listDelegate->setIsInAllNotes(true);
     } else {
         m_listDelegate->setIsInAllNotes(false);
@@ -281,7 +281,7 @@ void ListViewLogic::loadNoteListModel(const QVector<NodeData> &noteList, const L
     m_listView->setListViewInfo(m_listViewInfo);
     updateListViewLabel();
 
-    if ((!m_listViewInfo.isInTag) && m_listViewInfo.parentFolderId == SpecialNodeID::TrashFolder) {
+    if ((!m_listViewInfo.isInTag) && m_listViewInfo.parentFolderId == TRASH_FOLDER_ID) {
         emit setNewNoteButtonVisible(false);
         m_listView->setIsInTrash(true);
     } else {
@@ -289,7 +289,7 @@ void ListViewLogic::loadNoteListModel(const QVector<NodeData> &noteList, const L
         m_listView->setIsInTrash(false);
     }
     if (m_listViewInfo.isInTag) {
-        m_listView->setCurrentFolderId(SpecialNodeID::InvalidNodeId);
+        m_listView->setCurrentFolderId(INVALID_NODE_ID);
     } else {
         m_listView->setCurrentFolderId(m_listViewInfo.parentFolderId);
     }
@@ -300,14 +300,14 @@ void ListViewLogic::loadNoteListModel(const QVector<NodeData> &noteList, const L
     }
 
     if (!m_listViewInfo.isInSearch && !isInvalidCurrentNotesId(currentNotesId)) {
-        if (m_listViewInfo.scrollToId != SpecialNodeID::InvalidNodeId) {
+        if (m_listViewInfo.scrollToId != INVALID_NODE_ID) {
             currentNotesId = { m_listViewInfo.scrollToId };
-            m_listViewInfo.scrollToId = SpecialNodeID::InvalidNodeId;
+            m_listViewInfo.scrollToId = INVALID_NODE_ID;
         }
         if (!currentNotesId.isEmpty()) {
             QModelIndexList indexes;
             for (const auto &id : std::as_const(currentNotesId)) {
-                if (id != SpecialNodeID::InvalidNodeId) {
+                if (id != INVALID_NODE_ID) {
                     indexes.append(m_listModel->getNoteIndex(id));
                 }
             }
@@ -322,7 +322,7 @@ void ListViewLogic::loadNoteListModel(const QVector<NodeData> &noteList, const L
         if (!m_lastSelectedNotes.isEmpty()) {
             QModelIndexList indexes;
             for (const auto &id : std::as_const(m_lastSelectedNotes)) {
-                if (id != SpecialNodeID::InvalidNodeId) {
+                if (id != INVALID_NODE_ID) {
                     indexes.append(m_listModel->getNoteIndex(id));
                 }
             }
@@ -364,8 +364,8 @@ void ListViewLogic::onNoteMovedOut(int nodeId, int targetId)
 {
     auto index = m_listModel->getNoteIndex(nodeId);
     if (index.isValid()) {
-        if ((!m_listViewInfo.isInTag && m_listViewInfo.parentFolderId != SpecialNodeID::RootFolder && m_listViewInfo.parentFolderId != targetId)
-            || targetId == SpecialNodeID::TrashFolder) {
+        if ((!m_listViewInfo.isInTag && m_listViewInfo.parentFolderId != ROOT_FOLDER_ID && m_listViewInfo.parentFolderId != targetId)
+            || targetId == TRASH_FOLDER_ID) {
             selectNoteDown();
             m_listModel->removeNotes({ index });
             if (m_listModel->rowCount() == 0) {
@@ -374,7 +374,7 @@ void ListViewLogic::onNoteMovedOut(int nodeId, int targetId)
         } else {
             NodeData note;
             QMetaObject::invokeMethod(m_dbManager, "getNode", Qt::BlockingQueuedConnection, Q_RETURN_ARG(NodeData, note), Q_ARG(int, nodeId));
-            if (note.id() != SpecialNodeID::InvalidNodeId) {
+            if (note.id() != INVALID_NODE_ID) {
                 m_listView->closePersistentEditorC(index);
                 m_listModel->setNoteData(index, note);
                 m_listView->openPersistentEditorC(index);
@@ -410,7 +410,7 @@ void ListViewLogic::onNotesListInFolderRequested(int parentID, bool isRecursive,
         m_listViewInfo.isInTag = false;
         m_listViewInfo.needCreateNewNote = false;
         m_listViewInfo.currentTagList = {};
-        m_listViewInfo.scrollToId = SpecialNodeID::InvalidNodeId;
+        m_listViewInfo.scrollToId = INVALID_NODE_ID;
         m_clearButton->show();
         emit requestSearchInDb(m_searchEdit->text(), m_listViewInfo);
     } else {
@@ -421,12 +421,12 @@ void ListViewLogic::onNotesListInFolderRequested(int parentID, bool isRecursive,
 void ListViewLogic::onNotesListInTagsRequested(const QSet<int> &tagIds, bool newNote, int scrollToId)
 {
     if (m_listViewInfo.isInSearch && !m_searchEdit->text().isEmpty()) {
-        m_listViewInfo.parentFolderId = SpecialNodeID::InvalidNodeId;
+        m_listViewInfo.parentFolderId = INVALID_NODE_ID;
         m_listViewInfo.currentNotesId.clear();
         m_listViewInfo.isInTag = true;
         m_listViewInfo.needCreateNewNote = false;
         m_listViewInfo.currentTagList = tagIds;
-        m_listViewInfo.scrollToId = SpecialNodeID::InvalidNodeId;
+        m_listViewInfo.scrollToId = INVALID_NODE_ID;
         emit requestSearchInDb(m_searchEdit->text(), m_listViewInfo);
     } else {
         emit requestNotesListInTags(tagIds, newNote, scrollToId);
@@ -506,7 +506,7 @@ void ListViewLogic::deleteNoteRequestedI(const QModelIndexList &indexes)
                 auto id = index.data(NoteListModel::NoteID).toInt();
                 NodeData note;
                 QMetaObject::invokeMethod(m_dbManager, "getNode", Qt::BlockingQueuedConnection, Q_RETURN_ARG(NodeData, note), Q_ARG(int, id));
-                if (note.parentId() == SpecialNodeID::TrashFolder) {
+                if (note.parentId() == TRASH_FOLDER_ID) {
                     isInTrash = true;
                 }
                 needDeleteI.append(index);
@@ -557,7 +557,7 @@ void ListViewLogic::restoreNotesRequestedI(const QModelIndexList &indexes)
             auto id = index.data(NoteListModel::NoteID).toInt();
             NodeData note;
             QMetaObject::invokeMethod(m_dbManager, "getNode", Qt::BlockingQueuedConnection, Q_RETURN_ARG(NodeData, note), Q_ARG(int, id));
-            if (note.parentId() == SpecialNodeID::TrashFolder) {
+            if (note.parentId() == TRASH_FOLDER_ID) {
                 needRestoredI.append(index);
                 needRestored.insert(note.id());
             } else {
@@ -575,7 +575,7 @@ void ListViewLogic::restoreNotesRequestedI(const QModelIndexList &indexes)
     }
     NodeData defaultNotesFolder;
     QMetaObject::invokeMethod(m_dbManager, "getNode", Qt::BlockingQueuedConnection, Q_RETURN_ARG(NodeData, defaultNotesFolder),
-                              Q_ARG(int, SpecialNodeID::DefaultNotesFolder));
+                              Q_ARG(int, DEFAULT_NOTES_FOLDER_ID));
     for (const auto &id : std::as_const(needRestored)) {
         emit requestMoveNoteDb(id, defaultNotesFolder);
     }
@@ -584,9 +584,9 @@ void ListViewLogic::restoreNotesRequestedI(const QModelIndexList &indexes)
 void ListViewLogic::updateListViewLabel()
 {
     QString l1, l2;
-    if ((!m_listViewInfo.isInTag) && m_listViewInfo.parentFolderId == SpecialNodeID::RootFolder) {
+    if ((!m_listViewInfo.isInTag) && m_listViewInfo.parentFolderId == ROOT_FOLDER_ID) {
         l1 = "All Notes";
-    } else if ((!m_listViewInfo.isInTag) && m_listViewInfo.parentFolderId == SpecialNodeID::TrashFolder) {
+    } else if ((!m_listViewInfo.isInTag) && m_listViewInfo.parentFolderId == TRASH_FOLDER_ID) {
         l1 = "Trash";
     } else if (!m_listViewInfo.isInTag) {
         NodeData parentFolder;

--- a/src/listviewlogic.cpp
+++ b/src/listviewlogic.cpp
@@ -583,7 +583,8 @@ void ListViewLogic::restoreNotesRequestedI(const QModelIndexList &indexes)
 
 void ListViewLogic::updateListViewLabel()
 {
-    QString l1, l2;
+    QString l1;
+    QString l2;
     if ((!m_listViewInfo.isInTag) && m_listViewInfo.parentFolderId == ROOT_FOLDER_ID) {
         l1 = "All Notes";
     } else if ((!m_listViewInfo.isInTag) && m_listViewInfo.parentFolderId == TRASH_FOLDER_ID) {
@@ -594,7 +595,7 @@ void ListViewLogic::updateListViewLabel()
                                   Q_ARG(int, m_listViewInfo.parentFolderId));
         l1 = parentFolder.fullTitle();
     } else {
-        if (m_listViewInfo.currentTagList.size() == 0) {
+        if (m_listViewInfo.currentTagList.empty()) {
             l1 = "Tags ...";
         } else if (m_listViewInfo.currentTagList.size() > 1) {
             l1 = "Multiple tags ...";
@@ -622,7 +623,8 @@ void ListViewLogic::onRowCountChanged()
         auto range = abs(m_listView->viewport()->height());
         if (y < -range) {
             continue;
-        } else if (y > 2 * range) {
+        }
+        if (y > 2 * range) {
             break;
         }
         m_listView->openPersistentEditorC(index);

--- a/src/listviewlogic.h
+++ b/src/listviewlogic.h
@@ -39,7 +39,7 @@ public slots:
     void selectNoteUp();
     void selectNoteDown();
     void onSearchEditTextChanged(const QString &keyword);
-    void clearSearch(bool createNewNote = false, int scrollToId = SpecialNodeID::InvalidNodeId);
+    void clearSearch(bool createNewNote = false, int scrollToId = INVALID_NODE_ID);
     void onAddTagRequestD(int noteId, int tagId);
     void onNoteMovedOut(int nodeId, int targetId);
     void setLastSelectedNote();

--- a/src/listviewlogic.h
+++ b/src/listviewlogic.h
@@ -20,9 +20,8 @@ class ListViewLogic : public QObject
 {
     Q_OBJECT
 public:
-    explicit ListViewLogic(NoteListView *noteView, NoteListModel *noteModel, QLineEdit *searchEdit,
-                           QToolButton *clearButton, TagPool *tagPool, DBManager *dbManager,
-                           QObject *parent = nullptr);
+    explicit ListViewLogic(NoteListView *noteView, NoteListModel *noteModel, QLineEdit *searchEdit, QToolButton *clearButton, TagPool *tagPool,
+                           DBManager *dbManager, QObject *parent = nullptr);
     void selectNote(const QModelIndex &noteIndex);
 
     const ListViewInfo &listViewInfo() const;

--- a/src/lqtutils_enum.h
+++ b/src/lqtutils_enum.h
@@ -34,7 +34,7 @@
 #define L_DECLARE_ENUM(enumName, ...)                                                                                                      \
     namespace enumName {                                                                                                                   \
     Q_NAMESPACE                                                                                                                            \
-    enum Value { __VA_ARGS__ };                                                                                                            \
+    enum Value : uint8_t { __VA_ARGS__ };                                                                                                            \
     Q_ENUM_NS(Value)                                                                                                                       \
     inline int qmlRegister##enumName(const char *uri, int major, int minor)                                                                \
     {                                                                                                                                      \

--- a/src/lqtutils_enum.h
+++ b/src/lqtutils_enum.h
@@ -24,31 +24,30 @@
 
 // Credit: https://github.com/carlonluca/lqtutils
 
-#ifndef LQTUTILS_ENUM_H
-#define LQTUTILS_ENUM_H
+#pragma once
 
 #include <QObject>
 #include <QQmlEngine>
 
-#define L_DECLARE_ENUM(enumName, ...)                                                      \
-  namespace enumName {                                                                     \
-  Q_NAMESPACE                                                                              \
-  enum Value { __VA_ARGS__ };                                                              \
-  Q_ENUM_NS(Value)                                                                         \
-  inline int qmlRegister##enumName(const char *uri, int major, int minor)                  \
-  {                                                                                        \
-    return qmlRegisterUncreatableMetaObject(enumName::staticMetaObject, uri, major, minor, \
-                                            #enumName, "Access to enums & flags only");    \
-  }                                                                                        \
-  inline int qRegisterMetaType()                                                           \
-  {                                                                                        \
-    return ::qRegisterMetaType<enumName::Value>(#enumName);                                \
-  }                                                                                        \
-  inline void registerEnum(const char *uri, int major, int minor)                          \
-  {                                                                                        \
-    enumName::qmlRegister##enumName(uri, major, minor);                                    \
-    enumName::qRegisterMetaType();                                                         \
-  }                                                                                        \
-  }
-
-#endif // LQTUTILS_ENUM_H
+// older versions of clang-format (which are used by the CI) mess this up, so we disable formatting for this block
+// clang-format off
+#define L_DECLARE_ENUM(enumName, ...)                                                                                                      \
+    namespace enumName {                                                                                                                   \
+    Q_NAMESPACE                                                                                                                            \
+    enum Value { __VA_ARGS__ };                                                                                                            \
+    Q_ENUM_NS(Value)                                                                                                                       \
+    inline int qmlRegister##enumName(const char *uri, int major, int minor)                                                                \
+    {                                                                                                                                      \
+        return qmlRegisterUncreatableMetaObject(enumName::staticMetaObject, uri, major, minor, #enumName, "Access to enums & flags only"); \
+    }                                                                                                                                      \
+    inline int qRegisterMetaType()                                                                                                         \
+    {                                                                                                                                      \
+        return ::qRegisterMetaType<enumName::Value>(#enumName);                                                                            \
+    }                                                                                                                                      \
+    inline void registerEnum(const char *uri, int major, int minor)                                                                        \
+    {                                                                                                                                      \
+        enumName::qmlRegister##enumName(uri, major, minor);                                                                                \
+        enumName::qRegisterMetaType();                                                                                                     \
+    }                                                                                                                                      \
+    }
+// clang-format on

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -97,8 +97,7 @@ int main(int argc, char *argv[])
     w.show();
 
     // Bring the Notes window to the front
-    QObject::connect(&instance, &SingleInstance::newInstance, &w,
-                     [&]() { (&w)->setMainWindowVisibility(true); });
+    QObject::connect(&instance, &SingleInstance::newInstance, &w, [&]() { (&w)->setMainWindowVisibility(true); });
 
     return app.exec();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,11 +13,11 @@ int main(int argc, char *argv[])
 {
     QApplication app(argc, argv);
     // Set application information
-    app.setApplicationName("Notes");
-    app.setApplicationVersion(APP_VERSION);
+    QApplication::setApplicationName("Notes");
+    QApplication::setApplicationVersion(APP_VERSION);
 
 #if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
-    app.setDesktopFileName(APP_ID);
+    QApplication::setDesktopFileName(APP_ID);
 #endif
 
     if (QFontDatabase::addApplicationFont(":/fonts/fontawesome/fa-solid-900.ttf") < 0)
@@ -86,7 +86,7 @@ int main(int argc, char *argv[])
     // Prevent many instances of the app to be launched
     QString name = "com.awsomeness.notes";
     SingleInstance instance;
-    if (instance.hasPrevious(name)) {
+    if (SingleInstance::hasPrevious(name)) {
         return EXIT_SUCCESS;
     }
 
@@ -99,5 +99,5 @@ int main(int argc, char *argv[])
     // Bring the Notes window to the front
     QObject::connect(&instance, &SingleInstance::newInstance, &w, [&]() { (&w)->setMainWindowVisibility(true); });
 
-    return app.exec();
+    return QApplication::exec();
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -701,8 +701,8 @@ void MainWindow::setupButtons()
     m_yellowMinimizeButton->installEventFilter(this);
     m_greenMaximizeButton->installEventFilter(this);
 
-    QFont fontAwesomeIcon = FontLoader::getInstance().loadFont("Font Awesome 6 Free Solid", "", 16);
-    QFont materialSymbols = FontLoader::getInstance().loadFont("Material Symbols Outlined", "", 30);
+    QFont fontAwesomeIcon = font_loader::loadFont("Font Awesome 6 Free Solid", "", 16);
+    QFont materialSymbols = font_loader::loadFont("Material Symbols Outlined", "", 30);
 
 #if defined(Q_OS_MACOS)
     int pointSizeOffset = 0;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1818,7 +1818,7 @@ void MainWindow::setButtonsAndFieldsEnabled(bool doEnable)
 void MainWindow::setKanbanVisibility(bool isVisible)
 {
     auto inf = m_listViewLogic->listViewInfo();
-    if (isVisible && inf.parentFolderId != SpecialNodeID::TrashFolder) {
+    if (isVisible && inf.parentFolderId != TRASH_FOLDER_ID) {
         emit m_noteEditorLogic->showKanbanView();
     } else {
         emit m_noteEditorLogic->hideKanbanView();
@@ -2354,21 +2354,21 @@ void MainWindow::createNewNote()
         tmpNote.setLastModificationDateTime(noteDate);
         tmpNote.setFullTitle(QStringLiteral("New Note"));
         auto inf = m_listViewLogic->listViewInfo();
-        if ((!inf.isInTag) && (inf.parentFolderId > SpecialNodeID::RootFolder)) {
+        if ((!inf.isInTag) && (inf.parentFolderId > ROOT_FOLDER_ID)) {
             NodeData parent;
             QMetaObject::invokeMethod(m_dbManager, "getNode", Qt::BlockingQueuedConnection, Q_RETURN_ARG(NodeData, parent), Q_ARG(int, inf.parentFolderId));
             if (parent.nodeType() == NodeData::Type::Folder) {
                 tmpNote.setParentId(parent.id());
                 tmpNote.setParentName(parent.fullTitle());
             } else {
-                tmpNote.setParentId(SpecialNodeID::DefaultNotesFolder);
+                tmpNote.setParentId(DEFAULT_NOTES_FOLDER_ID);
                 tmpNote.setParentName("Notes");
             }
         } else {
-            tmpNote.setParentId(SpecialNodeID::DefaultNotesFolder);
+            tmpNote.setParentId(DEFAULT_NOTES_FOLDER_ID);
             tmpNote.setParentName("Notes");
         }
-        int noteId = SpecialNodeID::InvalidNodeId;
+        int noteId = INVALID_NODE_ID;
         QMetaObject::invokeMethod(m_dbManager, "nextAvailableNodeId", Qt::BlockingQueuedConnection, Q_RETURN_ARG(int, noteId));
         tmpNote.setId(noteId);
         tmpNote.setIsTempNote(true);
@@ -2400,7 +2400,7 @@ void MainWindow::selectNoteDown()
  */
 void MainWindow::setFocusOnText()
 {
-    if (m_noteEditorLogic->currentEditingNoteId() != SpecialNodeID::InvalidNodeId && !m_textEdit->hasFocus()) {
+    if (m_noteEditorLogic->currentEditingNoteId() != INVALID_NODE_ID && !m_textEdit->hasFocus()) {
         m_listView->setCurrentRowActive(true);
         m_textEdit->setFocus();
     }
@@ -2663,7 +2663,7 @@ void MainWindow::executeImport(const bool replace)
             emit requestImportNotes(fileName);
         }
         setButtonsAndFieldsEnabled(true);
-        //        emit requestNotesList(SpecialNodeID::RootFolder, true);
+        //        emit requestNotesList(ROOT_FOLDER_ID, true);
     }
 }
 
@@ -3768,14 +3768,14 @@ bool MainWindow::eventFilter(QObject *object, QEvent *event)
                     if (!m_searchEdit->text().isEmpty()) {
                         m_listViewLogic->clearSearch(true);
                     } else {
-                        if (inf.parentFolderId != SpecialNodeID::TrashFolder) {
+                        if (inf.parentFolderId != TRASH_FOLDER_ID) {
                             createNewNote();
                         }
                     }
                 }
             }
             m_listView->setCurrentRowActive(true);
-            if (inf.parentFolderId == SpecialNodeID::TrashFolder) {
+            if (inf.parentFolderId == TRASH_FOLDER_ID) {
                 m_textEdit->setReadOnly(true);
             } else {
                 m_textEdit->setFocus();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -90,11 +90,9 @@ MainWindow::MainWindow(QWidget *parent)
       m_alwaysStayOnTop(false),
       m_useNativeWindowFrame(false),
       m_hideToTray(false),
-      m_listOfSerifFonts(
-              { QStringLiteral("Trykker"), QStringLiteral("PT Serif"), QStringLiteral("Mate") }),
+      m_listOfSerifFonts({ QStringLiteral("Trykker"), QStringLiteral("PT Serif"), QStringLiteral("Mate") }),
       m_listOfSansSerifFonts({ QStringLiteral("Source Sans Pro"), QStringLiteral("Roboto") }),
-      m_listOfMonoFonts({ QStringLiteral("iA Writer Mono S"), QStringLiteral("iA Writer Duo S"),
-                          QStringLiteral("iA Writer Quattro S") }),
+      m_listOfMonoFonts({ QStringLiteral("iA Writer Mono S"), QStringLiteral("iA Writer Duo S"), QStringLiteral("iA Writer Quattro S") }),
       m_chosenSerifFontIndex(0),
       m_chosenSansSerifFontIndex(0),
       m_chosenMonoFontIndex(0),
@@ -103,12 +101,9 @@ MainWindow::MainWindow(QWidget *parent)
                                    80 }), // SansSerif
       m_currentFontTypeface(FontTypeface::SansSerif),
 #ifdef __APPLE__
-      m_displayFont(QFont(QStringLiteral("SF Pro Text")).exactMatch()
-                            ? QStringLiteral("SF Pro Text")
-                            : QStringLiteral("Roboto")),
+      m_displayFont(QFont(QStringLiteral("SF Pro Text")).exactMatch() ? QStringLiteral("SF Pro Text") : QStringLiteral("Roboto")),
 #elif _WIN32
-      m_displayFont(QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI")
-                                                                   : QStringLiteral("Roboto")),
+      m_displayFont(QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI") : QStringLiteral("Roboto")),
 #else
       m_displayFont(QStringLiteral("Roboto")),
 #endif
@@ -127,8 +122,7 @@ MainWindow::MainWindow(QWidget *parent)
       m_subscriptionWindowWidget(new QWidget(this)),
       m_purchaseDataAlt1(QStringLiteral("https://raw.githubusercontent.com/nuttyartist/notes/"
                                         "master/notes_purchase_data.json")),
-      m_purchaseDataAlt2(
-              QStringLiteral("https://www.rubymamistvalove.com/notes/notes_purchase_data.json")),
+      m_purchaseDataAlt2(QStringLiteral("https://www.rubymamistvalove.com/notes/notes_purchase_data.json")),
       m_dataBuffer(std::make_unique<QByteArray>()),
       m_netManager(new QNetworkAccessManager(this)),
       m_reqAlt1(QNetworkRequest(QUrl(m_purchaseDataAlt1))),
@@ -185,8 +179,7 @@ void MainWindow::InitData()
 
     bool isV0_9_0 = (QFile::exists(oldNoteDBPath) || QFile::exists(oldTrashDBPath));
     if (isV0_9_0) {
-        QProgressDialog *pd =
-                new QProgressDialog(tr("Migrating database, please wait."), QString(), 0, 0, this);
+        QProgressDialog *pd = new QProgressDialog(tr("Migrating database, please wait."), QString(), 0, 0, this);
         pd->setCancelButton(nullptr);
 #if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
         pd->setWindowFlags(Qt::Window);
@@ -208,8 +201,7 @@ void MainWindow::InitData()
         watcher->setFuture(migration);
     }
     /// Check if it is running with an argument (ex. hide)
-    if (qApp->arguments().contains(QStringLiteral("--autostart"))
-        && QSystemTrayIcon::isSystemTrayAvailable()) {
+    if (qApp->arguments().contains(QStringLiteral("--autostart")) && QSystemTrayIcon::isSystemTrayAvailable()) {
         setMainWindowVisibility(false);
     }
 
@@ -249,8 +241,7 @@ void MainWindow::setMainWindowVisibility(bool state)
     }
 }
 
-void MainWindow::saveLastSelectedFolderTags(bool isFolder, const QString &folderPath,
-                                            const QSet<int> &tagId)
+void MainWindow::saveLastSelectedFolderTags(bool isFolder, const QString &folderPath, const QSet<int> &tagId)
 {
     m_settingsDatabase->setValue("isSelectingFolder", isFolder);
     m_settingsDatabase->setValue("currentSelectFolder", folderPath);
@@ -319,8 +310,7 @@ void MainWindow::resizeEvent(QResizeEvent *event)
 
     resizeAndPositionEditorSettingsWindow();
 
-    QJsonObject dataToSendToView{ { "parentWindowHeight", height() },
-                                  { "parentWindowWidth", width() } };
+    QJsonObject dataToSendToView{ { "parentWindowHeight", height() }, { "parentWindowWidth", width() } };
     emit mainWindowResized(QVariant(dataToSendToView));
 
     QMainWindow::resizeEvent(event);
@@ -334,14 +324,11 @@ void MainWindow::resizeAndPositionEditorSettingsWindow()
 #if defined(Q_OS_WINDOWS) || (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
     m_editorSettingsWidget->resize(240, 0.80 * this->height());
     QPoint buttonGlobalPos = m_dotsButton->mapToGlobal(QPoint(0, 0));
-    m_editorSettingsWidget->move(buttonGlobalPos.x() - m_editorSettingsWidget->width()
-                                         + m_dotsButton->width(),
-                                 buttonGlobalPos.y() + m_dotsButton->height());
+    m_editorSettingsWidget->move(buttonGlobalPos.x() - m_editorSettingsWidget->width() + m_dotsButton->width(), buttonGlobalPos.y() + m_dotsButton->height());
 #else
     m_editorSettingsWidget->resize(300, 0.80 * this->height() + 40);
     QPoint buttonGlobalPos = m_dotsButton->mapToGlobal(QPoint(0, 0));
-    m_editorSettingsWidget->move(buttonGlobalPos.x() - m_editorSettingsWidget->width() + 70,
-                                 buttonGlobalPos.y() + m_dotsButton->height() - 10);
+    m_editorSettingsWidget->move(buttonGlobalPos.x() - m_editorSettingsWidget->width() + 70, buttonGlobalPos.y() + m_dotsButton->height() - 10);
 #endif
 }
 
@@ -367,8 +354,7 @@ void MainWindow::setupMainWindow()
 #if !defined(Q_OS_MAC)
     auto flags = Qt::Window | Qt::CustomizeWindowHint;
 #  if defined(Q_OS_UNIX)
-    //    flags |= Qt::FramelessWindowHint;
-    flags = Qt::Window;
+    flags = Qt::Window; // cppcheck-suppress redundantInitialization // false positive
 #  endif
     setWindowFlags(flags);
 #endif
@@ -555,8 +541,7 @@ void MainWindow::setupKeyboardShortcuts()
     // new QShortcut(QKeySequence(Qt::Key_Return), this, SLOT(setFocusOnText()));
     new QShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_F), this, SLOT(fullscreenWindow()));
     new QShortcut(Qt::Key_F11, this, SLOT(fullscreenWindow()));
-    connect(new QShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_L), this),
-            &QShortcut::activated, this, [=]() { m_listView->setFocus(); });
+    connect(new QShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_L), this), &QShortcut::activated, this, [=]() { m_listView->setFocus(); });
     new QShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_M), this, SLOT(minimizeWindow()));
     new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_Q), this, SLOT(QuitApplication()));
 #if defined(Q_OS_MACOS) || defined(Q_OS_WINDOWS)
@@ -569,21 +554,18 @@ void MainWindow::setupKeyboardShortcuts()
     new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_B), this, SLOT(makeBold()));
     new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_I), this, SLOT(makeItalic()));
     new QShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_X), this, SLOT(makeStrikethrough()));
-    new QShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_Minus), this,
-                  SLOT(decreaseHeading()));
-    new QShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_Equal), this,
-                  SLOT(increaseHeading()));
+    new QShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_Minus), this, SLOT(decreaseHeading()));
+    new QShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_Equal), this, SLOT(increaseHeading()));
     new QShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_Plus), this, SLOT(increaseHeading()));
-    connect(new QShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_S), this),
-            &QShortcut::activated, this, [=]() {
+    connect(new QShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_S), this), &QShortcut::activated, this, [=]() {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 2, 0)
-                if (m_kanbanWidget->isHidden()) {
-                    if (m_editorSettingsWidget->isHidden()) {
-                        showEditorSettings();
-                    }
-                } else {
-                    emit toggleEditorSettingsKeyboardShorcutFired();
-                };
+        if (m_kanbanWidget->isHidden()) {
+            if (m_editorSettingsWidget->isHidden()) {
+                showEditorSettings();
+            }
+        } else {
+            emit toggleEditorSettingsKeyboardShorcutFired();
+        };
 #else
             if (m_editorSettingsWidget->isHidden()) {
                 showEditorSettings();
@@ -591,37 +573,29 @@ void MainWindow::setupKeyboardShortcuts()
                 m_editorSettingsWidget->close();
             }
 #endif
-            });
-    connect(new QShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_S), m_editorSettingsWidget),
-            &QShortcut::activated, this, [=]() {
+    });
+    connect(new QShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_S), m_editorSettingsWidget), &QShortcut::activated, this, [=]() {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 2, 0)
-                if (m_kanbanWidget->isHidden()) {
-                    if (!m_editorSettingsWidget->isHidden()) {
-                        m_editorSettingsWidget->close();
-                    }
-                } else {
-                    emit toggleEditorSettingsKeyboardShorcutFired();
-                };
+        if (m_kanbanWidget->isHidden()) {
+            if (!m_editorSettingsWidget->isHidden()) {
+                m_editorSettingsWidget->close();
+            }
+        } else {
+            emit toggleEditorSettingsKeyboardShorcutFired();
+        };
 #else
                 if (m_editorSettingsWidget->isVisible()) {
                     m_editorSettingsWidget->close();
                 };
 #endif
-            });
-    connect(new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_0), this), &QShortcut::activated, this,
-            [=]() { setHeading(0); });
-    connect(new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_1), this), &QShortcut::activated, this,
-            [=]() { setHeading(1); });
-    connect(new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_2), this), &QShortcut::activated, this,
-            [=]() { setHeading(2); });
-    connect(new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_3), this), &QShortcut::activated, this,
-            [=]() { setHeading(3); });
-    connect(new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_4), this), &QShortcut::activated, this,
-            [=]() { setHeading(4); });
-    connect(new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_5), this), &QShortcut::activated, this,
-            [=]() { setHeading(5); });
-    connect(new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_6), this), &QShortcut::activated, this,
-            [=]() { setHeading(6); });
+    });
+    connect(new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_0), this), &QShortcut::activated, this, [=]() { setHeading(0); });
+    connect(new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_1), this), &QShortcut::activated, this, [=]() { setHeading(1); });
+    connect(new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_2), this), &QShortcut::activated, this, [=]() { setHeading(2); });
+    connect(new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_3), this), &QShortcut::activated, this, [=]() { setHeading(3); });
+    connect(new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_4), this), &QShortcut::activated, this, [=]() { setHeading(4); });
+    connect(new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_5), this), &QShortcut::activated, this, [=]() { setHeading(5); });
+    connect(new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_6), this), &QShortcut::activated, this, [=]() { setHeading(6); });
     new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_Backslash), this, SLOT(resetBlockFormat()));
 
     QxtGlobalShortcut *shortcut = new QxtGlobalShortcut(this);
@@ -635,10 +609,8 @@ void MainWindow::setupKeyboardShortcuts()
         // from taking 'N' from shortcut
         m_textEdit->setDisabled(true);
         m_searchEdit->setDisabled(true);
-        setMainWindowVisibility(isHidden() || windowState() == Qt::WindowMinimized
-                                || qApp->applicationState() == Qt::ApplicationInactive);
-        if (isHidden() || windowState() == Qt::WindowMinimized
-            || qApp->applicationState() == Qt::ApplicationInactive)
+        setMainWindowVisibility(isHidden() || windowState() == Qt::WindowMinimized || qApp->applicationState() == Qt::ApplicationInactive);
+        if (isHidden() || windowState() == Qt::WindowMinimized || qApp->applicationState() == Qt::ApplicationInactive)
 #ifdef __APPLE__
             raise();
 #else
@@ -648,14 +620,13 @@ void MainWindow::setupKeyboardShortcuts()
         m_searchEdit->setDisabled(false);
     });
 #if QT_VERSION >= QT_VERSION_CHECK(6, 2, 0)
-    connect(new QShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_K), this),
-            &QShortcut::activated, this, [=]() {
-                if (m_kanbanWidget->isHidden()) {
-                    setKanbanVisibility(true);
-                } else {
-                    setKanbanVisibility(false);
-                }
-            });
+    connect(new QShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_K), this), &QShortcut::activated, this, [=]() {
+        if (m_kanbanWidget->isHidden()) {
+            setKanbanVisibility(true);
+        } else {
+            setKanbanVisibility(false);
+        }
+    });
 #endif
 }
 
@@ -757,38 +728,30 @@ void MainWindow::setupButtons()
 void MainWindow::setupSignalsSlots()
 {
 #if defined(UPDATE_CHECKER)
-    connect(&m_updater, &UpdaterWindow::dontShowUpdateWindowChanged, this,
-            [=](bool state) { m_dontShowUpdateWindow = state; });
+    connect(&m_updater, &UpdaterWindow::dontShowUpdateWindowChanged, this, [=](bool state) { m_dontShowUpdateWindow = state; });
 #endif
     // actions
     // connect(rightToLeftActionion, &QAction::triggered, this, );
     // connect(checkForUpdatesAction, &QAction::triggered, this, );
     // green button
-    connect(m_greenMaximizeButton, &QPushButton::pressed, this,
-            &MainWindow::onGreenMaximizeButtonPressed);
-    connect(m_greenMaximizeButton, &QPushButton::clicked, this,
-            &MainWindow::onGreenMaximizeButtonClicked);
+    connect(m_greenMaximizeButton, &QPushButton::pressed, this, &MainWindow::onGreenMaximizeButtonPressed);
+    connect(m_greenMaximizeButton, &QPushButton::clicked, this, &MainWindow::onGreenMaximizeButtonClicked);
     // red button
     connect(m_redCloseButton, &QPushButton::pressed, this, &MainWindow::onRedCloseButtonPressed);
     connect(m_redCloseButton, &QPushButton::clicked, this, &MainWindow::onRedCloseButtonClicked);
     // yellow button
-    connect(m_yellowMinimizeButton, &QPushButton::pressed, this,
-            &MainWindow::onYellowMinimizeButtonPressed);
-    connect(m_yellowMinimizeButton, &QPushButton::clicked, this,
-            &MainWindow::onYellowMinimizeButtonClicked);
+    connect(m_yellowMinimizeButton, &QPushButton::pressed, this, &MainWindow::onYellowMinimizeButtonPressed);
+    connect(m_yellowMinimizeButton, &QPushButton::clicked, this, &MainWindow::onYellowMinimizeButtonClicked);
     // new note button
     connect(m_newNoteButton, &QPushButton::clicked, this, &MainWindow::onNewNoteButtonClicked);
     // 3 dots button
     connect(m_dotsButton, &QPushButton::clicked, this, &MainWindow::onDotsButtonClicked);
     // switch to kanban view button
-    connect(m_switchToKanbanViewButton, &QPushButton::clicked, this,
-            &MainWindow::onSwitchToKanbanViewButtonClicked);
+    connect(m_switchToKanbanViewButton, &QPushButton::clicked, this, &MainWindow::onSwitchToKanbanViewButtonClicked);
     // global settings button
-    connect(m_globalSettingsButton, &QPushButton::clicked, this,
-            &MainWindow::onGlobalSettingsButtonClicked);
+    connect(m_globalSettingsButton, &QPushButton::clicked, this, &MainWindow::onGlobalSettingsButtonClicked);
     // line edit text changed
-    connect(m_searchEdit, &QLineEdit::textChanged, m_listViewLogic,
-            &ListViewLogic::onSearchEditTextChanged);
+    connect(m_searchEdit, &QLineEdit::textChanged, m_listViewLogic, &ListViewLogic::onSearchEditTextChanged);
     // line edit enter key pressed
     connect(m_searchEdit, &QLineEdit::returnPressed, this, &MainWindow::onSearchEditReturnPressed);
     // clear button
@@ -798,15 +761,12 @@ void MainWindow::setupSignalsSlots()
 
 #if !defined(Q_OS_MAC)
     // System tray context menu action: "Show/Hide Notes"
-    connect(m_restoreAction, &QAction::triggered, this, [this]() {
-        setMainWindowVisibility(isHidden() || windowState() == Qt::WindowMinimized
-                                || (qApp->applicationState() == Qt::ApplicationInactive));
-    });
+    connect(m_restoreAction, &QAction::triggered, this,
+            [this]() { setMainWindowVisibility(isHidden() || windowState() == Qt::WindowMinimized || (qApp->applicationState() == Qt::ApplicationInactive)); });
     // System tray context menu action: "Quit"
     connect(m_quitAction, &QAction::triggered, this, &MainWindow::QuitApplication);
     // Application state changed
-    connect(qApp, &QApplication::applicationStateChanged, this,
-            [this]() { m_listView->update(m_listView->currentIndex()); });
+    connect(qApp, &QApplication::applicationStateChanged, this, [this]() { m_listView->update(m_listView->currentIndex()); });
 #endif
 
     // TextEdit's scroll bar
@@ -820,42 +780,26 @@ void MainWindow::setupSignalsSlots()
             m_textEditScrollBarTimer->start(m_textEditScrollBarTimerDuration);
         }
     });
-    connect(m_textEditScrollBarTimer, &QTimer::timeout, this,
-            [=]() { m_textEdit->verticalScrollBar()->hide(); });
+    connect(m_textEditScrollBarTimer, &QTimer::timeout, this, [=]() { m_textEdit->verticalScrollBar()->hide(); });
 #endif
 
     // MainWindow <-> DBManager
-    connect(this, &MainWindow::requestNodesTree, m_dbManager, &DBManager::onNodeTagTreeRequested,
-            Qt::BlockingQueuedConnection);
-    connect(this, &MainWindow::requestRestoreNotes, m_dbManager,
-            &DBManager::onRestoreNotesRequested, Qt::BlockingQueuedConnection);
-    connect(this, &MainWindow::requestImportNotes, m_dbManager, &DBManager::onImportNotesRequested,
-            Qt::BlockingQueuedConnection);
-    connect(this, &MainWindow::requestExportNotes, m_dbManager, &DBManager::onExportNotesRequested,
-            Qt::BlockingQueuedConnection);
-    connect(this, &MainWindow::requestMigrateNotesFromV0_9_0, m_dbManager,
-            &DBManager::onMigrateNotesFromV0_9_0Requested, Qt::BlockingQueuedConnection);
-    connect(this, &MainWindow::requestMigrateTrashFromV0_9_0, m_dbManager,
-            &DBManager::onMigrateTrashFrom0_9_0Requested, Qt::BlockingQueuedConnection);
+    connect(this, &MainWindow::requestNodesTree, m_dbManager, &DBManager::onNodeTagTreeRequested, Qt::BlockingQueuedConnection);
+    connect(this, &MainWindow::requestRestoreNotes, m_dbManager, &DBManager::onRestoreNotesRequested, Qt::BlockingQueuedConnection);
+    connect(this, &MainWindow::requestImportNotes, m_dbManager, &DBManager::onImportNotesRequested, Qt::BlockingQueuedConnection);
+    connect(this, &MainWindow::requestExportNotes, m_dbManager, &DBManager::onExportNotesRequested, Qt::BlockingQueuedConnection);
+    connect(this, &MainWindow::requestMigrateNotesFromV0_9_0, m_dbManager, &DBManager::onMigrateNotesFromV0_9_0Requested, Qt::BlockingQueuedConnection);
+    connect(this, &MainWindow::requestMigrateTrashFromV0_9_0, m_dbManager, &DBManager::onMigrateTrashFrom0_9_0Requested, Qt::BlockingQueuedConnection);
 
-    connect(m_listViewLogic, &ListViewLogic::showNotesInEditor, m_noteEditorLogic,
-            &NoteEditorLogic::showNotesInEditor);
-    connect(m_listViewLogic, &ListViewLogic::closeNoteEditor, m_noteEditorLogic,
-            &NoteEditorLogic::closeEditor);
-    connect(m_noteEditorLogic, &NoteEditorLogic::setVisibilityOfFrameRightWidgets, this,
-            [this](bool vl) { setVisibilityOfFrameRightWidgets(vl); });
-    connect(m_noteEditorLogic, &NoteEditorLogic::setVisibilityOfFrameRightNonEditor, this,
-            [this](bool vl) { setVisibilityOfFrameRightNonEditor(vl); });
-    connect(m_noteEditorLogic, &NoteEditorLogic::moveNoteToListViewTop, m_listViewLogic,
-            &ListViewLogic::moveNoteToTop);
-    connect(m_noteEditorLogic, &NoteEditorLogic::updateNoteDataInList, m_listViewLogic,
-            &ListViewLogic::setNoteData);
-    connect(m_noteEditorLogic, &NoteEditorLogic::deleteNoteRequested, m_listViewLogic,
-            &ListViewLogic::deleteNoteRequested);
-    connect(m_listViewLogic, &ListViewLogic::noteTagListChanged, m_noteEditorLogic,
-            &NoteEditorLogic::onNoteTagListChanged);
-    connect(m_noteEditorLogic, &NoteEditorLogic::noteEditClosed, m_listViewLogic,
-            &ListViewLogic::onNoteEditClosed);
+    connect(m_listViewLogic, &ListViewLogic::showNotesInEditor, m_noteEditorLogic, &NoteEditorLogic::showNotesInEditor);
+    connect(m_listViewLogic, &ListViewLogic::closeNoteEditor, m_noteEditorLogic, &NoteEditorLogic::closeEditor);
+    connect(m_noteEditorLogic, &NoteEditorLogic::setVisibilityOfFrameRightWidgets, this, [this](bool vl) { setVisibilityOfFrameRightWidgets(vl); });
+    connect(m_noteEditorLogic, &NoteEditorLogic::setVisibilityOfFrameRightNonEditor, this, [this](bool vl) { setVisibilityOfFrameRightNonEditor(vl); });
+    connect(m_noteEditorLogic, &NoteEditorLogic::moveNoteToListViewTop, m_listViewLogic, &ListViewLogic::moveNoteToTop);
+    connect(m_noteEditorLogic, &NoteEditorLogic::updateNoteDataInList, m_listViewLogic, &ListViewLogic::setNoteData);
+    connect(m_noteEditorLogic, &NoteEditorLogic::deleteNoteRequested, m_listViewLogic, &ListViewLogic::deleteNoteRequested);
+    connect(m_listViewLogic, &ListViewLogic::noteTagListChanged, m_noteEditorLogic, &NoteEditorLogic::onNoteTagListChanged);
+    connect(m_noteEditorLogic, &NoteEditorLogic::noteEditClosed, m_listViewLogic, &ListViewLogic::onNoteEditClosed);
     connect(m_noteEditorLogic, &NoteEditorLogic::showKanbanView, this, [this]() {
         if (!m_editorSettingsWidget->isHidden()) {
             m_editorSettingsWidget->close();
@@ -872,47 +816,33 @@ void MainWindow::setupSignalsSlots()
         ui->frameRightTop->show();
     });
     connect(m_listViewLogic, &ListViewLogic::requestClearSearchUI, this, &MainWindow::clearSearch);
-    connect(m_treeViewLogic, &TreeViewLogic::addNoteToTag, m_listViewLogic,
-            &ListViewLogic::onAddTagRequestD);
-    connect(m_listViewLogic, &ListViewLogic::listViewLabelChanged, this,
-            [this](const QString &l1, const QString &l2) {
-                ui->listviewLabel1->setText(l1);
-                ui->listviewLabel2->setText(l2);
-                m_splitter->setHandleWidth(0);
-            });
+    connect(m_treeViewLogic, &TreeViewLogic::addNoteToTag, m_listViewLogic, &ListViewLogic::onAddTagRequestD);
+    connect(m_listViewLogic, &ListViewLogic::listViewLabelChanged, this, [this](const QString &l1, const QString &l2) {
+        ui->listviewLabel1->setText(l1);
+        ui->listviewLabel2->setText(l2);
+        m_splitter->setHandleWidth(0);
+    });
     connect(m_toggleTreeViewButton, &QPushButton::clicked, this, &MainWindow::toggleFolderTree);
-    connect(m_dbManager, &DBManager::showErrorMessage, this, &MainWindow::showErrorMessage,
-            Qt::QueuedConnection);
-    connect(m_listViewLogic, &ListViewLogic::requestNewNote, this,
-            &MainWindow::onNewNoteButtonClicked);
+    connect(m_dbManager, &DBManager::showErrorMessage, this, &MainWindow::showErrorMessage, Qt::QueuedConnection);
+    connect(m_listViewLogic, &ListViewLogic::requestNewNote, this, &MainWindow::onNewNoteButtonClicked);
     connect(m_listViewLogic, &ListViewLogic::moveNoteRequested, this, [this](int id, int target) {
         m_treeViewLogic->onMoveNodeRequested(id, target);
         m_treeViewLogic->openFolder(target);
     });
-    connect(m_listViewLogic, &ListViewLogic::setNewNoteButtonVisible, this,
-            [this](bool visible) { ui->newNoteButton->setVisible(visible); });
-    connect(m_treeViewLogic, &TreeViewLogic::noteMoved, m_listViewLogic,
-            &ListViewLogic::onNoteMovedOut);
+    connect(m_listViewLogic, &ListViewLogic::setNewNoteButtonVisible, this, [this](bool visible) { ui->newNoteButton->setVisible(visible); });
+    connect(m_treeViewLogic, &TreeViewLogic::noteMoved, m_listViewLogic, &ListViewLogic::onNoteMovedOut);
 
-    connect(m_listViewLogic, &ListViewLogic::requestClearSearchDb, this,
-            &MainWindow::setNoteListLoading);
-    connect(m_treeView, &NodeTreeView::loadNotesInTagsRequested, this,
-            &MainWindow::setNoteListLoading);
-    connect(m_treeView, &NodeTreeView::loadNotesInFolderRequested, this,
-            &MainWindow::setNoteListLoading);
+    connect(m_listViewLogic, &ListViewLogic::requestClearSearchDb, this, &MainWindow::setNoteListLoading);
+    connect(m_treeView, &NodeTreeView::loadNotesInTagsRequested, this, &MainWindow::setNoteListLoading);
+    connect(m_treeView, &NodeTreeView::loadNotesInFolderRequested, this, &MainWindow::setNoteListLoading);
     connect(m_treeView, &NodeTreeView::saveExpand, this, &MainWindow::saveExpandedFolder);
     connect(m_treeView, &NodeTreeView::saveSelected, this, &MainWindow::saveLastSelectedFolderTags);
     connect(m_listView, &NoteListView::saveSelectedNote, this, &MainWindow::saveLastSelectedNote);
-    connect(m_treeView, &NodeTreeView::saveLastSelectedNote, m_listViewLogic,
-            &ListViewLogic::setLastSelectedNote);
-    connect(m_treeView, &NodeTreeView::requestLoadLastSelectedNote, m_listViewLogic,
-            &ListViewLogic::loadLastSelectedNoteRequested);
-    connect(m_treeView, &NodeTreeView::loadNotesInFolderRequested, m_listViewLogic,
-            &ListViewLogic::onNotesListInFolderRequested);
-    connect(m_treeView, &NodeTreeView::loadNotesInTagsRequested, m_listViewLogic,
-            &ListViewLogic::onNotesListInTagsRequested);
-    connect(this, &MainWindow::requestChangeDatabasePath, m_dbManager,
-            &DBManager::onChangeDatabasePathRequested, Qt::QueuedConnection);
+    connect(m_treeView, &NodeTreeView::saveLastSelectedNote, m_listViewLogic, &ListViewLogic::setLastSelectedNote);
+    connect(m_treeView, &NodeTreeView::requestLoadLastSelectedNote, m_listViewLogic, &ListViewLogic::loadLastSelectedNoteRequested);
+    connect(m_treeView, &NodeTreeView::loadNotesInFolderRequested, m_listViewLogic, &ListViewLogic::onNotesListInFolderRequested);
+    connect(m_treeView, &NodeTreeView::loadNotesInTagsRequested, m_listViewLogic, &ListViewLogic::onNotesListInTagsRequested);
+    connect(this, &MainWindow::requestChangeDatabasePath, m_dbManager, &DBManager::onChangeDatabasePathRequested, Qt::QueuedConnection);
     connect(m_textEdit, &CustomDocument::mouseMoved, this, [this]() {
         if (!m_areNonEditorWidgetsVisible) {
             setVisibilityOfFrameRightWidgets(true);
@@ -989,7 +919,7 @@ void MainWindow::setupSearchEdit()
     m_searchButton->setCursor(Qt::ArrowCursor);
 
     // layout
-    QBoxLayout *layout = new QBoxLayout(QBoxLayout::RightToLeft, m_searchEdit);
+    auto *layout = new QBoxLayout(QBoxLayout::RightToLeft, m_searchEdit);
     layout->setContentsMargins(2, 0, 3, 0);
     layout->addWidget(m_clearButton);
     layout->addStretch();
@@ -1041,8 +971,7 @@ void MainWindow::setupEditorSettings()
 #endif
 
     m_editorSettingsQuickView.rootContext()->setContextProperty("mainWindow", this);
-    m_editorSettingsQuickView.rootContext()->setContextProperty("noteEditorLogic",
-                                                                m_noteEditorLogic);
+    m_editorSettingsQuickView.rootContext()->setContextProperty("noteEditorLogic", m_noteEditorLogic);
     m_editorSettingsQuickView.setSource(source);
     m_editorSettingsQuickView.setResizeMode(QQuickView::SizeViewToRootObject);
     m_editorSettingsQuickView.setFlags(Qt::FramelessWindowHint);
@@ -1050,8 +979,7 @@ void MainWindow::setupEditorSettings()
     m_editorSettingsWidget = QWidget::createWindowContainer(&m_editorSettingsQuickView, this);
 #if defined(Q_OS_MACOS)
 #  if QT_VERSION >= QT_VERSION_CHECK(6, 2, 0)
-    m_editorSettingsWidget->setWindowFlags(Qt::Popup | Qt::FramelessWindowHint
-                                           | Qt::NoDropShadowWindowHint);
+    m_editorSettingsWidget->setWindowFlags(Qt::Popup | Qt::FramelessWindowHint | Qt::NoDropShadowWindowHint);
 #  else
     m_editorSettingsWidget->setWindowFlags(Qt::Window | Qt::CustomizeWindowHint);
     m_editorSettingsWidget->setAttribute(Qt::WA_AlwaysStackOnTop);
@@ -1070,9 +998,7 @@ void MainWindow::setupEditorSettings()
     m_editorSettingsWidget->installEventFilter(this);
 
     QJsonObject dataToSendToView{ { "displayFont",
-                                    QFont(QStringLiteral("SF Pro Text")).exactMatch()
-                                            ? QStringLiteral("SF Pro Text")
-                                            : QStringLiteral("Roboto") } };
+                                    QFont(QStringLiteral("SF Pro Text")).exactMatch() ? QStringLiteral("SF Pro Text") : QStringLiteral("Roboto") } };
     emit displayFontSet(QVariant(dataToSendToView));
 
 #if defined(Q_OS_WINDOWS)
@@ -1113,15 +1039,14 @@ void MainWindow::setCurrentFontBasedOnTypeface(FontTypeface::Value selectedFontT
     }
 
 #ifdef __APPLE__
-    int increaseSize = 2;
+    int increaseSize = 2; // cppcheck-suppress variableScope
 #else
-    int increaseSize = 1;
+    int increaseSize = 1; // cppcheck-suppress variableScope
 #endif
 
     if (m_textEdit->width() < m_smallEditorWidth) {
         m_currentFontPointSize = m_editorMediumFontSize - 2;
-    } else if (m_textEdit->width() > m_smallEditorWidth
-               && m_textEdit->width() < m_largeEditorWidth) {
+    } else if (m_textEdit->width() > m_smallEditorWidth && m_textEdit->width() < m_largeEditorWidth) {
         m_currentFontPointSize = m_editorMediumFontSize;
     } else if (m_textEdit->width() > m_largeEditorWidth) {
         m_currentFontPointSize = m_editorMediumFontSize + increaseSize;
@@ -1192,30 +1117,23 @@ void MainWindow::setupTextEditStyleSheet(int paddingLeft, int paddingRight)
 void MainWindow::alignTextEditText()
 {
     if (m_textEdit->lineWrapMode() == QTextEdit::WidgetWidth) {
-        setupTextEditStyleSheet(m_noteEditorLogic->currentMinimumEditorPadding(),
-                                m_noteEditorLogic->currentMinimumEditorPadding());
+        setupTextEditStyleSheet(m_noteEditorLogic->currentMinimumEditorPadding(), m_noteEditorLogic->currentMinimumEditorPadding());
         return;
     }
 
     QFontMetricsF fm(m_currentSelectedFont);
-    QString limitingStringSample = QStringLiteral(
-            "The quick brown fox jumps over the lazy dog the quick brown fox jumps over "
-            "the lazy dog the quick brown fox jumps over the lazy dog");
+    QString limitingStringSample = QStringLiteral("The quick brown fox jumps over the lazy dog the quick brown fox jumps over "
+                                                  "the lazy dog the quick brown fox jumps over the lazy dog");
     limitingStringSample.truncate(m_textEdit->lineWrapColumnOrWidth());
     qreal textSamplePixelsWidth = fm.horizontalAdvance(limitingStringSample);
-    m_noteEditorLogic->setCurrentAdaptableEditorPadding(
-            (m_textEdit->width() - textSamplePixelsWidth) / 2 - 10);
+    m_noteEditorLogic->setCurrentAdaptableEditorPadding(((m_textEdit->width() - textSamplePixelsWidth) / 2) - 10);
 
-    if (m_textEdit->width() - m_noteEditorLogic->currentMinimumEditorPadding() * 2
-                > textSamplePixelsWidth
+    if (m_textEdit->width() - m_noteEditorLogic->currentMinimumEditorPadding() * 2 > textSamplePixelsWidth
         && m_noteEditorLogic->currentAdaptableEditorPadding() > 0
-        && m_noteEditorLogic->currentAdaptableEditorPadding()
-                > m_noteEditorLogic->currentMinimumEditorPadding()) {
-        setupTextEditStyleSheet(m_noteEditorLogic->currentAdaptableEditorPadding(),
-                                m_noteEditorLogic->currentAdaptableEditorPadding());
+        && m_noteEditorLogic->currentAdaptableEditorPadding() > m_noteEditorLogic->currentMinimumEditorPadding()) {
+        setupTextEditStyleSheet(m_noteEditorLogic->currentAdaptableEditorPadding(), m_noteEditorLogic->currentAdaptableEditorPadding());
     } else {
-        setupTextEditStyleSheet(m_noteEditorLogic->currentMinimumEditorPadding(),
-                                m_noteEditorLogic->currentMinimumEditorPadding());
+        setupTextEditStyleSheet(m_noteEditorLogic->currentMinimumEditorPadding(), m_noteEditorLogic->currentMinimumEditorPadding());
     }
 }
 
@@ -1232,8 +1150,7 @@ void MainWindow::setupTextEdit()
     m_textEdit->installEventFilter(this);
     m_textEdit->verticalScrollBar()->installEventFilter(this);
     m_textEdit->setCursorWidth(2);
-    setupTextEditStyleSheet(m_noteEditorLogic->currentMinimumEditorPadding(),
-                            m_noteEditorLogic->currentMinimumEditorPadding());
+    setupTextEditStyleSheet(m_noteEditorLogic->currentMinimumEditorPadding(), m_noteEditorLogic->currentMinimumEditorPadding());
     m_textEdit->setWordWrapMode(QTextOption::WordWrap);
 
 #ifdef __APPLE__
@@ -1294,8 +1211,7 @@ void MainWindow::setupKanbanView()
     m_kanbanWidget = QWidget::createWindowContainer(&m_kanbanQuickView, this);
     m_kanbanWidget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     m_kanbanWidget->hide();
-    ui->verticalLayout_textEdit->insertWidget(ui->verticalLayout_textEdit->indexOf(m_textEdit),
-                                              m_kanbanWidget);
+    ui->verticalLayout_textEdit->insertWidget(ui->verticalLayout_textEdit->indexOf(m_textEdit), m_kanbanWidget);
 #  if defined(Q_OS_WINDOWS)
     emit platformSet(QVariant(QStringLiteral("Windows")));
 #  elif defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
@@ -1305,9 +1221,7 @@ void MainWindow::setupKanbanView()
 #  endif
 
     QJsonObject dataToSendToView{ { "displayFont",
-                                    QFont(QStringLiteral("SF Pro Text")).exactMatch()
-                                            ? QStringLiteral("SF Pro Text")
-                                            : QStringLiteral("Roboto") } };
+                                    QFont(QStringLiteral("SF Pro Text")).exactMatch() ? QStringLiteral("SF Pro Text") : QStringLiteral("Roboto") } };
     emit displayFontSet(QVariant(dataToSendToView));
 }
 #endif
@@ -1323,8 +1237,7 @@ void MainWindow::initializeSettingsDatabase()
 
 #if defined(UPDATE_CHECKER)
     if (m_settingsDatabase->value(QStringLiteral("dontShowUpdateWindow"), "NULL") == "NULL")
-        m_settingsDatabase->setValue(QStringLiteral("dontShowUpdateWindow"),
-                                     m_dontShowUpdateWindow);
+        m_settingsDatabase->setValue(QStringLiteral("dontShowUpdateWindow"), m_dontShowUpdateWindow);
 #endif
 
     if (m_settingsDatabase->value(QStringLiteral("windowGeometry"), "NULL") == "NULL") {
@@ -1346,7 +1259,7 @@ void MainWindow::initializeSettingsDatabase()
 /*!
  * \brief MainWindow::setActivationSuccessful
  */
-void MainWindow::setActivationSuccessful(QString licenseKey, bool removeGracePeriodStartedDate)
+void MainWindow::setActivationSuccessful(QString const &licenseKey, bool removeGracePeriodStartedDate)
 {
     m_isProVersionActivated = true;
     emit proVersionCheck(QVariant(m_isProVersionActivated));
@@ -1387,8 +1300,7 @@ void MainWindow::getPaymentDetailsSignalsSlots()
  */
 void MainWindow::getSubscriptionStatus()
 {
-    QString validateLicenseEndpoint = m_paymentDetails["purchaseApiBase"].toString()
-            + m_paymentDetails["validateLicenseEndpoint"].toString();
+    QString validateLicenseEndpoint = m_paymentDetails["purchaseApiBase"].toString() + m_paymentDetails["validateLicenseEndpoint"].toString();
     QNetworkRequest request{ QUrl(validateLicenseEndpoint) };
     QJsonObject licenseDataObject;
     licenseDataObject["license_key"] = m_userLicenseKey;
@@ -1398,30 +1310,25 @@ void MainWindow::getSubscriptionStatus()
     QNetworkReply *reply = m_netManager->post(request, postData);
 
     connect(reply, &QNetworkReply::finished, this, [=]() {
-        bool skipSettingNotProOnError = false;
         bool showSubscriptionWindowWhenNotPro = true;
 
         if (reply->error() != QNetworkReply::NoError) {
             QByteArray responseData = reply->readAll();
             QJsonObject response = QJsonDocument::fromJson(responseData).object();
 
+            bool skipSettingNotProOnError = false;
             if (response.isEmpty()) {
                 // No Internet
                 if (!m_localLicenseData->contains(QStringLiteral("gracePeriodStartedDate"))) {
                     // gracePeriodStartedDate not found, so entering new one now
-                    m_localLicenseData->setValue(QStringLiteral("gracePeriodStartedDate"),
-                                                 QDateTime::currentDateTime());
+                    m_localLicenseData->setValue(QStringLiteral("gracePeriodStartedDate"), QDateTime::currentDateTime());
                     skipSettingNotProOnError = true;
                     setActivationSuccessful(m_userLicenseKey, false);
                     m_subscriptionStatus = SubscriptionStatus::EnteredGracePeriod;
                 } else {
                     QDateTime gracePeriodStartedDate =
-                            m_localLicenseData
-                                    ->value(QStringLiteral("gracePeriodStartedDate"),
-                                            QDateTime::currentDateTime())
-                                    .toDateTime();
-                    QDateTime dateAfterSevenDays =
-                            gracePeriodStartedDate.addDays(7); // 7 days grace period offline usage
+                            m_localLicenseData->value(QStringLiteral("gracePeriodStartedDate"), QDateTime::currentDateTime()).toDateTime();
+                    QDateTime dateAfterSevenDays = gracePeriodStartedDate.addDays(7); // 7 days grace period offline usage
                     if (QDateTime::currentDateTime() > dateAfterSevenDays) {
                         // Show grace period is over window, you need internt connection
                         m_subscriptionStatus = SubscriptionStatus::GracePeriodOver;
@@ -1433,12 +1340,8 @@ void MainWindow::getSubscriptionStatus()
                         setActivationSuccessful(m_userLicenseKey, false);
                     }
                 }
-            } else if (response.contains("valid") && response["valid"] == false
-                       && response.contains("license_key")
-                       && response[QStringLiteral("license_key")]
-                                       .toObject()[QStringLiteral("status")]
-                                       .toString()
-                               == "expired") {
+            } else if (response.contains("valid") && response["valid"] == false && response.contains("license_key")
+                       && response[QStringLiteral("license_key")].toObject()[QStringLiteral("status")].toString() == "expired") {
                 // Show license expired window
                 m_subscriptionStatus = SubscriptionStatus::Expired;
                 showSubscriptionWindowWhenNotPro = false;
@@ -1459,18 +1362,10 @@ void MainWindow::getSubscriptionStatus()
             QByteArray responseData = reply->readAll();
             QJsonObject response = QJsonDocument::fromJson(responseData).object();
 
-            if (response.contains("license_key") && response.contains("valid")
-                && response["valid"] == true) {
-                if (response[QStringLiteral("license_key")]
-                            .toObject()[QStringLiteral("status")]
-                            .toString()
-                    == "inactive") {
-                    int activationUsage = response[QStringLiteral("license_key")]
-                                                  .toObject()[QStringLiteral("activation_usage")]
-                                                  .toInt();
-                    int activationLimit = response[QStringLiteral("license_key")]
-                                                  .toObject()[QStringLiteral("activation_limit")]
-                                                  .toInt();
+            if (response.contains("license_key") && response.contains("valid") && response["valid"] == true) {
+                if (response[QStringLiteral("license_key")].toObject()[QStringLiteral("status")].toString() == "inactive") {
+                    int activationUsage = response[QStringLiteral("license_key")].toObject()[QStringLiteral("activation_usage")].toInt();
+                    int activationLimit = response[QStringLiteral("license_key")].toObject()[QStringLiteral("activation_limit")].toInt();
                     if (activationUsage >= activationLimit) {
                         // Over activation limit
                         m_subscriptionStatus = SubscriptionStatus::ActivationLimitReached;
@@ -1482,25 +1377,20 @@ void MainWindow::getSubscriptionStatus()
                         // License valid but not activated yet. Activate
                         // TODO: verify against some device ID
                         QString activateLicenseEndpoint =
-                                m_paymentDetails["purchaseApiBase"].toString()
-                                + m_paymentDetails["activateLicenseEndpoint"].toString();
+                                m_paymentDetails["purchaseApiBase"].toString() + m_paymentDetails["activateLicenseEndpoint"].toString();
                         QNetworkRequest requestActivate{ QUrl(activateLicenseEndpoint) };
                         QJsonObject licenseDataObject2;
                         licenseDataObject2["license_key"] = m_userLicenseKey;
                         licenseDataObject2["instance_name"] = "Notes_Pro";
                         QJsonDocument licenseDataDoc2(licenseDataObject2);
                         QByteArray postData2 = licenseDataDoc2.toJson();
-                        requestActivate.setHeader(QNetworkRequest::ContentTypeHeader,
-                                                  "application/json");
+                        requestActivate.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
                         m_netManager->post(requestActivate, postData2);
 
                         m_subscriptionStatus = SubscriptionStatus::Active;
                         setActivationSuccessful(m_userLicenseKey);
                     }
-                } else if (response[QStringLiteral("license_key")]
-                                   .toObject()[QStringLiteral("status")]
-                                   .toString()
-                           == "active") {
+                } else if (response[QStringLiteral("license_key")].toObject()[QStringLiteral("status")].toString() == "active") {
                     // Lincense is active
                     // TODO: verify against device ID as well
                     m_subscriptionStatus = SubscriptionStatus::Active;
@@ -1562,8 +1452,7 @@ void MainWindow::verifyLicenseSignalsSlots()
         emit gettingPaymentDetailsFinished();
     });
 
-    connect(this, &MainWindow::gettingPaymentDetailsFinished, this,
-            [this]() { getSubscriptionStatus(); });
+    connect(this, &MainWindow::gettingPaymentDetailsFinished, this, [this]() { getSubscriptionStatus(); });
 }
 
 /*!
@@ -1622,19 +1511,13 @@ void MainWindow::openSubscriptionWindow()
  */
 void MainWindow::setupDatabases()
 {
-    m_settingsDatabase =
-            new QSettings(QSettings::IniFormat, QSettings::UserScope, QStringLiteral("Awesomeness"),
-                          QStringLiteral("Settings"), this);
+    m_settingsDatabase = new QSettings(QSettings::IniFormat, QSettings::UserScope, QStringLiteral("Awesomeness"), QStringLiteral("Settings"), this);
 
 #if !defined(PRO_VERSION)
 #  if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
-    m_localLicenseData =
-            new QSettings(QSettings::NativeFormat, QSettings::UserScope,
-                          QStringLiteral("Awesomeness"), QStringLiteral(".notesLicenseData"), this);
+    m_localLicenseData = new QSettings(QSettings::NativeFormat, QSettings::UserScope, QStringLiteral("Awesomeness"), QStringLiteral(".notesLicenseData"), this);
 #  else
-    m_localLicenseData =
-            new QSettings(QSettings::NativeFormat, QSettings::UserScope,
-                          QStringLiteral("Awesomeness"), QStringLiteral("notesLicenseData"), this);
+    m_localLicenseData = new QSettings(QSettings::NativeFormat, QSettings::UserScope, QStringLiteral("Awesomeness"), QStringLiteral("notesLicenseData"), this);
 #  endif
 #endif
 
@@ -1655,12 +1538,10 @@ void MainWindow::setupDatabases()
     QDir dir(fi.absolutePath());
     bool folderCreated = dir.mkpath(QStringLiteral("."));
     if (!folderCreated)
-        qFatal("ERROR: Can't create settings folder : %s",
-               dir.absolutePath().toStdString().c_str());
+        qFatal("ERROR: Can't create settings folder : %s", dir.absolutePath().toStdString().c_str());
     QString defaultDBPath = QStringLiteral("%1%2notes.db").arg(dir.path(), QDir::separator());
 
-    QString noteDBFilePath =
-            m_settingsDatabase->value(QStringLiteral("noteDBFilePath"), QString()).toString();
+    QString noteDBFilePath = m_settingsDatabase->value(QStringLiteral("noteDBFilePath"), QString()).toString();
     if (noteDBFilePath.isEmpty()) {
         noteDBFilePath = defaultDBPath;
     }
@@ -1719,14 +1600,11 @@ void MainWindow::setupDatabases()
         setTheme(m_currentTheme);
         emit requestOpenDBManager(noteDBFilePath, doCreate);
         if (needMigrateFromV1_5_0) {
-            emit requestMigrateNotesFromV1_5_0(dir.path() + QDir::separator()
-                                               + QStringLiteral("oldNotes.db"));
+            emit requestMigrateNotesFromV1_5_0(dir.path() + QDir::separator() + QStringLiteral("oldNotes.db"));
         }
     });
-    connect(this, &MainWindow::requestOpenDBManager, m_dbManager,
-            &DBManager::onOpenDBManagerRequested, Qt::QueuedConnection);
-    connect(this, &MainWindow::requestMigrateNotesFromV1_5_0, m_dbManager,
-            &DBManager::onMigrateNotesFrom1_5_0Requested, Qt::QueuedConnection);
+    connect(this, &MainWindow::requestOpenDBManager, m_dbManager, &DBManager::onOpenDBManagerRequested, Qt::QueuedConnection);
+    connect(this, &MainWindow::requestMigrateNotesFromV1_5_0, m_dbManager, &DBManager::onMigrateNotesFrom1_5_0Requested, Qt::QueuedConnection);
     connect(m_dbThread, &QThread::finished, m_dbManager, &QObject::deleteLater);
     m_dbThread->start();
 }
@@ -1741,22 +1619,17 @@ void MainWindow::setupModelView()
     m_listModel = new NoteListModel(m_listView);
     m_listView->setTagPool(m_tagPool);
     m_listView->setModel(m_listModel);
-    m_listViewLogic = new ListViewLogic(m_listView, m_listModel, m_searchEdit, m_clearButton,
-                                        m_tagPool, m_dbManager, m_listView);
+    m_listViewLogic = new ListViewLogic(m_listView, m_listModel, m_searchEdit, m_clearButton, m_tagPool, m_dbManager, m_listView);
     m_treeView = ui->treeView;
     m_treeView->setModel(m_treeModel);
     m_treeViewLogic = new TreeViewLogic(m_treeView, m_treeModel, m_dbManager, m_listView, this);
 #if QT_VERSION >= QT_VERSION_CHECK(6, 2, 0)
-    m_noteEditorLogic =
-            new NoteEditorLogic(m_textEdit, m_editorDateLabel, m_searchEdit, m_kanbanWidget,
-                                ui->tagListView, m_tagPool, m_dbManager, this);
+    m_noteEditorLogic = new NoteEditorLogic(m_textEdit, m_editorDateLabel, m_searchEdit, m_kanbanWidget, ui->tagListView, m_tagPool, m_dbManager, this);
     m_kanbanQuickView.rootContext()->setContextProperty("noteEditorLogic", m_noteEditorLogic);
 #else
-    m_noteEditorLogic = new NoteEditorLogic(m_textEdit, m_editorDateLabel, m_searchEdit,
-                                            ui->tagListView, m_tagPool, m_dbManager, this);
+    m_noteEditorLogic = new NoteEditorLogic(m_textEdit, m_editorDateLabel, m_searchEdit, ui->tagListView, m_tagPool, m_dbManager, this);
 #endif
-    m_editorSettingsQuickView.rootContext()->setContextProperty("noteEditorLogic",
-                                                                m_noteEditorLogic);
+    m_editorSettingsQuickView.rootContext()->setContextProperty("noteEditorLogic", m_noteEditorLogic);
 }
 
 /*!
@@ -1771,9 +1644,7 @@ void MainWindow::restoreStates()
 #else
     bool nativeByDefault = true;
 #endif
-    setUseNativeWindowFrame(
-            m_settingsDatabase->value(QStringLiteral("useNativeWindowFrame"), nativeByDefault)
-                    .toBool());
+    setUseNativeWindowFrame(m_settingsDatabase->value(QStringLiteral("useNativeWindowFrame"), nativeByDefault).toBool());
 
     setHideToTray(m_settingsDatabase->value(QStringLiteral("hideToTray"), true).toBool());
     m_hideToTrayAction->setChecked(m_hideToTray);
@@ -1793,8 +1664,7 @@ void MainWindow::restoreStates()
 
 #if defined(UPDATE_CHECKER)
     if (m_settingsDatabase->value(QStringLiteral("dontShowUpdateWindow"), "NULL") != "NULL")
-        m_dontShowUpdateWindow =
-                m_settingsDatabase->value(QStringLiteral("dontShowUpdateWindow")).toBool();
+        m_dontShowUpdateWindow = m_settingsDatabase->value(QStringLiteral("dontShowUpdateWindow")).toBool();
 #endif
 
     m_splitter->setCollapsible(0, true);
@@ -1802,8 +1672,7 @@ void MainWindow::restoreStates()
     m_splitter->resize(width() - m_layoutMargin, height() - m_layoutMargin);
 
     if (m_settingsDatabase->contains(QStringLiteral("splitterSizes"))) {
-        m_splitter->restoreState(
-                m_settingsDatabase->value(QStringLiteral("splitterSizes")).toByteArray());
+        m_splitter->restoreState(m_settingsDatabase->value(QStringLiteral("splitterSizes")).toByteArray());
         // in rare cases, the splitter sizes can be zero, which causes bugs (issue #531)
         auto splitterSizes = m_splitter->sizes();
         splitterSizes[0] = std::max(splitterSizes[0], m_foldersWidget->minimumWidth());
@@ -1811,10 +1680,8 @@ void MainWindow::restoreStates()
         m_splitter->setSizes(splitterSizes);
     }
 
-    m_foldersWidget->setHidden(
-            m_settingsDatabase->value(QStringLiteral("isTreeCollapsed")).toBool());
-    m_noteListWidget->setHidden(
-            m_settingsDatabase->value(QStringLiteral("isNoteListCollapsed")).toBool());
+    m_foldersWidget->setHidden(m_settingsDatabase->value(QStringLiteral("isTreeCollapsed")).toBool());
+    m_noteListWidget->setHidden(m_settingsDatabase->value(QStringLiteral("isNoteListCollapsed")).toBool());
 
 #if defined(Q_OS_MACOS)
     if (m_foldersWidget->isHidden()) {
@@ -1831,8 +1698,7 @@ void MainWindow::restoreStates()
     m_splitter->setCollapsible(0, false);
     m_splitter->setCollapsible(1, false);
 
-    QString selectedFontTypefaceFromDatabase =
-            m_settingsDatabase->value(QStringLiteral("selectedFontTypeface"), "NULL").toString();
+    QString selectedFontTypefaceFromDatabase = m_settingsDatabase->value(QStringLiteral("selectedFontTypeface"), "NULL").toString();
     if (selectedFontTypefaceFromDatabase != "NULL") {
         if (selectedFontTypefaceFromDatabase == "Mono") {
             m_currentFontTypeface = FontTypeface::Mono;
@@ -1844,8 +1710,7 @@ void MainWindow::restoreStates()
     }
 
     if (m_settingsDatabase->value(QStringLiteral("editorMediumFontSize"), "NULL") != "NULL") {
-        m_editorMediumFontSize =
-                m_settingsDatabase->value(QStringLiteral("editorMediumFontSize")).toInt();
+        m_editorMediumFontSize = m_settingsDatabase->value(QStringLiteral("editorMediumFontSize")).toInt();
     } else {
 #ifdef __APPLE__
         m_editorMediumFontSize = 17;
@@ -1855,10 +1720,8 @@ void MainWindow::restoreStates()
     }
     m_currentFontPointSize = m_editorMediumFontSize;
 
-    bool isTextFullWidth = false;
     if (m_settingsDatabase->value(QStringLiteral("isTextFullWidth"), "NULL") != "NULL") {
-        isTextFullWidth = m_settingsDatabase->value(QStringLiteral("isTextFullWidth")).toBool();
-        if (isTextFullWidth) {
+        if (m_settingsDatabase->value(QStringLiteral("isTextFullWidth")).toBool()) {
             m_textEdit->setLineWrapMode(QTextEdit::WidgetWidth);
         } else {
             m_textEdit->setLineWrapMode(QTextEdit::FixedColumnWidth);
@@ -1869,14 +1732,11 @@ void MainWindow::restoreStates()
     }
 
     if (m_settingsDatabase->value(QStringLiteral("charsLimitPerFontMono"), "NULL") != "NULL")
-        m_currentCharsLimitPerFont.mono =
-                m_settingsDatabase->value(QStringLiteral("charsLimitPerFontMono")).toInt();
+        m_currentCharsLimitPerFont.mono = m_settingsDatabase->value(QStringLiteral("charsLimitPerFontMono")).toInt();
     if (m_settingsDatabase->value(QStringLiteral("charsLimitPerFontSerif"), "NULL") != "NULL")
-        m_currentCharsLimitPerFont.serif =
-                m_settingsDatabase->value(QStringLiteral("charsLimitPerFontSerif")).toInt();
+        m_currentCharsLimitPerFont.serif = m_settingsDatabase->value(QStringLiteral("charsLimitPerFontSerif")).toInt();
     if (m_settingsDatabase->value(QStringLiteral("charsLimitPerFontSansSerif"), "NULL") != "NULL")
-        m_currentCharsLimitPerFont.sansSerif =
-                m_settingsDatabase->value(QStringLiteral("charsLimitPerFontSansSerif")).toInt();
+        m_currentCharsLimitPerFont.sansSerif = m_settingsDatabase->value(QStringLiteral("charsLimitPerFontSansSerif")).toInt();
 
     if (m_settingsDatabase->value(QStringLiteral("chosenMonoFont"), "NULL") != "NULL") {
         QString fontName = m_settingsDatabase->value(QStringLiteral("chosenMonoFont")).toString();
@@ -1893,8 +1753,7 @@ void MainWindow::restoreStates()
         }
     }
     if (m_settingsDatabase->value(QStringLiteral("chosenSansSerifFont"), "NULL") != "NULL") {
-        QString fontName =
-                m_settingsDatabase->value(QStringLiteral("chosenSansSerifFont")).toString();
+        QString fontName = m_settingsDatabase->value(QStringLiteral("chosenSansSerifFont")).toString();
         int fontIndex = m_listOfSansSerifFonts.indexOf(fontName);
         if (fontIndex != -1) {
             m_chosenSansSerifFontIndex = fontIndex;
@@ -1915,25 +1774,16 @@ void MainWindow::restoreStates()
     setCurrentFontBasedOnTypeface(m_currentFontTypeface);
     setTheme(m_currentTheme);
 
-    auto expandedFolder =
-            m_settingsDatabase->value(QStringLiteral("currentExpandedFolder"), QStringList{})
-                    .toStringList();
-    auto isSelectingFolder =
-            m_settingsDatabase->value(QStringLiteral("isSelectingFolder"), true).toBool();
-    auto currentSelectFolder =
-            m_settingsDatabase->value(QStringLiteral("currentSelectFolder"), QString{}).toString();
-    auto currentSelectTagsId =
-            m_settingsDatabase->value(QStringLiteral("currentSelectTagsId"), QStringList{})
-                    .toStringList();
+    auto expandedFolder = m_settingsDatabase->value(QStringLiteral("currentExpandedFolder"), QStringList{}).toStringList();
+    auto isSelectingFolder = m_settingsDatabase->value(QStringLiteral("isSelectingFolder"), true).toBool();
+    auto currentSelectFolder = m_settingsDatabase->value(QStringLiteral("currentSelectFolder"), QString{}).toString();
+    auto currentSelectTagsId = m_settingsDatabase->value(QStringLiteral("currentSelectTagsId"), QStringList{}).toStringList();
     QSet<int> tags;
     for (const auto &tagId : std::as_const(currentSelectTagsId)) {
         tags.insert(tagId.toInt());
     }
-    m_treeViewLogic->setLastSavedState(isSelectingFolder, currentSelectFolder, tags,
-                                       expandedFolder);
-    auto currentSelectNotes =
-            m_settingsDatabase->value(QStringLiteral("currentSelectNotesId"), QStringList{})
-                    .toStringList();
+    m_treeViewLogic->setLastSavedState(isSelectingFolder, currentSelectFolder, tags, expandedFolder);
+    auto currentSelectNotes = m_settingsDatabase->value(QStringLiteral("currentSelectNotesId"), QStringList{}).toStringList();
     QSet<int> notesId;
     for (const auto &id : std::as_const(currentSelectNotes)) {
         notesId.insert(id.toInt());
@@ -2047,8 +1897,7 @@ void MainWindow::resetFormat(const QString &formatChars)
         if (!cursor.hasSelection()) {
             for (int i = 0; i < 2; ++i) {
                 QTextDocument *doc = m_textEdit->document();
-                cursor = doc->find(QRegularExpression(QRegularExpression::escape(formatChars)),
-                                   cursor.selectionStart(), QTextDocument::FindBackward);
+                cursor = doc->find(QRegularExpression(QRegularExpression::escape(formatChars)), cursor.selectionStart(), QTextDocument::FindBackward);
                 if (!cursor.isNull()) {
                     cursor.deleteChar();
                 }
@@ -2158,8 +2007,7 @@ void MainWindow::setupGlobalSettingsMenu()
 
     // Autostart
     QAction *autostartAction = m_mainMenu.addAction(tr("&Start automatically"));
-    connect(autostartAction, &QAction::triggered, this,
-            [=]() { m_autostart.setAutostart(autostartAction->isChecked()); });
+    connect(autostartAction, &QAction::triggered, this, [=]() { m_autostart.setAutostart(autostartAction->isChecked()); });
     autostartAction->setCheckable(true);
     autostartAction->setChecked(m_autostart.isAutostart());
 
@@ -2177,8 +2025,7 @@ void MainWindow::setupGlobalSettingsMenu()
 
     QAction *changeDBPathAction = m_mainMenu.addAction(tr("&Change database path"));
     connect(changeDBPathAction, &QAction::triggered, this, [=]() {
-        auto btn = QMessageBox::question(this, "Are you sure you want to change the database path?",
-                                         "Are you sure you want to change the database path?");
+        auto btn = QMessageBox::question(this, "Are you sure you want to change the database path?", "Are you sure you want to change the database path?");
         if (btn == QMessageBox::Yes) {
             auto newDbPath = QFileDialog::getSaveFileName(this, "New Database path", "notes.db");
             if (!newDbPath.isEmpty()) {
@@ -2198,11 +2045,9 @@ void MainWindow::setupGlobalSettingsMenu()
 
 #if !defined(PRO_VERSION)
     // Buy/Manage subscription
-    m_buyOrManageSubscriptionAction = m_mainMenu.addAction(
-            tr(m_isProVersionActivated ? "&Notes Pro (Paid)" : "&Buy Notes Pro..."));
+    m_buyOrManageSubscriptionAction = m_mainMenu.addAction(tr(m_isProVersionActivated ? "&Notes Pro (Paid)" : "&Buy Notes Pro..."));
     m_buyOrManageSubscriptionAction->setVisible(false);
-    connect(m_buyOrManageSubscriptionAction, &QAction::triggered, this,
-            &MainWindow::openSubscriptionWindow);
+    connect(m_buyOrManageSubscriptionAction, &QAction::triggered, this, &MainWindow::openSubscriptionWindow);
 
     m_mainMenu.addSeparator();
 #endif
@@ -2214,22 +2059,17 @@ void MainWindow::setupGlobalSettingsMenu()
     // Import notes from plain text actions
     QAction *importNotesPlainTextAction = importExportNotesMenu->addAction(tr("&Import .txt/.md"));
     importNotesPlainTextAction->setToolTip(tr("Import notes from .txt or .md files"));
-    connect(importNotesPlainTextAction, &QAction::triggered, this,
-            &MainWindow::importPlainTextFiles);
+    connect(importNotesPlainTextAction, &QAction::triggered, this, &MainWindow::importPlainTextFiles);
 
     QAction *exportNotesToPlainTextAction = importExportNotesMenu->addAction(tr("&Export to .txt"));
-    exportNotesToPlainTextAction->setToolTip(
-            tr("Export notes to .txt files\nNote: If you wish to backup your notes,\nuse the .nbk "
-               "file format instead of .txt/.md"));
-    connect(exportNotesToPlainTextAction, &QAction::triggered, this,
-            [this]() { exportToPlainTextFiles(".txt"); });
+    exportNotesToPlainTextAction->setToolTip(tr("Export notes to .txt files\nNote: If you wish to backup your notes,\nuse the .nbk "
+                                                "file format instead of .txt/.md"));
+    connect(exportNotesToPlainTextAction, &QAction::triggered, this, [this]() { exportToPlainTextFiles(".txt"); });
 
     QAction *exportNotesToMarkdownAction = importExportNotesMenu->addAction(tr("&Export to .md"));
-    exportNotesToMarkdownAction->setToolTip(
-            tr("Export notes to .md files\nNote: If you wish to backup your notes,\nuse the .nbk "
-               "file format instead of .txt/.md"));
-    connect(exportNotesToMarkdownAction, &QAction::triggered, this,
-            [this]() { exportToPlainTextFiles(".md"); });
+    exportNotesToMarkdownAction->setToolTip(tr("Export notes to .md files\nNote: If you wish to backup your notes,\nuse the .nbk "
+                                               "file format instead of .txt/.md"));
+    connect(exportNotesToMarkdownAction, &QAction::triggered, this, [this]() { exportToPlainTextFiles(".md"); });
 
     importExportNotesMenu->addSeparator();
 
@@ -2254,8 +2094,7 @@ void MainWindow::setupGlobalSettingsMenu()
     useNativeFrameAction->setToolTip(tr("Use the window frame provided by the window manager"));
     useNativeFrameAction->setCheckable(true);
     useNativeFrameAction->setChecked(m_useNativeWindowFrame);
-    connect(useNativeFrameAction, &QAction::triggered, this,
-            [this]() { setUseNativeWindowFrame(!m_useNativeWindowFrame); });
+    connect(useNativeFrameAction, &QAction::triggered, this, [this]() { setUseNativeWindowFrame(!m_useNativeWindowFrame); });
 #endif
 }
 
@@ -2265,8 +2104,7 @@ void MainWindow::setupGlobalSettingsMenu()
  */
 void MainWindow::onGlobalSettingsButtonClicked()
 {
-    m_mainMenu.exec(
-            m_globalSettingsButton->mapToGlobal(QPoint(0, m_globalSettingsButton->height())));
+    m_mainMenu.exec(m_globalSettingsButton->mapToGlobal(QPoint(0, m_globalSettingsButton->height())));
 }
 
 /*!
@@ -2323,8 +2161,7 @@ void MainWindow::updateSelectedOptionsEditorSettings()
  * \brief MainWindow::changeEditorFontTypeFromStyleButtons
  * Change the font based on the type passed from the Style Editor Window
  */
-void MainWindow::changeEditorFontTypeFromStyleButtons(FontTypeface::Value fontTypeface,
-                                                      int chosenFontIndex)
+void MainWindow::changeEditorFontTypeFromStyleButtons(FontTypeface::Value fontTypeface, int chosenFontIndex)
 {
     if (chosenFontIndex < 0)
         return;
@@ -2442,8 +2279,7 @@ void MainWindow::setTheme(Theme::Value theme)
 
     switch (theme) {
     case Theme::Light: {
-        QJsonObject themeData{ { "theme", QStringLiteral("Light") },
-                               { "backgroundColor", "#f7f7f7" } };
+        QJsonObject themeData{ { "theme", QStringLiteral("Light") }, { "backgroundColor", "#f7f7f7" } };
         emit themeChanged(QVariant(themeData));
         m_currentEditorTextColor = QColor(26, 26, 26);
         m_searchButton->setStyleSheet("QToolButton { color: rgb(205, 205, 205) }");
@@ -2452,8 +2288,7 @@ void MainWindow::setTheme(Theme::Value theme)
         break;
     }
     case Theme::Dark: {
-        QJsonObject themeData{ { "theme", QStringLiteral("Dark") },
-                               { "backgroundColor", "#191919" } };
+        QJsonObject themeData{ { "theme", QStringLiteral("Dark") }, { "backgroundColor", "#191919" } };
         emit themeChanged(QVariant(themeData));
         m_currentEditorTextColor = QColor(212, 212, 212);
         m_searchButton->setStyleSheet("QToolButton { color: rgb(68, 68, 68) }");
@@ -2462,8 +2297,7 @@ void MainWindow::setTheme(Theme::Value theme)
         break;
     }
     case Theme::Sepia: {
-        QJsonObject themeData{ { "theme", QStringLiteral("Sepia") },
-                               { "backgroundColor", "#fbf0d9" } };
+        QJsonObject themeData{ { "theme", QStringLiteral("Sepia") }, { "backgroundColor", "#fbf0d9" } };
         emit themeChanged(QVariant(themeData));
         m_currentEditorTextColor = QColor(50, 30, 3);
         m_searchButton->setStyleSheet("QToolButton { color: rgb(205, 205, 205) }");
@@ -2472,8 +2306,7 @@ void MainWindow::setTheme(Theme::Value theme)
         break;
     }
     }
-    setupTextEditStyleSheet(m_noteEditorLogic->currentMinimumEditorPadding(),
-                            m_noteEditorLogic->currentMinimumEditorPadding());
+    setupTextEditStyleSheet(m_noteEditorLogic->currentMinimumEditorPadding(), m_noteEditorLogic->currentMinimumEditorPadding());
     m_noteEditorLogic->setTheme(theme, m_currentEditorTextColor, m_editorMediumFontSize);
     m_listViewLogic->setTheme(theme);
     m_aboutWindow.setTheme(theme);
@@ -2515,7 +2348,7 @@ void MainWindow::createNewNote()
         m_noteEditorLogic->closeEditor();
 
         NodeData tmpNote;
-        tmpNote.setNodeType(NodeData::Note);
+        tmpNote.setNodeType(NodeData::Type::Note);
         QDateTime noteDate = QDateTime::currentDateTime();
         tmpNote.setCreationDateTime(noteDate);
         tmpNote.setLastModificationDateTime(noteDate);
@@ -2523,10 +2356,8 @@ void MainWindow::createNewNote()
         auto inf = m_listViewLogic->listViewInfo();
         if ((!inf.isInTag) && (inf.parentFolderId > SpecialNodeID::RootFolder)) {
             NodeData parent;
-            QMetaObject::invokeMethod(m_dbManager, "getNode", Qt::BlockingQueuedConnection,
-                                      Q_RETURN_ARG(NodeData, parent),
-                                      Q_ARG(int, inf.parentFolderId));
-            if (parent.nodeType() == NodeData::Folder) {
+            QMetaObject::invokeMethod(m_dbManager, "getNode", Qt::BlockingQueuedConnection, Q_RETURN_ARG(NodeData, parent), Q_ARG(int, inf.parentFolderId));
+            if (parent.nodeType() == NodeData::Type::Folder) {
                 tmpNote.setParentId(parent.id());
                 tmpNote.setParentName(parent.fullTitle());
             } else {
@@ -2538,8 +2369,7 @@ void MainWindow::createNewNote()
             tmpNote.setParentName("Notes");
         }
         int noteId = SpecialNodeID::InvalidNodeId;
-        QMetaObject::invokeMethod(m_dbManager, "nextAvailableNodeId", Qt::BlockingQueuedConnection,
-                                  Q_RETURN_ARG(int, noteId));
+        QMetaObject::invokeMethod(m_dbManager, "nextAvailableNodeId", Qt::BlockingQueuedConnection, Q_RETURN_ARG(int, noteId));
         tmpNote.setId(noteId);
         tmpNote.setIsTempNote(true);
         if (inf.isInTag) {
@@ -2570,8 +2400,7 @@ void MainWindow::selectNoteDown()
  */
 void MainWindow::setFocusOnText()
 {
-    if (m_noteEditorLogic->currentEditingNoteId() != SpecialNodeID::InvalidNodeId
-        && !m_textEdit->hasFocus()) {
+    if (m_noteEditorLogic->currentEditingNoteId() != SpecialNodeID::InvalidNodeId && !m_textEdit->hasFocus()) {
         m_listView->setCurrentRowActive(true);
         m_textEdit->setFocus();
     }
@@ -2658,8 +2487,7 @@ void MainWindow::applyFormat(const QString &formatChars)
     cursor.insertText(formatChars);
     cursor.setPosition(end + formatChars.length(), QTextCursor::MoveAnchor);
     cursor.insertText(formatChars);
-    cursor.movePosition(QTextCursor::PreviousCharacter, QTextCursor::MoveAnchor,
-                        formatChars.length());
+    cursor.movePosition(QTextCursor::PreviousCharacter, QTextCursor::MoveAnchor, formatChars.length());
     cursor.endEditBlock();
     if (selected) {
         QTextDocument *doc = m_textEdit->document();
@@ -2742,28 +2570,18 @@ void MainWindow::QuitApplication()
     m_settingsDatabase->setValue(QStringLiteral("splitterSizes"), m_splitter->saveState());
 
     m_settingsDatabase->setValue(QStringLiteral("isTreeCollapsed"), m_foldersWidget->isHidden());
-    m_settingsDatabase->setValue(QStringLiteral("isNoteListCollapsed"),
-                                 m_noteListWidget->isHidden());
+    m_settingsDatabase->setValue(QStringLiteral("isNoteListCollapsed"), m_noteListWidget->isHidden());
 
-    m_settingsDatabase->setValue(QStringLiteral("selectedFontTypeface"),
-                                 to_string(m_currentFontTypeface).c_str());
+    m_settingsDatabase->setValue(QStringLiteral("selectedFontTypeface"), to_string(m_currentFontTypeface).c_str());
     m_settingsDatabase->setValue(QStringLiteral("editorMediumFontSize"), m_editorMediumFontSize);
-    m_settingsDatabase->setValue(QStringLiteral("isTextFullWidth"),
-                                 m_textEdit->lineWrapMode() == QTextEdit::WidgetWidth ? true
-                                                                                      : false);
-    m_settingsDatabase->setValue(QStringLiteral("charsLimitPerFontMono"),
-                                 m_currentCharsLimitPerFont.mono);
-    m_settingsDatabase->setValue(QStringLiteral("charsLimitPerFontSerif"),
-                                 m_currentCharsLimitPerFont.serif);
-    m_settingsDatabase->setValue(QStringLiteral("charsLimitPerFontSansSerif"),
-                                 m_currentCharsLimitPerFont.sansSerif);
+    m_settingsDatabase->setValue(QStringLiteral("isTextFullWidth"), m_textEdit->lineWrapMode() == QTextEdit::WidgetWidth ? true : false);
+    m_settingsDatabase->setValue(QStringLiteral("charsLimitPerFontMono"), m_currentCharsLimitPerFont.mono);
+    m_settingsDatabase->setValue(QStringLiteral("charsLimitPerFontSerif"), m_currentCharsLimitPerFont.serif);
+    m_settingsDatabase->setValue(QStringLiteral("charsLimitPerFontSansSerif"), m_currentCharsLimitPerFont.sansSerif);
     m_settingsDatabase->setValue(QStringLiteral("theme"), to_string(m_currentTheme).c_str());
-    m_settingsDatabase->setValue(QStringLiteral("chosenMonoFont"),
-                                 m_listOfMonoFonts.at(m_chosenMonoFontIndex));
-    m_settingsDatabase->setValue(QStringLiteral("chosenSerifFont"),
-                                 m_listOfSerifFonts.at(m_chosenSerifFontIndex));
-    m_settingsDatabase->setValue(QStringLiteral("chosenSansSerifFont"),
-                                 m_listOfSansSerifFonts.at(m_chosenSansSerifFontIndex));
+    m_settingsDatabase->setValue(QStringLiteral("chosenMonoFont"), m_listOfMonoFonts.at(m_chosenMonoFontIndex));
+    m_settingsDatabase->setValue(QStringLiteral("chosenSerifFont"), m_listOfSerifFonts.at(m_chosenSerifFontIndex));
+    m_settingsDatabase->setValue(QStringLiteral("chosenSansSerifFont"), m_listOfSansSerifFonts.at(m_chosenSansSerifFontIndex));
 
     m_settingsDatabase->sync();
 
@@ -2827,8 +2645,7 @@ void MainWindow::restoreNotesFile()
  */
 void MainWindow::executeImport(const bool replace)
 {
-    QString fileName = QFileDialog::getOpenFileName(this, tr("Open Notes Backup File"), "",
-                                                    tr("Notes Backup File (*.nbk)"));
+    QString fileName = QFileDialog::getOpenFileName(this, tr("Open Notes Backup File"), "", tr("Notes Backup File (*.nbk)"));
     if (fileName.isEmpty()) {
         return;
     } else {
@@ -2860,8 +2677,7 @@ void MainWindow::executeImport(const bool replace)
  */
 void MainWindow::exportNotesFile()
 {
-    QString fileName = QFileDialog::getSaveFileName(this, tr("Save Notes"), "notes.nbk",
-                                                    tr("Notes Backup File (*.nbk)"));
+    QString fileName = QFileDialog::getSaveFileName(this, tr("Save Notes"), "notes.nbk", tr("Notes Backup File (*.nbk)"));
     if (fileName.isEmpty()) {
         return;
     } else {
@@ -2926,9 +2742,8 @@ void MainWindow::importPlainTextFiles()
 
 void MainWindow::exportToPlainTextFiles(const QString &extension)
 {
-    QString dir = QFileDialog::getExistingDirectory(nullptr, tr("Select Export Directory"), "/home",
-                                                    QFileDialog::ShowDirsOnly
-                                                            | QFileDialog::DontResolveSymlinks);
+    QString dir =
+            QFileDialog::getExistingDirectory(nullptr, tr("Select Export Directory"), "/home", QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
 
     if (dir.isEmpty()) {
         return;
@@ -3035,11 +2850,9 @@ void MainWindow::onYellowMinimizeButtonPressed()
 {
 #ifdef _WIN32
     if (windowState() == Qt::WindowFullScreen) {
-        m_yellowMinimizeButton->setIcon(
-                QIcon(QStringLiteral(":images/windows_de-maximize_pressed.png")));
+        m_yellowMinimizeButton->setIcon(QIcon(QStringLiteral(":images/windows_de-maximize_pressed.png")));
     } else {
-        m_yellowMinimizeButton->setIcon(
-                QIcon(QStringLiteral(":images/windows_maximize_pressed.png")));
+        m_yellowMinimizeButton->setIcon(QIcon(QStringLiteral(":images/windows_maximize_pressed.png")));
     }
 #else
     m_yellowMinimizeButton->setIcon(QIcon(QStringLiteral(":images/yellowPressed.png")));
@@ -3084,8 +2897,7 @@ void MainWindow::onGreenMaximizeButtonClicked()
 void MainWindow::onYellowMinimizeButtonClicked()
 {
 #ifdef _WIN32
-    m_yellowMinimizeButton->setIcon(
-            QIcon(QStringLiteral(":images/windows_de-maximize_regular.png")));
+    m_yellowMinimizeButton->setIcon(QIcon(QStringLiteral(":images/windows_de-maximize_regular.png")));
 
     fullscreenWindow();
 #else
@@ -3177,17 +2989,14 @@ void MainWindow::mousePressEvent(QMouseEvent *event)
         } else if (!isMaximized() && !isFullScreen()) {
             m_canStretchWindow = true;
 
-            if ((m_mousePressX < width() && m_mousePressX > width() - m_layoutMargin)
-                && (m_mousePressY < m_layoutMargin && m_mousePressY > 0)) {
+            if ((m_mousePressX < width() && m_mousePressX > width() - m_layoutMargin) && (m_mousePressY < m_layoutMargin && m_mousePressY > 0)) {
                 m_stretchSide = StretchSide::TopRight;
             } else if ((m_mousePressX < width() && m_mousePressX > width() - m_layoutMargin)
                        && (m_mousePressY < height() && m_mousePressY > height() - m_layoutMargin)) {
                 m_stretchSide = StretchSide::BottomRight;
-            } else if ((m_mousePressX < m_layoutMargin && m_mousePressX > 0)
-                       && (m_mousePressY < m_layoutMargin && m_mousePressY > 0)) {
+            } else if ((m_mousePressX < m_layoutMargin && m_mousePressX > 0) && (m_mousePressY < m_layoutMargin && m_mousePressY > 0)) {
                 m_stretchSide = StretchSide::TopLeft;
-            } else if ((m_mousePressX < m_layoutMargin && m_mousePressX > 0)
-                       && (m_mousePressY < height() && m_mousePressY > height() - m_layoutMargin)) {
+            } else if ((m_mousePressX < m_layoutMargin && m_mousePressX > 0) && (m_mousePressY < height() && m_mousePressY > height() - m_layoutMargin)) {
                 m_stretchSide = StretchSide::BottomLeft;
             } else if (m_mousePressX < width() && m_mousePressX > width() - m_layoutMargin) {
                 m_stretchSide = StretchSide::Right;
@@ -3227,17 +3036,14 @@ void MainWindow::mouseMoveEvent(QMouseEvent *event)
         m_mousePressX = event->position().toPoint().x();
         m_mousePressY = event->position().toPoint().y();
 
-        if ((m_mousePressX < width() && m_mousePressX > width() - m_layoutMargin)
-            && (m_mousePressY < m_layoutMargin && m_mousePressY > 0)) {
+        if ((m_mousePressX < width() && m_mousePressX > width() - m_layoutMargin) && (m_mousePressY < m_layoutMargin && m_mousePressY > 0)) {
             m_stretchSide = StretchSide::TopRight;
         } else if ((m_mousePressX < width() && m_mousePressX > width() - m_layoutMargin)
                    && (m_mousePressY < height() && m_mousePressY > height() - m_layoutMargin)) {
             m_stretchSide = StretchSide::BottomRight;
-        } else if ((m_mousePressX < m_layoutMargin && m_mousePressX > 0)
-                   && (m_mousePressY < m_layoutMargin && m_mousePressY > 0)) {
+        } else if ((m_mousePressX < m_layoutMargin && m_mousePressX > 0) && (m_mousePressY < m_layoutMargin && m_mousePressY > 0)) {
             m_stretchSide = StretchSide::TopLeft;
-        } else if ((m_mousePressX < m_layoutMargin && m_mousePressX > 0)
-                   && (m_mousePressY < height() && m_mousePressY > height() - m_layoutMargin)) {
+        } else if ((m_mousePressX < m_layoutMargin && m_mousePressX > 0) && (m_mousePressY < height() && m_mousePressY > height() - m_layoutMargin)) {
             m_stretchSide = StretchSide::BottomLeft;
         } else if (m_mousePressX < width() && m_mousePressX > width() - m_layoutMargin) {
             m_stretchSide = StretchSide::Right;
@@ -3301,18 +3107,14 @@ void MainWindow::mouseMoveEvent(QMouseEvent *event)
         case StretchSide::Left:
             newX = event->globalPosition().x() - m_mousePressX;
             newX = newX > 0 ? newX : 0;
-            newX = newX > geometry().bottomRight().x() - minimumWidth()
-                    ? geometry().bottomRight().x() - minimumWidth()
-                    : newX;
+            newX = newX > geometry().bottomRight().x() - minimumWidth() ? geometry().bottomRight().x() - minimumWidth() : newX;
             newWidth = geometry().topRight().x() - newX + 1;
             newWidth = newWidth < minimumWidth() ? minimumWidth() : newWidth;
             break;
         case StretchSide::Top:
             newY = event->globalPosition().y() - m_mousePressY;
             newY = newY < minY ? minY : newY;
-            newY = newY > geometry().bottomRight().y() - minimumHeight()
-                    ? geometry().bottomRight().y() - minimumHeight()
-                    : newY;
+            newY = newY > geometry().bottomRight().y() - minimumHeight() ? geometry().bottomRight().y() - minimumHeight() : newY;
             newHeight = geometry().bottomLeft().y() - newY + 1;
             newHeight = newHeight < minimumHeight() ? minimumHeight() : newHeight;
 
@@ -3325,15 +3127,11 @@ void MainWindow::mouseMoveEvent(QMouseEvent *event)
         case StretchSide::TopLeft:
             newX = event->globalPosition().x() - m_mousePressX;
             newX = newX < 0 ? 0 : newX;
-            newX = newX > geometry().bottomRight().x() - minimumWidth()
-                    ? geometry().bottomRight().x() - minimumWidth()
-                    : newX;
+            newX = newX > geometry().bottomRight().x() - minimumWidth() ? geometry().bottomRight().x() - minimumWidth() : newX;
 
             newY = event->globalPosition().y() - m_mousePressY;
             newY = newY < minY ? minY : newY;
-            newY = newY > geometry().bottomRight().y() - minimumHeight()
-                    ? geometry().bottomRight().y() - minimumHeight()
-                    : newY;
+            newY = newY > geometry().bottomRight().y() - minimumHeight() ? geometry().bottomRight().y() - minimumHeight() : newY;
 
             newWidth = geometry().bottomRight().x() - newX + 1;
             newWidth = newWidth < minimumWidth() ? minimumWidth() : newWidth;
@@ -3345,9 +3143,7 @@ void MainWindow::mouseMoveEvent(QMouseEvent *event)
         case StretchSide::BottomLeft:
             newX = event->globalPosition().x() - m_mousePressX;
             newX = newX < 0 ? 0 : newX;
-            newX = newX > geometry().bottomRight().x() - minimumWidth()
-                    ? geometry().bottomRight().x() - minimumWidth()
-                    : newX;
+            newX = newX > geometry().bottomRight().x() - minimumWidth() ? geometry().bottomRight().x() - minimumWidth() : newX;
 
             newWidth = geometry().bottomRight().x() - newX + 1;
             newWidth = newWidth < minimumWidth() ? minimumWidth() : newWidth;
@@ -3358,9 +3154,7 @@ void MainWindow::mouseMoveEvent(QMouseEvent *event)
             break;
         case StretchSide::TopRight:
             newY = event->globalPosition().y() - m_mousePressY;
-            newY = newY > geometry().bottomRight().y() - minimumHeight()
-                    ? geometry().bottomRight().y() - minimumHeight()
-                    : newY;
+            newY = newY > geometry().bottomRight().y() - minimumHeight() ? geometry().bottomRight().y() - minimumHeight() : newY;
             newY = newY < minY ? minY : newY;
 
             newWidth = event->globalPosition().x() - x() + 1;
@@ -3548,14 +3342,11 @@ void MainWindow::migrateNoteFromV0_9_0(const QString &notePath)
         int id = noteName.split(QStringLiteral("_"))[1].toInt();
         NodeData newNote;
         newNote.setId(id);
-        QString createdDateDB =
-                notesIni.value(noteName + QStringLiteral("/dateCreated"), "Error").toString();
+        QString createdDateDB = notesIni.value(noteName + QStringLiteral("/dateCreated"), "Error").toString();
         newNote.setCreationDateTime(QDateTime::fromString(createdDateDB, Qt::ISODate));
-        QString lastEditedDateDB =
-                notesIni.value(noteName + QStringLiteral("/dateEdited"), "Error").toString();
+        QString lastEditedDateDB = notesIni.value(noteName + QStringLiteral("/dateEdited"), "Error").toString();
         newNote.setLastModificationDateTime(QDateTime::fromString(lastEditedDateDB, Qt::ISODate));
-        QString contentText =
-                notesIni.value(noteName + QStringLiteral("/content"), "Error").toString();
+        QString contentText = notesIni.value(noteName + QStringLiteral("/content"), "Error").toString();
         newNote.setContent(contentText);
         QString firstLine = NoteEditorLogic::getFirstLine(contentText);
         newNote.setFullTitle(firstLine);
@@ -3567,8 +3358,7 @@ void MainWindow::migrateNoteFromV0_9_0(const QString &notePath)
     }
 
     QFile oldNoteDBFile(notePath);
-    oldNoteDBFile.rename(QFileInfo(notePath).dir().path() + QDir::separator()
-                         + QStringLiteral("oldNotes.ini"));
+    oldNoteDBFile.rename(QFileInfo(notePath).dir().path() + QDir::separator() + QStringLiteral("oldNotes.ini"));
 }
 
 /*!
@@ -3588,14 +3378,11 @@ void MainWindow::migrateTrashFromV0_9_0(const QString &trashPath)
         int id = noteName.split(QStringLiteral("_"))[1].toInt();
         NodeData newNote;
         newNote.setId(id);
-        QString createdDateDB =
-                trashIni.value(noteName + QStringLiteral("/dateCreated"), "Error").toString();
+        QString createdDateDB = trashIni.value(noteName + QStringLiteral("/dateCreated"), "Error").toString();
         newNote.setCreationDateTime(QDateTime::fromString(createdDateDB, Qt::ISODate));
-        QString lastEditedDateDB =
-                trashIni.value(noteName + QStringLiteral("/dateEdited"), "Error").toString();
+        QString lastEditedDateDB = trashIni.value(noteName + QStringLiteral("/dateEdited"), "Error").toString();
         newNote.setLastModificationDateTime(QDateTime::fromString(lastEditedDateDB, Qt::ISODate));
-        QString contentText =
-                trashIni.value(noteName + QStringLiteral("/content"), "Error").toString();
+        QString contentText = trashIni.value(noteName + QStringLiteral("/content"), "Error").toString();
         newNote.setContent(contentText);
         QString firstLine = NoteEditorLogic::getFirstLine(contentText);
         newNote.setFullTitle(firstLine);
@@ -3606,8 +3393,7 @@ void MainWindow::migrateTrashFromV0_9_0(const QString &trashPath)
         emit requestMigrateTrashFromV0_9_0(noteList);
     }
     QFile oldTrashDBFile(trashPath);
-    oldTrashDBFile.rename(QFileInfo(trashPath).dir().path() + QDir::separator()
-                          + QStringLiteral("oldTrash.ini"));
+    oldTrashDBFile.rename(QFileInfo(trashPath).dir().path() + QDir::separator() + QStringLiteral("oldTrash.ini"));
 }
 
 /*!
@@ -3622,10 +3408,8 @@ void MainWindow::dropShadow(QPainter &painter, ShadowType type, MainWindow::Shad
 
     QRect mainRect = rect();
 
-    QRect innerRect(m_layoutMargin, m_layoutMargin, mainRect.width() - 2 * resizedShadowWidth + 1,
-                    mainRect.height() - 2 * resizedShadowWidth + 1);
-    QRect outerRect(innerRect.x() - resizedShadowWidth, innerRect.y() - resizedShadowWidth,
-                    innerRect.width() + 2 * resizedShadowWidth,
+    QRect innerRect(m_layoutMargin, m_layoutMargin, mainRect.width() - 2 * resizedShadowWidth + 1, mainRect.height() - 2 * resizedShadowWidth + 1);
+    QRect outerRect(innerRect.x() - resizedShadowWidth, innerRect.y() - resizedShadowWidth, innerRect.width() + 2 * resizedShadowWidth,
                     innerRect.height() + 2 * resizedShadowWidth);
 
     QPoint center;
@@ -3741,8 +3525,7 @@ double MainWindow::gaussianDist(double x, const double center, double sigma) con
  */
 void MainWindow::mouseDoubleClickEvent(QMouseEvent *event)
 {
-    if (m_useNativeWindowFrame || event->buttons() != Qt::LeftButton
-        || !isTitleBar(event->position().toPoint().x(), event->position().toPoint().y())) {
+    if (m_useNativeWindowFrame || event->buttons() != Qt::LeftButton || !isTitleBar(event->position().toPoint().x(), event->position().toPoint().y())) {
         MainWindowBase::mouseDoubleClickEvent(event);
         return;
     }
@@ -3839,38 +3622,31 @@ bool MainWindow::eventFilter(QObject *object, QEvent *event)
         if (qApp->applicationState() == Qt::ApplicationActive) {
 #ifdef _WIN32
             if (object == m_redCloseButton) {
-                m_redCloseButton->setIcon(
-                        QIcon(QStringLiteral(":images/windows_close_hovered.png")));
+                m_redCloseButton->setIcon(QIcon(QStringLiteral(":images/windows_close_hovered.png")));
             }
 
             if (object == m_yellowMinimizeButton) {
                 if (windowState() == Qt::WindowFullScreen) {
-                    m_yellowMinimizeButton->setIcon(
-                            QIcon(QStringLiteral(":images/windows_de-maximize_hovered.png")));
+                    m_yellowMinimizeButton->setIcon(QIcon(QStringLiteral(":images/windows_de-maximize_hovered.png")));
                 } else {
-                    m_yellowMinimizeButton->setIcon(
-                            QIcon(QStringLiteral(":images/windows_maximize_hovered.png")));
+                    m_yellowMinimizeButton->setIcon(QIcon(QStringLiteral(":images/windows_maximize_hovered.png")));
                 }
             }
 
             if (object == m_greenMaximizeButton) {
-                m_greenMaximizeButton->setIcon(
-                        QIcon(QStringLiteral(":images/windows_minimize_hovered.png")));
+                m_greenMaximizeButton->setIcon(QIcon(QStringLiteral(":images/windows_minimize_hovered.png")));
             }
 #else
             // When hovering one of the traffic light buttons (red, yellow, green),
             // set new icons to show their function
-            if (object == m_redCloseButton || object == m_yellowMinimizeButton
-                || object == m_greenMaximizeButton) {
+            if (object == m_redCloseButton || object == m_yellowMinimizeButton || object == m_greenMaximizeButton) {
 
                 m_redCloseButton->setIcon(QIcon(QStringLiteral(":images/redHovered.png")));
                 m_yellowMinimizeButton->setIcon(QIcon(QStringLiteral(":images/yellowHovered.png")));
                 if (windowState() == Qt::WindowFullScreen) {
-                    m_greenMaximizeButton->setIcon(
-                            QIcon(QStringLiteral(":images/greenInHovered.png")));
+                    m_greenMaximizeButton->setIcon(QIcon(QStringLiteral(":images/greenInHovered.png")));
                 } else {
-                    m_greenMaximizeButton->setIcon(
-                            QIcon(QStringLiteral(":images/greenHovered.png")));
+                    m_greenMaximizeButton->setIcon(QIcon(QStringLiteral(":images/greenHovered.png")));
                 }
             }
 #endif
@@ -3891,21 +3667,16 @@ bool MainWindow::eventFilter(QObject *object, QEvent *event)
     case QEvent::Leave: {
         if (qApp->applicationState() == Qt::ApplicationActive) {
             // When not hovering, change back the icons of the traffic lights to their default icon
-            if (object == m_redCloseButton || object == m_yellowMinimizeButton
-                || object == m_greenMaximizeButton) {
+            if (object == m_redCloseButton || object == m_yellowMinimizeButton || object == m_greenMaximizeButton) {
 
 #ifdef _WIN32
-                m_redCloseButton->setIcon(
-                        QIcon(QStringLiteral(":images/windows_close_regular.png")));
-                m_greenMaximizeButton->setIcon(
-                        QIcon(QStringLiteral(":images/windows_minimize_regular.png")));
+                m_redCloseButton->setIcon(QIcon(QStringLiteral(":images/windows_close_regular.png")));
+                m_greenMaximizeButton->setIcon(QIcon(QStringLiteral(":images/windows_minimize_regular.png")));
 
                 if (windowState() == Qt::WindowFullScreen) {
-                    m_yellowMinimizeButton->setIcon(
-                            QIcon(QStringLiteral(":images/windows_de-maximize_regular.png")));
+                    m_yellowMinimizeButton->setIcon(QIcon(QStringLiteral(":images/windows_de-maximize_regular.png")));
                 } else {
-                    m_yellowMinimizeButton->setIcon(
-                            QIcon(QStringLiteral(":images/windows_maximize_regular.png")));
+                    m_yellowMinimizeButton->setIcon(QIcon(QStringLiteral(":images/windows_maximize_regular.png")));
                 }
 #else
                 m_redCloseButton->setIcon(QIcon(QStringLiteral(":images/red.png")));
@@ -3947,15 +3718,12 @@ bool MainWindow::eventFilter(QObject *object, QEvent *event)
     case QEvent::WindowActivate: {
 #ifdef _WIN32
         m_redCloseButton->setIcon(QIcon(QStringLiteral(":images/windows_close_regular.png")));
-        m_greenMaximizeButton->setIcon(
-                QIcon(QStringLiteral(":images/windows_minimize_regular.png")));
+        m_greenMaximizeButton->setIcon(QIcon(QStringLiteral(":images/windows_minimize_regular.png")));
 
         if (windowState() == Qt::WindowFullScreen) {
-            m_yellowMinimizeButton->setIcon(
-                    QIcon(QStringLiteral(":images/windows_de-maximize_regular.png")));
+            m_yellowMinimizeButton->setIcon(QIcon(QStringLiteral(":images/windows_de-maximize_regular.png")));
         } else {
-            m_yellowMinimizeButton->setIcon(
-                    QIcon(QStringLiteral(":images/windows_maximize_regular.png")));
+            m_yellowMinimizeButton->setIcon(QIcon(QStringLiteral(":images/windows_maximize_regular.png")));
         }
 #else
         m_redCloseButton->setIcon(QIcon(QStringLiteral(":images/red.png")));
@@ -4058,8 +3826,7 @@ bool MainWindow::eventFilter(QObject *object, QEvent *event)
         auto *keyEvent = static_cast<QKeyEvent *>(event);
         if (keyEvent->key() == Qt::Key_Return && m_searchEdit->text().isEmpty()) {
             setFocusOnText();
-        } else if (keyEvent->key() == Qt::Key_Return
-                   && keyEvent->modifiers().testFlag(Qt::ControlModifier)) {
+        } else if (keyEvent->key() == Qt::Key_Return && keyEvent->modifiers().testFlag(Qt::ControlModifier)) {
             setFocusOnText();
             return true;
         } else if (keyEvent->key() == Qt::Key_Escape && isFullScreen()) {
@@ -4101,10 +3868,9 @@ bool MainWindow::alreadyAppliedFormat(const QString &formatChars)
         cursor.select(QTextCursor::WordUnderCursor);
         if (!cursor.hasSelection()) {
             QTextDocument *doc = m_textEdit->document();
-            cursor = doc->find(QRegularExpression(QRegularExpression::escape(formatChars) + "[^ "
-                                                  + formatChars + "]+"
-                                                  + QRegularExpression::escape(formatChars) + "$"),
-                               cursor.selectionStart(), QTextDocument::FindBackward);
+            cursor = doc->find(
+                    QRegularExpression(QRegularExpression::escape(formatChars) + "[^ " + formatChars + "]+" + QRegularExpression::escape(formatChars) + "$"),
+                    cursor.selectionStart(), QTextDocument::FindBackward);
             if (!cursor.isNull()) {
                 // m_textEdit->setTextCursor(cursor);
                 return true;
@@ -4119,8 +3885,7 @@ bool MainWindow::alreadyAppliedFormat(const QString &formatChars)
     }
     QString selectedText = cursor.selectedText();
     QTextDocument *doc = m_textEdit->document();
-    cursor = doc->find(formatChars + selectedText + formatChars,
-                       cursor.selectionStart() - formatChars.length());
+    cursor = doc->find(formatChars + selectedText + formatChars, cursor.selectionStart() - formatChars.length());
     return cursor.hasSelection();
 }
 
@@ -4189,8 +3954,7 @@ void MainWindow::setHeading(int level)
     QString new_text = "\n";
     if (cursor.hasSelection()) {
         QString selected_text = cursor.selectedText();
-        if (selected_text.at(0).unicode()
-            != 8233) { // if it doesn't start with a paragraph delimiter (first line)
+        if (selected_text.at(0).unicode() != 8233) { // if it doesn't start with a paragraph delimiter (first line)
             new_text.clear();
         }
         selected_text = selected_text.trimmed().remove(QRegularExpression("^#*\\s?"));
@@ -4302,6 +4066,5 @@ bool MainWindow::isTitleBar(int x, int y) const
         adjustedY -= m_layoutMargin;
     }
 
-    return (adjustedX >= 0 && adjustedX <= titleBarWidth && adjustedY >= 0
-            && adjustedY <= titleBarHeight);
+    return (adjustedX >= 0 && adjustedX <= titleBarWidth && adjustedY >= 0 && adjustedY <= titleBarHeight);
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3676,10 +3676,9 @@ bool MainWindow::eventFilter(QObject *object, QEvent *event)
     }
     case QEvent::ActivationChange: {
         if (m_editorSettingsWidget->isHidden()) {
-            QApplication::setActiveWindow(
-                    this); // TODO: The docs say this function is deprecated but it's the only one
-                           // that works in returning the user input from m_editorSettingsWidget
-                           // Qt::Popup
+            QApplication::setActiveWindow(this); // TODO: The docs say this function is deprecated but it's the only one
+                                                 // that works in returning the user input from m_editorSettingsWidget
+                                                 // Qt::Popup
             m_textEdit->setFocus();
         }
         break;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -52,8 +52,8 @@
 #include "nodetreeview.h"
 #include "editorsettingsoptions.h"
 
-L_DECLARE_ENUM(SubscriptionStatus, NoSubscription, Active, ActivationLimitReached, Expired, Invalid,
-               EnteredGracePeriod, GracePeriodOver, NoInternetConnection, UnknownError)
+L_DECLARE_ENUM(SubscriptionStatus, NoSubscription, Active, ActivationLimitReached, Expired, Invalid, EnteredGracePeriod, GracePeriodOver, NoInternetConnection,
+               UnknownError)
 
 namespace Ui {
 class MainWindow;
@@ -82,28 +82,9 @@ class MainWindow : public MainWindowBase
 public:
     enum class ShadowType { Linear = 0, Radial };
 
-    enum class ShadowSide {
-        Left = 0,
-        Right,
-        Top,
-        Bottom,
-        TopLeft,
-        TopRight,
-        BottomLeft,
-        BottomRight
-    };
+    enum class ShadowSide { Left = 0, Right, Top, Bottom, TopLeft, TopRight, BottomLeft, BottomRight };
 
-    enum class StretchSide {
-        None = 0,
-        Left,
-        Right,
-        Top,
-        Bottom,
-        TopLeft,
-        TopRight,
-        BottomLeft,
-        BottomRight
-    };
+    enum class StretchSide { None = 0, Left, Right, Top, Bottom, TopLeft, TopRight, BottomLeft, BottomRight };
 
     Q_ENUM(ShadowType)
     Q_ENUM(ShadowSide)
@@ -115,11 +96,10 @@ public:
     void setMainWindowVisibility(bool state);
 
 public slots:
-    void saveLastSelectedFolderTags(bool isFolder, const QString &folderPath,
-                                    const QSet<int> &tagId);
+    void saveLastSelectedFolderTags(bool isFolder, const QString &folderPath, const QSet<int> &tagId);
     void saveExpandedFolder(const QStringList &folderPaths);
     void saveLastSelectedNote(const QSet<int> &notesId);
-    void changeEditorFontTypeFromStyleButtons(FontTypeface::Value fontType, int chosenFontIndex);
+    void changeEditorFontTypeFromStyleButtons(FontTypeface::Value fontTypeface, int chosenFontIndex);
     void changeEditorFontSizeFromStyleButtons(FontSizeAction::Value fontSizeAction);
     void changeEditorTextWidthFromStyleButtons(EditorTextWidth::Value editorTextWidth);
     void resetEditorSettings();
@@ -135,7 +115,7 @@ public slots:
     void toggleEditorSettings();
     void setEditorSettingsFromQuickViewVisibility(bool isVisible);
     void setEditorSettingsScrollBarPosition(double position);
-    void setActivationSuccessful(QString licenseKey, bool removeGracePeriodStartedDate = true);
+    void setActivationSuccessful(QString const &licenseKey, bool removeGracePeriodStartedDate = true);
     void checkProVersion();
     QVariant getUserLicenseKey();
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -55,7 +55,7 @@
 L_DECLARE_ENUM(SubscriptionStatus, NoSubscription, Active, ActivationLimitReached, Expired, Invalid, EnteredGracePeriod, GracePeriodOver, NoInternetConnection,
                UnknownError)
 
-namespace Ui {
+namespace Ui { // NOLINT(readability-identifier-naming)
 class MainWindow;
 }
 class TreeViewLogic;
@@ -128,12 +128,12 @@ protected:
     void moveEvent(QMoveEvent *event) override;
     void mouseReleaseEvent(QMouseEvent *event) override;
     void mouseDoubleClickEvent(QMouseEvent *event) override;
-    void leaveEvent(QEvent *) override;
+    void leaveEvent(QEvent * /*event*/) override;
     void changeEvent(QEvent *event) override;
     bool eventFilter(QObject *object, QEvent *event) override;
 
 private:
-    Ui::MainWindow *ui;
+    Ui::MainWindow *m_ui;
 
     QSettings *m_settingsDatabase;
     QToolButton *m_clearButton;
@@ -213,7 +213,7 @@ private:
     int m_chosenMonoFontIndex;
     int m_editorMediumFontSize;
     int m_currentFontPointSize;
-    struct m_charsLimitPerFont
+    struct CharsLimitPerFont
     {
         int mono;
         int serif;
@@ -284,7 +284,7 @@ private:
     void resetFormat(const QString &formatChars);
     void restoreStates();
     void migrateFromV0_9_0();
-    void executeImport(const bool replace);
+    void executeImport(bool replace);
     void migrateNoteFromV0_9_0(const QString &notePath);
     void migrateTrashFromV0_9_0(const QString &trashPath);
     void setCurrentFontBasedOnTypeface(FontTypeface::Value selectedFontTypeFace);
@@ -295,7 +295,6 @@ private:
     void updateSelectedOptionsEditorSettings();
     void dropShadow(QPainter &painter, ShadowType type, ShadowSide side);
     void fillRectWithGradient(QPainter &painter, QRect rect, QGradient &gradient);
-    double gaussianDist(double x, const double center, double sigma) const;
     void resizeAndPositionEditorSettingsWindow();
     void getPaymentDetailsSignalsSlots();
     void verifyLicenseSignalsSlots();
@@ -304,7 +303,7 @@ private:
     void setMargins(QMargins margins);
 
 private slots:
-    void InitData();
+    void initData();
 
     void onSystemTrayIconActivated(QSystemTrayIcon::ActivationReason reason);
     void onNewNoteButtonClicked();
@@ -330,7 +329,7 @@ private slots:
     void makeStrikethrough();
     void maximizeWindow();
     void minimizeWindow();
-    void QuitApplication();
+    void quitApplication();
 #if defined(UPDATE_CHECKER)
     void checkForUpdates();
 #endif

--- a/src/nodedata.cpp
+++ b/src/nodedata.cpp
@@ -2,12 +2,12 @@
 #include <QDataStream>
 
 NodeData::NodeData()
-    : m_id{ SpecialNodeID::InvalidNodeId },
+    : m_id{ INVALID_NODE_ID },
       m_isModified(false),
       m_isSelected(false),
       m_scrollBarPosition(0),
       m_nodeType(Type::Note),
-      m_parentId(SpecialNodeID::InvalidNodeId),
+      m_parentId(INVALID_NODE_ID),
       m_relativePosition(0),
       m_isTempNote{ false },
       m_isPinnedNote{ false },
@@ -242,7 +242,7 @@ QDataStream &operator>>(QDataStream &stream, NodeData *&nodeData)
     QDateTime creationDateTime;
     QString content;
     stream >> id >> fullTitle >> creationDateTime >> lastModificationDateTime >> content;
-    nodeData->setId(SpecialNodeID::InvalidNodeId);
+    nodeData->setId(INVALID_NODE_ID);
     nodeData->setFullTitle(fullTitle);
     nodeData->setLastModificationDateTime(lastModificationDateTime);
     nodeData->setCreationDateTime(creationDateTime);

--- a/src/nodedata.cpp
+++ b/src/nodedata.cpp
@@ -6,6 +6,9 @@ NodeData::NodeData()
       m_isModified(false),
       m_isSelected(false),
       m_scrollBarPosition(0),
+      m_nodeType(Type::Note),
+      m_parentId(SpecialNodeID::InvalidNodeId),
+      m_relativePosition(0),
       m_isTempNote{ false },
       m_isPinnedNote{ false },
       m_tagListScrollBarPos{ 0 },
@@ -24,7 +27,7 @@ void NodeData::setId(int id)
     m_id = id;
 }
 
-QString NodeData::fullTitle() const
+QString const &NodeData::fullTitle() const
 {
     return m_fullTitle;
 }
@@ -34,7 +37,7 @@ void NodeData::setFullTitle(const QString &fullTitle)
     m_fullTitle = fullTitle;
 }
 
-QDateTime NodeData::lastModificationdateTime() const
+QDateTime const &NodeData::lastModificationdateTime() const
 {
     return m_lastModificationDateTime;
 }
@@ -44,7 +47,7 @@ void NodeData::setLastModificationDateTime(const QDateTime &lastModificationdate
     m_lastModificationDateTime = lastModificationdateTime;
 }
 
-QString NodeData::content() const
+QString const &NodeData::content() const
 {
     return m_content;
 }

--- a/src/nodedata.h
+++ b/src/nodedata.h
@@ -5,14 +5,12 @@
 #include <QDateTime>
 #include <QSet>
 
-namespace SpecialNodeID {
-enum Value {
-    InvalidNodeId = -1,
-    RootFolder = 0,
-    TrashFolder = 1,
-    DefaultNotesFolder = 2,
-};
-}
+namespace {
+auto constexpr INVALID_NODE_ID = -1;
+auto constexpr ROOT_FOLDER_ID = 0;
+auto constexpr TRASH_FOLDER_ID = 1;
+auto constexpr DEFAULT_NOTES_FOLDER_ID = 2;
+} // namespace
 
 class NodeData
 {

--- a/src/nodedata.h
+++ b/src/nodedata.h
@@ -19,21 +19,21 @@ class NodeData
 public:
     explicit NodeData();
 
-    enum Type { Note = 0, Folder };
+    enum class Type : uint8_t { Note = 0, Folder };
 
     int id() const;
     void setId(int id);
 
-    QString fullTitle() const;
+    QString const &fullTitle() const;
     void setFullTitle(const QString &fullTitle);
 
-    QDateTime lastModificationdateTime() const;
+    QDateTime const &lastModificationdateTime() const;
     void setLastModificationDateTime(const QDateTime &lastModificationdateTime);
 
     QDateTime creationDateTime() const;
     void setCreationDateTime(const QDateTime &creationDateTime);
 
-    QString content() const;
+    QString const &content() const;
     void setContent(const QString &content);
 
     bool isModified() const;

--- a/src/nodepath.cpp
+++ b/src/nodepath.cpp
@@ -1,14 +1,14 @@
 #include "nodepath.h"
 #include "nodedata.h"
 
-NodePath::NodePath(const QString &path) : m_path(path) { }
+NodePath::NodePath(QString path) : m_path(std::move(path)) { }
 
 QStringList NodePath::separate() const
 {
     return m_path.split(PATH_SEPARATOR, Qt::SkipEmptyParts);
 }
 
-QString NodePath::path() const
+QString const &NodePath::path() const
 {
     return m_path;
 }
@@ -17,7 +17,7 @@ NodePath NodePath::parentPath() const
 {
     auto s = separate();
     s.takeLast();
-    return s.join(PATH_SEPARATOR);
+    return { s.join(PATH_SEPARATOR) };
 }
 
 QString NodePath::getAllNoteFolderPath()
@@ -27,8 +27,5 @@ QString NodePath::getAllNoteFolderPath()
 
 QString NodePath::getTrashFolderPath()
 {
-    return QStringLiteral("%1%2%1%3")
-            .arg(PATH_SEPARATOR)
-            .arg(SpecialNodeID::RootFolder)
-            .arg(SpecialNodeID::TrashFolder);
+    return QStringLiteral("%1%2%1%3").arg(PATH_SEPARATOR).arg(SpecialNodeID::RootFolder).arg(SpecialNodeID::TrashFolder);
 }

--- a/src/nodepath.cpp
+++ b/src/nodepath.cpp
@@ -22,10 +22,10 @@ NodePath NodePath::parentPath() const
 
 QString NodePath::getAllNoteFolderPath()
 {
-    return QStringLiteral("%1%2").arg(PATH_SEPARATOR).arg(SpecialNodeID::RootFolder);
+    return QStringLiteral("%1%2").arg(PATH_SEPARATOR).arg(ROOT_FOLDER_ID);
 }
 
 QString NodePath::getTrashFolderPath()
 {
-    return QStringLiteral("%1%2%1%3").arg(PATH_SEPARATOR).arg(SpecialNodeID::RootFolder).arg(SpecialNodeID::TrashFolder);
+    return QStringLiteral("%1%2%1%3").arg(PATH_SEPARATOR).arg(ROOT_FOLDER_ID).arg(TRASH_FOLDER_ID);
 }

--- a/src/nodepath.h
+++ b/src/nodepath.h
@@ -1,21 +1,21 @@
-#ifndef NODEPATH_H
-#define NODEPATH_H
+#pragma once
 
 #include <QString>
 #include <QList>
 
-#define PATH_SEPARATOR "/"
-#define FOLDER_MIME "application/x-foldernode"
-#define TAG_MIME "application/x-tagnode"
-#define NOTE_MIME "application/x-notenode"
+auto constexpr PATH_SEPARATOR = '/';
+auto constexpr FOLDER_MIME = "application/x-foldernode";
+auto constexpr TAG_MIME = "application/x-tagnode";
+auto constexpr NOTE_MIME = "application/x-notenode";
 
 class NodePath
 {
 public:
-    NodePath(const QString &path);
+    // cppcheck-suppress noExplicitConstructor
+    NodePath(QString path);
     QStringList separate() const;
 
-    QString path() const;
+    QString const &path() const;
     NodePath parentPath() const;
     static QString getAllNoteFolderPath();
     static QString getTrashFolderPath();
@@ -23,5 +23,3 @@ public:
 private:
     QString m_path;
 };
-
-#endif // NODEPATH_H

--- a/src/nodetreedelegate.cpp
+++ b/src/nodetreedelegate.cpp
@@ -131,24 +131,24 @@ void NodeTreeDelegate::paint(QPainter *painter, const QStyleOptionViewItem &opti
         }
         if (m_theme == Theme::Dark) {
             if (itemType == NodeItem::Type::AllNoteButton) {
-                painter->setFont(FontLoader::getInstance().loadFont("Material Symbols Outlined", "",
+                painter->setFont(font_loader::loadFont("Material Symbols Outlined", "",
                                                                     16 + iconPointSizeOffset));
                 painter->drawText(iconRect, u8"\ue2c7"); // folder
             } else if (itemType == NodeItem::Type::TrashButton) {
                 iconRect.setY(iconRect.y() + 2);
-                painter->setFont(FontLoader::getInstance().loadFont("Font Awesome 6 Free Solid", "",
+                painter->setFont(font_loader::loadFont("Font Awesome 6 Free Solid", "",
                                                                     16 + iconPointSizeOffset));
                 painter->drawText(iconRect, u8"\uf1f8"); // fa-trash
             }
         } else {
             auto iconPath = index.data(NodeItem::Roles::Icon).toString();
             if (itemType == NodeItem::Type::AllNoteButton) {
-                painter->setFont(FontLoader::getInstance().loadFont("Material Symbols Outlined", "",
+                painter->setFont(font_loader::loadFont("Material Symbols Outlined", "",
                                                                     16 + iconPointSizeOffset));
                 painter->drawText(iconRect, iconPath); // folder
             } else if (itemType == NodeItem::Type::TrashButton) {
                 iconRect.setY(iconRect.y() + 2);
-                painter->setFont(FontLoader::getInstance().loadFont("Font Awesome 6 Free Solid", "",
+                painter->setFont(font_loader::loadFont("Font Awesome 6 Free Solid", "",
                                                                     16 + iconPointSizeOffset));
                 painter->drawText(iconRect, iconPath); // fa-trash
             }
@@ -195,7 +195,7 @@ void NodeTreeDelegate::paint(QPainter *painter, const QStyleOptionViewItem &opti
         auto iconRect = QRect(option.rect.x() + 10,
                               option.rect.y() + (option.rect.height() - 12) / 2, 12, 12);
         QString iconPath;
-        painter->setFont(FontLoader::getInstance().loadFont("Font Awesome 6 Free Solid", "",
+        painter->setFont(font_loader::loadFont("Font Awesome 6 Free Solid", "",
                                                             10 + iconPointSizeOffset));
         if (m_theme == Theme::Dark) {
             painter->setPen(QColor(169, 160, 172));
@@ -227,7 +227,7 @@ void NodeTreeDelegate::paint(QPainter *painter, const QStyleOptionViewItem &opti
         } else {
             painter->setPen(m_folderIconColor);
         }
-        painter->setFont(FontLoader::getInstance().loadFont("Material Symbols Outlined", "",
+        painter->setFont(font_loader::loadFont("Material Symbols Outlined", "",
                                                             16 + iconPointSizeOffset));
         painter->drawText(folderIconRect, u8"\ue2c7"); // folder
 
@@ -281,7 +281,7 @@ void NodeTreeDelegate::paint(QPainter *painter, const QStyleOptionViewItem &opti
                               option.rect.y() + (option.rect.height() - 14) / 2, 16, 16);
         auto tagColor = index.data(NodeItem::Roles::TagColor).toString();
         painter->setPen(QColor(tagColor));
-        painter->setFont(FontLoader::getInstance().loadFont("Font Awesome 6 Free Solid", "",
+        painter->setFont(font_loader::loadFont("Font Awesome 6 Free Solid", "",
                                                             16 + iconPointSizeOffset));
         painter->drawText(iconRect, u8"\uf111"); // fa-circle
         painter->setBrush(Qt::black);
@@ -383,7 +383,7 @@ QWidget *NodeTreeDelegate::createEditor(QWidget *parent, const QStyleOptionViewI
 #else
         int iconPointSizeOffset = -4;
 #endif
-        addButton->setFont(FontLoader::getInstance().loadFont("Font Awesome 6 Free Solid", "",
+        addButton->setFont(font_loader::loadFont("Font Awesome 6 Free Solid", "",
                                                               16 + iconPointSizeOffset));
         addButton->setText(u8"\uf067"); // fa_plus
         addButton->setStyleSheet(QStringLiteral(R"(QPushButton { )"

--- a/src/nodetreedelegate.cpp
+++ b/src/nodetreedelegate.cpp
@@ -387,7 +387,7 @@ QWidget *NodeTreeDelegate::createEditor(QWidget *parent, const QStyleOptionViewI
         return widget;
     } else if (itemType == NodeItem::Type::FolderItem) {
         auto id = index.data(NodeItem::Roles::NodeId).toInt();
-        if (id == SpecialNodeID::DefaultNotesFolder) {
+        if (id == DEFAULT_NOTES_FOLDER_ID) {
             auto widget = new DefaultNoteFolderDelegateEditor(m_view, option, index, m_listView, parent);
             widget->setTheme(m_theme);
             connect(this, &NodeTreeDelegate::themeChanged, widget, &DefaultNoteFolderDelegateEditor::setTheme);

--- a/src/nodetreedelegate.cpp
+++ b/src/nodetreedelegate.cpp
@@ -18,12 +18,9 @@
 NodeTreeDelegate::NodeTreeDelegate(QTreeView *view, QObject *parent, QListView *listView)
     : QStyledItemDelegate{ parent },
 #ifdef __APPLE__
-      m_displayFont(QFont(QStringLiteral("SF Pro Text")).exactMatch()
-                            ? QStringLiteral("SF Pro Text")
-                            : QStringLiteral("Roboto")),
+      m_displayFont(QFont(QStringLiteral("SF Pro Text")).exactMatch() ? QStringLiteral("SF Pro Text") : QStringLiteral("Roboto")),
 #elif _WIN32
-      m_displayFont(QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI")
-                                                                   : QStringLiteral("Roboto")),
+      m_displayFont(QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI") : QStringLiteral("Roboto")),
 #else
       m_displayFont(QStringLiteral("Roboto")),
 #endif
@@ -101,8 +98,7 @@ void NodeTreeDelegate::setTheme(Theme::Value theme)
     }
 }
 
-void NodeTreeDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option,
-                             const QModelIndex &index) const
+void NodeTreeDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
 {
     painter->setRenderHint(QPainter::Antialiasing);
     auto itemType = static_cast<NodeItem::Type>(index.data(NodeItem::Roles::ItemType).toInt());
@@ -121,8 +117,7 @@ void NodeTreeDelegate::paint(QPainter *painter, const QStyleOptionViewItem &opti
     case NodeItem::Type::AllNoteButton:
     case NodeItem::Type::TrashButton: {
         paintBackgroundSelectable(painter, option, index);
-        auto iconRect = QRect(option.rect.x() + 22,
-                              option.rect.y() + (option.rect.height() - 20) / 2, 18, 20);
+        auto iconRect = QRect(option.rect.x() + 22, option.rect.y() + (option.rect.height() - 20) / 2, 18, 20);
         QFont previousPainterFont = painter->font();
         if ((option.state & QStyle::State_Selected) == QStyle::State_Selected) {
             painter->setPen(m_titleSelectedColor);
@@ -131,25 +126,21 @@ void NodeTreeDelegate::paint(QPainter *painter, const QStyleOptionViewItem &opti
         }
         if (m_theme == Theme::Dark) {
             if (itemType == NodeItem::Type::AllNoteButton) {
-                painter->setFont(font_loader::loadFont("Material Symbols Outlined", "",
-                                                                    16 + iconPointSizeOffset));
+                painter->setFont(font_loader::loadFont("Material Symbols Outlined", "", 16 + iconPointSizeOffset));
                 painter->drawText(iconRect, u8"\ue2c7"); // folder
             } else if (itemType == NodeItem::Type::TrashButton) {
                 iconRect.setY(iconRect.y() + 2);
-                painter->setFont(font_loader::loadFont("Font Awesome 6 Free Solid", "",
-                                                                    16 + iconPointSizeOffset));
+                painter->setFont(font_loader::loadFont("Font Awesome 6 Free Solid", "", 16 + iconPointSizeOffset));
                 painter->drawText(iconRect, u8"\uf1f8"); // fa-trash
             }
         } else {
             auto iconPath = index.data(NodeItem::Roles::Icon).toString();
             if (itemType == NodeItem::Type::AllNoteButton) {
-                painter->setFont(font_loader::loadFont("Material Symbols Outlined", "",
-                                                                    16 + iconPointSizeOffset));
+                painter->setFont(font_loader::loadFont("Material Symbols Outlined", "", 16 + iconPointSizeOffset));
                 painter->drawText(iconRect, iconPath); // folder
             } else if (itemType == NodeItem::Type::TrashButton) {
                 iconRect.setY(iconRect.y() + 2);
-                painter->setFont(font_loader::loadFont("Font Awesome 6 Free Solid", "",
-                                                                    16 + iconPointSizeOffset));
+                painter->setFont(font_loader::loadFont("Font Awesome 6 Free Solid", "", 16 + iconPointSizeOffset));
                 painter->drawText(iconRect, iconPath); // fa-trash
             }
         }
@@ -175,8 +166,7 @@ void NodeTreeDelegate::paint(QPainter *painter, const QStyleOptionViewItem &opti
             painter->setPen(m_numberOfNotesColor);
         }
         painter->setFont(m_numberOfNotesFont);
-        painter->drawText(childCountRect, Qt::AlignHCenter | Qt::AlignVCenter,
-                          QString::number(childCount));
+        painter->drawText(childCountRect, Qt::AlignHCenter | Qt::AlignVCenter, QString::number(childCount));
         break;
     }
     case NodeItem::Type::FolderSeparator:
@@ -192,11 +182,9 @@ void NodeTreeDelegate::paint(QPainter *painter, const QStyleOptionViewItem &opti
     }
     case NodeItem::Type::FolderItem: {
         paintBackgroundSelectable(painter, option, index);
-        auto iconRect = QRect(option.rect.x() + 10,
-                              option.rect.y() + (option.rect.height() - 12) / 2, 12, 12);
+        auto iconRect = QRect(option.rect.x() + 10, option.rect.y() + (option.rect.height() - 12) / 2, 12, 12);
         QString iconPath;
-        painter->setFont(font_loader::loadFont("Font Awesome 6 Free Solid", "",
-                                                            10 + iconPointSizeOffset));
+        painter->setFont(font_loader::loadFont("Font Awesome 6 Free Solid", "", 10 + iconPointSizeOffset));
         if (m_theme == Theme::Dark) {
             painter->setPen(QColor(169, 160, 172));
             if ((option.state & QStyle::State_Open) == QStyle::State_Open) {
@@ -227,8 +215,7 @@ void NodeTreeDelegate::paint(QPainter *painter, const QStyleOptionViewItem &opti
         } else {
             painter->setPen(m_folderIconColor);
         }
-        painter->setFont(font_loader::loadFont("Material Symbols Outlined", "",
-                                                            16 + iconPointSizeOffset));
+        painter->setFont(font_loader::loadFont("Material Symbols Outlined", "", 16 + iconPointSizeOffset));
         painter->drawText(folderIconRect, u8"\ue2c7"); // folder
 
         QRect nameRect(option.rect);
@@ -254,8 +241,7 @@ void NodeTreeDelegate::paint(QPainter *painter, const QStyleOptionViewItem &opti
             painter->setPen(m_numberOfNotesColor);
         }
         painter->setFont(m_numberOfNotesFont);
-        painter->drawText(childCountRect, Qt::AlignHCenter | Qt::AlignVCenter,
-                          QString::number(childCount));
+        painter->drawText(childCountRect, Qt::AlignHCenter | Qt::AlignVCenter, QString::number(childCount));
         break;
     }
     case NodeItem::Type::NoteItem: {
@@ -277,12 +263,10 @@ void NodeTreeDelegate::paint(QPainter *painter, const QStyleOptionViewItem &opti
     }
     case NodeItem::Type::TagItem: {
         paintBackgroundSelectable(painter, option, index);
-        auto iconRect = QRect(option.rect.x() + 22,
-                              option.rect.y() + (option.rect.height() - 14) / 2, 16, 16);
+        auto iconRect = QRect(option.rect.x() + 22, option.rect.y() + (option.rect.height() - 14) / 2, 16, 16);
         auto tagColor = index.data(NodeItem::Roles::TagColor).toString();
         painter->setPen(QColor(tagColor));
-        painter->setFont(font_loader::loadFont("Font Awesome 6 Free Solid", "",
-                                                            16 + iconPointSizeOffset));
+        painter->setFont(font_loader::loadFont("Font Awesome 6 Free Solid", "", 16 + iconPointSizeOffset));
         painter->drawText(iconRect, u8"\uf111"); // fa-circle
         painter->setBrush(Qt::black);
         painter->setPen(Qt::black);
@@ -309,21 +293,18 @@ void NodeTreeDelegate::paint(QPainter *painter, const QStyleOptionViewItem &opti
             painter->setPen(m_numberOfNotesColor);
         }
         painter->setFont(m_numberOfNotesFont);
-        painter->drawText(childCountRect, Qt::AlignHCenter | Qt::AlignVCenter,
-                          QString::number(childCount));
+        painter->drawText(childCountRect, Qt::AlignHCenter | Qt::AlignVCenter, QString::number(childCount));
         break;
     }
     }
 }
 
-void NodeTreeDelegate::paintBackgroundSelectable(QPainter *painter,
-                                                 const QStyleOptionViewItem &option,
-                                                 const QModelIndex &index) const
+void NodeTreeDelegate::paintBackgroundSelectable(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
 {
     if ((option.state & QStyle::State_Selected) == QStyle::State_Selected) {
         painter->fillRect(option.rect, QBrush(m_ActiveColor));
     } else if ((option.state & QStyle::State_MouseOver) == QStyle::State_MouseOver) {
-        auto treeView = dynamic_cast<NodeTreeView *>(m_view);
+        auto const *treeView = static_cast<NodeTreeView *>(m_view);
         auto itemType = static_cast<NodeItem::Type>(index.data(NodeItem::Roles::ItemType).toInt());
         if (itemType == NodeItem::Type::TrashButton) {
             return;
@@ -342,8 +323,7 @@ QSize NodeTreeDelegate::sizeHint(const QStyleOptionViewItem &option, const QMode
         result.setHeight(NoteTreeConstant::folderLabelHeight);
     } else if (itemType == NodeItem::Type::TagSeparator) {
         result.setHeight(NoteTreeConstant::tagLabelHeight);
-    } else if (itemType == NodeItem::Type::FolderItem || itemType == NodeItem::Type::TrashButton
-               || itemType == NodeItem::Type::AllNoteButton) {
+    } else if (itemType == NodeItem::Type::FolderItem || itemType == NodeItem::Type::TrashButton || itemType == NodeItem::Type::AllNoteButton) {
         result.setHeight(NoteTreeConstant::folderItemHeight);
     } else if (itemType == NodeItem::Type::TagItem) {
         result.setHeight(NoteTreeConstant::tagItemHeight);
@@ -354,8 +334,7 @@ QSize NodeTreeDelegate::sizeHint(const QStyleOptionViewItem &option, const QMode
     return result;
 }
 
-QWidget *NodeTreeDelegate::createEditor(QWidget *parent, const QStyleOptionViewItem &option,
-                                        const QModelIndex &index) const
+QWidget *NodeTreeDelegate::createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const
 {
     auto itemType = static_cast<NodeItem::Type>(index.data(NodeItem::Roles::ItemType).toInt());
     if (itemType == NodeItem::Type::FolderSeparator || itemType == NodeItem::Type::TagSeparator) {
@@ -367,8 +346,7 @@ QWidget *NodeTreeDelegate::createEditor(QWidget *parent, const QStyleOptionViewI
         auto label = new QLabel(widget);
         auto displayName = index.data(NodeItem::Roles::DisplayText).toString();
         label->setStyleSheet(QStringLiteral("QLabel{color: rgb(%1, %2, %3);}")
-                                     .arg(QString::number(m_separatorTextColor.red()),
-                                          QString::number(m_separatorTextColor.green()),
+                                     .arg(QString::number(m_separatorTextColor.red()), QString::number(m_separatorTextColor.green()),
                                           QString::number(m_separatorTextColor.blue())));
         label->setFont(m_separatorFont);
         label->setText(displayName);
@@ -383,8 +361,7 @@ QWidget *NodeTreeDelegate::createEditor(QWidget *parent, const QStyleOptionViewI
 #else
         int iconPointSizeOffset = -4;
 #endif
-        addButton->setFont(font_loader::loadFont("Font Awesome 6 Free Solid", "",
-                                                              16 + iconPointSizeOffset));
+        addButton->setFont(font_loader::loadFont("Font Awesome 6 Free Solid", "", 16 + iconPointSizeOffset));
         addButton->setText(u8"\uf067"); // fa_plus
         addButton->setStyleSheet(QStringLiteral(R"(QPushButton { )"
                                                 R"(    border: none; )"
@@ -411,17 +388,14 @@ QWidget *NodeTreeDelegate::createEditor(QWidget *parent, const QStyleOptionViewI
     } else if (itemType == NodeItem::Type::FolderItem) {
         auto id = index.data(NodeItem::Roles::NodeId).toInt();
         if (id == SpecialNodeID::DefaultNotesFolder) {
-            auto widget =
-                    new DefaultNoteFolderDelegateEditor(m_view, option, index, m_listView, parent);
+            auto widget = new DefaultNoteFolderDelegateEditor(m_view, option, index, m_listView, parent);
             widget->setTheme(m_theme);
-            connect(this, &NodeTreeDelegate::themeChanged, widget,
-                    &DefaultNoteFolderDelegateEditor::setTheme);
+            connect(this, &NodeTreeDelegate::themeChanged, widget, &DefaultNoteFolderDelegateEditor::setTheme);
             return widget;
         } else {
             auto widget = new FolderTreeDelegateEditor(m_view, option, index, m_listView, parent);
             widget->setTheme(m_theme);
-            connect(this, &NodeTreeDelegate::themeChanged, widget,
-                    &FolderTreeDelegateEditor::setTheme);
+            connect(this, &NodeTreeDelegate::themeChanged, widget, &FolderTreeDelegateEditor::setTheme);
             return widget;
         }
     } else if (itemType == NodeItem::Type::TagItem) {
@@ -432,22 +406,18 @@ QWidget *NodeTreeDelegate::createEditor(QWidget *parent, const QStyleOptionViewI
     } else if (itemType == NodeItem::Type::TrashButton) {
         auto widget = new TrashButtonDelegateEditor(m_view, option, index, m_listView, parent);
         widget->setTheme(m_theme);
-        connect(this, &NodeTreeDelegate::themeChanged, widget,
-                &TrashButtonDelegateEditor::setTheme);
+        connect(this, &NodeTreeDelegate::themeChanged, widget, &TrashButtonDelegateEditor::setTheme);
         return widget;
     } else if (itemType == NodeItem::Type::AllNoteButton) {
-        auto widget =
-                new AllNoteButtonTreeDelegateEditor(m_view, option, index, m_listView, parent);
+        auto widget = new AllNoteButtonTreeDelegateEditor(m_view, option, index, m_listView, parent);
         widget->setTheme(m_theme);
-        connect(this, &NodeTreeDelegate::themeChanged, widget,
-                &AllNoteButtonTreeDelegateEditor::setTheme);
+        connect(this, &NodeTreeDelegate::themeChanged, widget, &AllNoteButtonTreeDelegateEditor::setTheme);
         return widget;
     }
     return nullptr;
 }
 
-void NodeTreeDelegate::updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option,
-                                            const QModelIndex &index) const
+void NodeTreeDelegate::updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex &index) const
 {
     QStyledItemDelegate::updateEditorGeometry(editor, option, index);
     auto itemType = static_cast<NodeItem::Type>(index.data(NodeItem::Roles::ItemType).toInt());

--- a/src/nodetreedelegate.cpp
+++ b/src/nodetreedelegate.cpp
@@ -40,7 +40,7 @@ NodeTreeDelegate::NodeTreeDelegate(QTreeView *view, QObject *parent, QListView *
       m_titleColor(26, 26, 26),
       m_titleSelectedColor(255, 255, 255),
       m_dateColor(132, 132, 132),
-      m_ActiveColor(68, 138, 201),
+      m_activeColor(68, 138, 201),
       m_notActiveColor(175, 212, 228),
       m_hoverColor(180, 208, 233),
       m_applicationInactiveColor(207, 207, 207),
@@ -66,7 +66,7 @@ void NodeTreeDelegate::setTheme(Theme::Value theme)
         m_titleColor = QColor(26, 26, 26);
         m_dateColor = QColor(26, 26, 26);
         m_defaultColor = QColor(247, 247, 247);
-        //        m_ActiveColor = QColor(218, 233, 239);
+        //        m_activeColor = QColor(218, 233, 239);
         m_notActiveColor = QColor(175, 212, 228);
         m_hoverColor = QColor(180, 208, 233);
         m_currentBackgroundColor = QColor(247, 247, 247);
@@ -77,7 +77,7 @@ void NodeTreeDelegate::setTheme(Theme::Value theme)
         m_titleColor = QColor(212, 212, 212);
         m_dateColor = QColor(212, 212, 212);
         m_defaultColor = QColor(25, 25, 25);
-        //        m_ActiveColor = QColor(0, 59, 148);
+        //        m_activeColor = QColor(0, 59, 148);
         m_notActiveColor = QColor(35, 52, 69);
         m_hoverColor = QColor(35, 52, 69);
         m_currentBackgroundColor = QColor(25, 25, 25);
@@ -88,7 +88,7 @@ void NodeTreeDelegate::setTheme(Theme::Value theme)
         m_titleColor = QColor(26, 26, 26);
         m_dateColor = QColor(26, 26, 26);
         m_defaultColor = QColor(251, 240, 217);
-        //        m_ActiveColor = QColor(218, 233, 239);
+        //        m_activeColor = QColor(218, 233, 239);
         m_notActiveColor = QColor(175, 212, 228);
         m_hoverColor = QColor(180, 208, 233);
         m_currentBackgroundColor = QColor(251, 240, 217);
@@ -117,7 +117,7 @@ void NodeTreeDelegate::paint(QPainter *painter, const QStyleOptionViewItem &opti
     case NodeItem::Type::AllNoteButton:
     case NodeItem::Type::TrashButton: {
         paintBackgroundSelectable(painter, option, index);
-        auto iconRect = QRect(option.rect.x() + 22, option.rect.y() + (option.rect.height() - 20) / 2, 18, 20);
+        auto iconRect = QRect(option.rect.x() + 22, option.rect.y() + ((option.rect.height() - 20) / 2), 18, 20);
         QFont previousPainterFont = painter->font();
         if ((option.state & QStyle::State_Selected) == QStyle::State_Selected) {
             painter->setPen(m_titleSelectedColor);
@@ -173,7 +173,7 @@ void NodeTreeDelegate::paint(QPainter *painter, const QStyleOptionViewItem &opti
     case NodeItem::Type::TagSeparator: {
         auto textRect = option.rect;
         textRect.moveLeft(textRect.x() + 5);
-        textRect.moveBottom(textRect.y() + NoteTreeConstant::folderLabelHeight + 2);
+        textRect.moveBottom(textRect.y() + NoteTreeConstant::FOLDER_LABEL_HEIGHT + 2);
         auto displayName = index.data(NodeItem::Roles::DisplayText).toString();
         painter->setPen(m_separatorColor);
         painter->setFont(m_separatorFont);
@@ -182,7 +182,7 @@ void NodeTreeDelegate::paint(QPainter *painter, const QStyleOptionViewItem &opti
     }
     case NodeItem::Type::FolderItem: {
         paintBackgroundSelectable(painter, option, index);
-        auto iconRect = QRect(option.rect.x() + 10, option.rect.y() + (option.rect.height() - 12) / 2, 12, 12);
+        auto iconRect = QRect(option.rect.x() + 10, option.rect.y() + ((option.rect.height() - 12) / 2), 12, 12);
         QString iconPath;
         painter->setFont(font_loader::loadFont("Font Awesome 6 Free Solid", "", 10 + iconPointSizeOffset));
         if (m_theme == Theme::Dark) {
@@ -263,7 +263,7 @@ void NodeTreeDelegate::paint(QPainter *painter, const QStyleOptionViewItem &opti
     }
     case NodeItem::Type::TagItem: {
         paintBackgroundSelectable(painter, option, index);
-        auto iconRect = QRect(option.rect.x() + 22, option.rect.y() + (option.rect.height() - 14) / 2, 16, 16);
+        auto iconRect = QRect(option.rect.x() + 22, option.rect.y() + ((option.rect.height() - 14) / 2), 16, 16);
         auto tagColor = index.data(NodeItem::Roles::TagColor).toString();
         painter->setPen(QColor(tagColor));
         painter->setFont(font_loader::loadFont("Font Awesome 6 Free Solid", "", 16 + iconPointSizeOffset));
@@ -302,7 +302,7 @@ void NodeTreeDelegate::paint(QPainter *painter, const QStyleOptionViewItem &opti
 void NodeTreeDelegate::paintBackgroundSelectable(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
 {
     if ((option.state & QStyle::State_Selected) == QStyle::State_Selected) {
-        painter->fillRect(option.rect, QBrush(m_ActiveColor));
+        painter->fillRect(option.rect, QBrush(m_activeColor));
     } else if ((option.state & QStyle::State_MouseOver) == QStyle::State_MouseOver) {
         auto const *treeView = static_cast<NodeTreeView *>(m_view);
         auto itemType = static_cast<NodeItem::Type>(index.data(NodeItem::Roles::ItemType).toInt());
@@ -320,13 +320,13 @@ QSize NodeTreeDelegate::sizeHint(const QStyleOptionViewItem &option, const QMode
     QSize result = QStyledItemDelegate::sizeHint(option, index);
     auto itemType = static_cast<NodeItem::Type>(index.data(NodeItem::Roles::ItemType).toInt());
     if (itemType == NodeItem::Type::FolderSeparator) {
-        result.setHeight(NoteTreeConstant::folderLabelHeight);
+        result.setHeight(NoteTreeConstant::FOLDER_LABEL_HEIGHT);
     } else if (itemType == NodeItem::Type::TagSeparator) {
-        result.setHeight(NoteTreeConstant::tagLabelHeight);
+        result.setHeight(NoteTreeConstant::TAG_LABEL_HEIGHT);
     } else if (itemType == NodeItem::Type::FolderItem || itemType == NodeItem::Type::TrashButton || itemType == NodeItem::Type::AllNoteButton) {
-        result.setHeight(NoteTreeConstant::folderItemHeight);
+        result.setHeight(NoteTreeConstant::FOLDER_ITEM_HEIGHT);
     } else if (itemType == NodeItem::Type::TagItem) {
-        result.setHeight(NoteTreeConstant::tagItemHeight);
+        result.setHeight(NoteTreeConstant::TAG_ITEM_HEIGHT);
     } else {
         result.setHeight(30);
     }
@@ -338,12 +338,12 @@ QWidget *NodeTreeDelegate::createEditor(QWidget *parent, const QStyleOptionViewI
 {
     auto itemType = static_cast<NodeItem::Type>(index.data(NodeItem::Roles::ItemType).toInt());
     if (itemType == NodeItem::Type::FolderSeparator || itemType == NodeItem::Type::TagSeparator) {
-        auto widget = new QWidget(parent);
+        auto *widget = new QWidget(parent);
         widget->setContentsMargins(0, 0, 0, 0);
-        auto layout = new QHBoxLayout(widget);
+        auto *layout = new QHBoxLayout(widget);
         layout->setContentsMargins(5, 7, 0, 0);
         widget->setLayout(layout);
-        auto label = new QLabel(widget);
+        auto *label = new QLabel(widget);
         auto displayName = index.data(NodeItem::Roles::DisplayText).toString();
         label->setStyleSheet(QStringLiteral("QLabel{color: rgb(%1, %2, %3);}")
                                      .arg(QString::number(m_separatorTextColor.red()), QString::number(m_separatorTextColor.green()),
@@ -351,7 +351,7 @@ QWidget *NodeTreeDelegate::createEditor(QWidget *parent, const QStyleOptionViewI
         label->setFont(m_separatorFont);
         label->setText(displayName);
         layout->addWidget(label);
-        auto addButton = new PushButtonType(parent);
+        auto *addButton = new PushButtonType(parent);
         addButton->setMaximumSize({ 38, 25 });
         addButton->setMinimumSize({ 38, 25 });
         addButton->setCursor(QCursor(Qt::PointingHandCursor));
@@ -385,31 +385,34 @@ QWidget *NodeTreeDelegate::createEditor(QWidget *parent, const QStyleOptionViewI
         }
         layout->addWidget(addButton, 1, Qt::AlignRight);
         return widget;
-    } else if (itemType == NodeItem::Type::FolderItem) {
+    }
+    if (itemType == NodeItem::Type::FolderItem) {
         auto id = index.data(NodeItem::Roles::NodeId).toInt();
         if (id == DEFAULT_NOTES_FOLDER_ID) {
-            auto widget = new DefaultNoteFolderDelegateEditor(m_view, option, index, m_listView, parent);
+            auto *widget = new DefaultNoteFolderDelegateEditor(m_view, option, index, m_listView, parent);
             widget->setTheme(m_theme);
             connect(this, &NodeTreeDelegate::themeChanged, widget, &DefaultNoteFolderDelegateEditor::setTheme);
             return widget;
-        } else {
-            auto widget = new FolderTreeDelegateEditor(m_view, option, index, m_listView, parent);
-            widget->setTheme(m_theme);
-            connect(this, &NodeTreeDelegate::themeChanged, widget, &FolderTreeDelegateEditor::setTheme);
-            return widget;
         }
-    } else if (itemType == NodeItem::Type::TagItem) {
-        auto widget = new TagTreeDelegateEditor(m_view, option, index, m_listView, parent);
+        auto *widget = new FolderTreeDelegateEditor(m_view, option, index, m_listView, parent);
+        widget->setTheme(m_theme);
+        connect(this, &NodeTreeDelegate::themeChanged, widget, &FolderTreeDelegateEditor::setTheme);
+        return widget;
+    }
+    if (itemType == NodeItem::Type::TagItem) {
+        auto *widget = new TagTreeDelegateEditor(m_view, option, index, m_listView, parent);
         widget->setTheme(m_theme);
         connect(this, &NodeTreeDelegate::themeChanged, widget, &TagTreeDelegateEditor::setTheme);
         return widget;
-    } else if (itemType == NodeItem::Type::TrashButton) {
-        auto widget = new TrashButtonDelegateEditor(m_view, option, index, m_listView, parent);
+    }
+    if (itemType == NodeItem::Type::TrashButton) {
+        auto *widget = new TrashButtonDelegateEditor(m_view, option, index, m_listView, parent);
         widget->setTheme(m_theme);
         connect(this, &NodeTreeDelegate::themeChanged, widget, &TrashButtonDelegateEditor::setTheme);
         return widget;
-    } else if (itemType == NodeItem::Type::AllNoteButton) {
-        auto widget = new AllNoteButtonTreeDelegateEditor(m_view, option, index, m_listView, parent);
+    }
+    if (itemType == NodeItem::Type::AllNoteButton) {
+        auto *widget = new AllNoteButtonTreeDelegateEditor(m_view, option, index, m_listView, parent);
         widget->setTheme(m_theme);
         connect(this, &NodeTreeDelegate::themeChanged, widget, &AllNoteButtonTreeDelegateEditor::setTheme);
         return widget;

--- a/src/nodetreedelegate.h
+++ b/src/nodetreedelegate.h
@@ -20,10 +20,10 @@ signals:
 
     // QAbstractItemDelegate interface
 public:
-    virtual void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
-    virtual QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const override;
-    virtual QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
-    virtual void updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+    void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+    QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+    QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+    void updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 
 private:
     void paintBackgroundSelectable(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
@@ -38,7 +38,7 @@ private:
     QColor m_titleColor;
     QColor m_titleSelectedColor;
     QColor m_dateColor;
-    QColor m_ActiveColor;
+    QColor m_activeColor;
     QColor m_notActiveColor;
     QColor m_hoverColor;
     QColor m_applicationInactiveColor;

--- a/src/nodetreedelegate.h
+++ b/src/nodetreedelegate.h
@@ -11,8 +11,7 @@ class NodeTreeDelegate : public QStyledItemDelegate
 {
     Q_OBJECT
 public:
-    explicit NodeTreeDelegate(QTreeView *view, QObject *parent = nullptr,
-                              QListView *listView = nullptr);
+    explicit NodeTreeDelegate(QTreeView *view, QObject *parent = nullptr, QListView *listView = nullptr);
     void setTheme(Theme::Value theme);
 signals:
     void addFolderRequested();
@@ -21,18 +20,13 @@ signals:
 
     // QAbstractItemDelegate interface
 public:
-    virtual void paint(QPainter *painter, const QStyleOptionViewItem &option,
-                       const QModelIndex &index) const override;
-    virtual QSize sizeHint(const QStyleOptionViewItem &option,
-                           const QModelIndex &index) const override;
-    virtual QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option,
-                                  const QModelIndex &index) const override;
-    virtual void updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option,
-                                      const QModelIndex &index) const override;
+    virtual void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+    virtual QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+    virtual QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+    virtual void updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 
 private:
-    void paintBackgroundSelectable(QPainter *painter, const QStyleOptionViewItem &option,
-                                   const QModelIndex &index) const;
+    void paintBackgroundSelectable(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
 
 private:
     QString m_displayFont;

--- a/src/nodetreemodel.cpp
+++ b/src/nodetreemodel.cpp
@@ -187,7 +187,7 @@ void NodeTreeModel::appendChildNodeToParent(const QModelIndex &parentIndex, cons
                 for (int i = 0; i < parentItem->getChildCount(); ++i) {
                     auto const *childItem = parentItem->getChild(i);
                     auto childType = static_cast<NodeItem::Type>(childItem->getData(NodeItem::Roles::ItemType).toInt());
-                    if (childType == NodeItem::Type::FolderItem && childItem->getData(NodeItem::Roles::NodeId).toInt() == SpecialNodeID::DefaultNotesFolder) {
+                    if (childType == NodeItem::Type::FolderItem && childItem->getData(NodeItem::Roles::NodeId).toInt() == DEFAULT_NOTES_FOLDER_ID) {
                         row = i + 1;
                         break;
                     }
@@ -435,7 +435,7 @@ QModelIndex NodeTreeModel::getDefaultNotesIndex()
         for (int i = 0; i < m_rootItem->getChildCount(); ++i) {
             auto *child = m_rootItem->getChild(i);
             auto type = static_cast<NodeItem::Type>(child->getData(NodeItem::Roles::ItemType).toInt());
-            if (type == NodeItem::Type::FolderItem && child->getData(NodeItem::Roles::NodeId).toInt() == SpecialNodeID::DefaultNotesFolder) {
+            if (type == NodeItem::Type::FolderItem && child->getData(NodeItem::Roles::NodeId).toInt() == DEFAULT_NOTES_FOLDER_ID) {
                 return createIndex(i, 0, child);
             }
         }
@@ -475,7 +475,7 @@ void NodeTreeModel::deleteRow(const QModelIndex &rowIndex, const QModelIndex &pa
 {
     auto type = static_cast<NodeItem::Type>(rowIndex.data(NodeItem::Roles::ItemType).toInt());
     auto id = rowIndex.data(NodeItem::Roles::NodeId).toInt();
-    if ((type != NodeItem::Type::FolderItem || id <= SpecialNodeID::DefaultNotesFolder) && type != NodeItem::Type::TagItem) {
+    if ((type != NodeItem::Type::FolderItem || id <= DEFAULT_NOTES_FOLDER_ID) && type != NodeItem::Type::TagItem) {
         qDebug() << "Can not delete this row with id" << id;
         return;
     }
@@ -516,9 +516,9 @@ void NodeTreeModel::setTreeData(const NodeTagTreeData &treeData)
 void NodeTreeModel::loadNodeTree(const QVector<NodeData> &nodeData, NodeTreeItem *rootNode)
 {
     QHash<int, NodeTreeItem *> itemMap;
-    itemMap[SpecialNodeID::RootFolder] = rootNode;
+    itemMap[ROOT_FOLDER_ID] = rootNode;
     for (const auto &node : nodeData) {
-        if (node.id() != SpecialNodeID::RootFolder && node.id() != SpecialNodeID::TrashFolder && node.parentId() != SpecialNodeID::TrashFolder) {
+        if (node.id() != ROOT_FOLDER_ID && node.id() != TRASH_FOLDER_ID && node.parentId() != TRASH_FOLDER_ID) {
             auto hs = QHash<NodeItem::Roles, QVariant>{};
             if (node.nodeType() == NodeData::Type::Folder) {
                 hs[NodeItem::Roles::ItemType] = NodeItem::Type::FolderItem;
@@ -539,8 +539,7 @@ void NodeTreeModel::loadNodeTree(const QVector<NodeData> &nodeData, NodeTreeItem
     }
 
     for (const auto &node : nodeData) {
-        if (node.id() != SpecialNodeID::RootFolder && node.parentId() != -1 && node.id() != SpecialNodeID::TrashFolder
-            && node.parentId() != SpecialNodeID::TrashFolder) {
+        if (node.id() != ROOT_FOLDER_ID && node.parentId() != -1 && node.id() != TRASH_FOLDER_ID && node.parentId() != TRASH_FOLDER_ID) {
             auto parentNode = itemMap.find(node.parentId());
             auto nodeItem = itemMap.find(node.id());
             if (parentNode != itemMap.end() && nodeItem != itemMap.end()) {
@@ -701,7 +700,7 @@ QMimeData *NodeTreeModel::mimeData(const QModelIndexList &indexes) const
     if (itemType == NodeItem::Type::FolderItem) {
         const auto &idx = indexes[0];
         auto id = idx.data(NodeItem::Roles::NodeId).toInt();
-        if (id == SpecialNodeID::DefaultNotesFolder) {
+        if (id == DEFAULT_NOTES_FOLDER_ID) {
             return nullptr;
         }
         auto absPath = idx.data(NodeItem::Roles::AbsPath).toString();
@@ -799,7 +798,7 @@ bool NodeTreeModel::dropMimeData(const QMimeData *mime, Qt::DropAction action, i
                 return false;
             }
         }
-        if (parent.data(NodeItem::Roles::NodeId).toInt() == SpecialNodeID::DefaultNotesFolder) {
+        if (parent.data(NodeItem::Roles::NodeId).toInt() == DEFAULT_NOTES_FOLDER_ID) {
             return false;
         }
 

--- a/src/nodetreemodel.cpp
+++ b/src/nodetreemodel.cpp
@@ -120,8 +120,13 @@ void NodeTreeItem::recursiveSort()
             child->recursiveSort();
         }
     } else if (type == NodeItem::Type::RootItem) {
-        QVector<NodeTreeItem *> allNoteButton, trashFolder, folderSep, folderItems, tagSep, tagItems;
-        for (const auto child : std::as_const(m_childItems)) {
+        QVector<NodeTreeItem *> allNoteButton;
+        QVector<NodeTreeItem *> trashFolder;
+        QVector<NodeTreeItem *> folderSep;
+        QVector<NodeTreeItem *> folderItems;
+        QVector<NodeTreeItem *> tagSep;
+        QVector<NodeTreeItem *> tagItems;
+        for (auto *const child : std::as_const(m_childItems)) {
             auto childType = static_cast<NodeItem::Type>(child->getData(NodeItem::Roles::ItemType).toInt());
             if (childType == NodeItem::Type::AllNoteButton) {
                 allNoteButton.append(child);

--- a/src/nodetreemodel.h
+++ b/src/nodetreemodel.h
@@ -71,7 +71,7 @@ class NodeTreeModel : public QAbstractItemModel
     Q_OBJECT
 public:
     explicit NodeTreeModel(QObject *parent = nullptr);
-    ~NodeTreeModel();
+    ~NodeTreeModel() override;
 
     void appendChildNodeToParent(const QModelIndex &parentIndex, const QHash<NodeItem::Roles, QVariant> &data);
     QModelIndex rootIndex() const;

--- a/src/nodetreemodel.h
+++ b/src/nodetreemodel.h
@@ -40,23 +40,22 @@ enum Type {
 class NodeTreeItem
 {
 public:
-    explicit NodeTreeItem(const QHash<NodeItem::Roles, QVariant> &data,
-                          NodeTreeItem *parentItem = nullptr);
+    explicit NodeTreeItem(const QHash<NodeItem::Roles, QVariant> &data, NodeTreeItem *parentItem = nullptr);
     ~NodeTreeItem();
 
     void appendChild(NodeTreeItem *child);
     void insertChild(int row, NodeTreeItem *child);
-    NodeTreeItem *child(int row);
+    NodeTreeItem *getChild(int row) const;
     void removeChild(int row);
     NodeTreeItem *takeChildAt(int row);
-    int childCount() const;
-    int columnCount() const;
+    int getChildCount() const;
+    static int getColumnCount(); // columnCount is always 1 => static
     int recursiveNodeCount() const;
     void recursiveUpdateFolderPath(const QString &oldP, const QString &newP);
-    QVariant data(NodeItem::Roles role) const;
+    QVariant getData(NodeItem::Roles role) const;
     void setData(NodeItem::Roles role, const QVariant &d);
-    int row() const;
-    NodeTreeItem *parentItem();
+    int getRow() const;
+    NodeTreeItem *getParentItem() const;
     void setParentItem(NodeTreeItem *parentItem);
     void moveChild(int from, int to);
     void recursiveSort();
@@ -74,8 +73,7 @@ public:
     explicit NodeTreeModel(QObject *parent = nullptr);
     ~NodeTreeModel();
 
-    void appendChildNodeToParent(const QModelIndex &parentIndex,
-                                 const QHash<NodeItem::Roles, QVariant> &data);
+    void appendChildNodeToParent(const QModelIndex &parentIndex, const QHash<NodeItem::Roles, QVariant> &data);
     QModelIndex rootIndex() const;
     QModelIndex folderIndexFromIdPath(const NodePath &idPath);
     QModelIndex tagIndexFromId(int id);
@@ -92,19 +90,18 @@ public slots:
 
     // QAbstractItemModel interface
 public:
-    virtual QModelIndex index(int row, int column, const QModelIndex &parent) const override;
-    virtual QModelIndex parent(const QModelIndex &index) const override;
-    virtual int rowCount(const QModelIndex &parent) const override;
-    virtual int columnCount(const QModelIndex &parent) const override;
-    virtual QVariant data(const QModelIndex &index, int role) const override;
-    virtual Qt::ItemFlags flags(const QModelIndex &index) const override;
-    virtual bool setData(const QModelIndex &index, const QVariant &value, int role) override;
-    virtual Qt::DropActions supportedDropActions() const override;
-    virtual Qt::DropActions supportedDragActions() const override;
-    virtual QStringList mimeTypes() const override;
-    virtual QMimeData *mimeData(const QModelIndexList &indexes) const override;
-    virtual bool dropMimeData(const QMimeData *mime, Qt::DropAction action, int row, int column,
-                              const QModelIndex &parent) override;
+    QModelIndex index(int row, int column, const QModelIndex &parent) const override;
+    QModelIndex parent(const QModelIndex &index) const override;
+    int rowCount(const QModelIndex &parent) const override;
+    int columnCount(const QModelIndex &parent) const override;
+    QVariant data(const QModelIndex &index, int role) const override;
+    Qt::ItemFlags flags(const QModelIndex &index) const override;
+    bool setData(const QModelIndex &index, const QVariant &value, int role) override;
+    Qt::DropActions supportedDropActions() const override;
+    Qt::DropActions supportedDragActions() const override;
+    QStringList mimeTypes() const override;
+    QMimeData *mimeData(const QModelIndexList &indexes) const override;
+    bool dropMimeData(const QMimeData *mime, Qt::DropAction action, int row, int column, const QModelIndex &parent) override;
 
 signals:
     void topLevelItemLayoutChanged();
@@ -118,13 +115,13 @@ signals:
     void requestMoveFolderToTrash(const QModelIndex &index);
 
 private:
-    NodeTreeItem *rootItem;
+    NodeTreeItem *m_rootItem;
     void loadNodeTree(const QVector<NodeData> &nodeData, NodeTreeItem *rootNode);
     void appendAllNotesAndTrashButton(NodeTreeItem *rootNode);
     void appendFolderSeparator(NodeTreeItem *rootNode);
     void appendTagsSeparator(NodeTreeItem *rootNode);
     void loadTagList(const QVector<TagData> &tagData, NodeTreeItem *rootNode);
-    void updateChildRelativePosition(NodeTreeItem *parent, const NodeItem::Type type);
+    void updateChildRelativePosition(NodeTreeItem *parent, NodeItem::Type type);
 };
 
 #endif // NODETREEMODEL_H

--- a/src/nodetreeview.cpp
+++ b/src/nodetreeview.cpp
@@ -11,11 +11,7 @@
 #include "nodetreeview_p.h"
 
 NodeTreeView::NodeTreeView(QWidget *parent)
-    : QTreeView(parent),
-      m_isContextMenuOpened{ false },
-      m_isEditing{ false },
-      m_ignoreThisCurrentLoad{ false },
-      m_isLastSelectedFolder{ false }
+    : QTreeView(parent), m_isContextMenuOpened{ false }, m_isEditing{ false }, m_ignoreThisCurrentLoad{ false }, m_isLastSelectedFolder{ false }
 {
     setHeaderHidden(true);
 
@@ -59,7 +55,7 @@ NodeTreeView::NodeTreeView(QWidget *parent)
     connect(clearSelectionAction, &QAction::triggered, this, [this] {
         closeCurrentEditor();
         clearSelection();
-        setCurrentIndexC(dynamic_cast<NodeTreeModel *>(model())->getAllNotesButtonIndex());
+        setCurrentIndexC(static_cast<NodeTreeModel *>(model())->getAllNotesButtonIndex());
     });
 
     contextMenuTimer.setInterval(100);
@@ -85,8 +81,7 @@ NodeTreeView::NodeTreeView(QWidget *parent)
 
 void NodeTreeView::onDeleteNodeAction()
 {
-    auto itemType = static_cast<NodeItem::Type>(
-            m_currentEditingIndex.data(NodeItem::Roles::ItemType).toInt());
+    auto itemType = static_cast<NodeItem::Type>(m_currentEditingIndex.data(NodeItem::Roles::ItemType).toInt());
     auto id = m_currentEditingIndex.data(NodeItem::Roles::NodeId).toInt();
     if (itemType == NodeItem::Type::FolderItem || itemType == NodeItem::Type::NoteItem) {
         if (id > SpecialNodeID::DefaultNotesFolder) {
@@ -123,23 +118,23 @@ void NodeTreeView::setIgnoreThisCurrentLoad(bool newIgnoreThisCurrentLoad)
 
 void NodeTreeView::onFolderDropSuccessful(const QString &path)
 {
-    auto m_model = dynamic_cast<NodeTreeModel *>(model());
-    auto index = m_model->folderIndexFromIdPath(path);
+    auto *nodeTreeModel = static_cast<NodeTreeModel *>(model());
+    auto index = nodeTreeModel->folderIndexFromIdPath(path);
     if (index.isValid()) {
         setCurrentIndexC(index);
     } else {
-        setCurrentIndexC(m_model->getAllNotesButtonIndex());
+        setCurrentIndexC(nodeTreeModel->getAllNotesButtonIndex());
     }
 }
 
 void NodeTreeView::onTagsDropSuccessful(const QSet<int> &ids)
 {
-    auto m_model = dynamic_cast<NodeTreeModel *>(model());
+    auto *nodeTreeModel = static_cast<NodeTreeModel *>(model());
     setCurrentIndex(QModelIndex());
     clearSelection();
     setSelectionMode(QAbstractItemView::MultiSelection);
     for (const auto &id : std::as_const(ids)) {
-        auto index = m_model->tagIndexFromId(id);
+        auto index = nodeTreeModel->tagIndexFromId(id);
         if (index.isValid()) {
             setCurrentIndex(index);
             setSelectionMode(QAbstractItemView::MultiSelection);
@@ -148,7 +143,7 @@ void NodeTreeView::onTagsDropSuccessful(const QSet<int> &ids)
     }
 
     if (selectionModel()->selectedIndexes().isEmpty()) {
-        setCurrentIndexC(m_model->getAllNotesButtonIndex());
+        setCurrentIndexC(nodeTreeModel->getAllNotesButtonIndex());
     }
 }
 
@@ -165,11 +160,10 @@ bool NodeTreeView::isDragging() const
 void NodeTreeView::reExpandC()
 {
     auto needExpand = std::move(m_expanded);
-    m_expanded.clear();
     QTreeView::reset();
     for (const auto &path : needExpand) {
-        auto m_model = dynamic_cast<NodeTreeModel *>(model());
-        auto index = m_model->folderIndexFromIdPath(path);
+        auto *m = static_cast<NodeTreeModel *>(model());
+        auto index = m->folderIndexFromIdPath(path);
         if (index.isValid()) {
             expand(index);
         }
@@ -178,15 +172,13 @@ void NodeTreeView::reExpandC()
 
 void NodeTreeView::reExpandC(const QStringList &expanded)
 {
-    m_expanded.clear();
     m_expanded = expanded.toVector();
     reExpandC();
 }
 
 void NodeTreeView::onChangeTagColorAction()
 {
-    auto itemType = static_cast<NodeItem::Type>(
-            m_currentEditingIndex.data(NodeItem::Roles::ItemType).toInt());
+    auto itemType = static_cast<NodeItem::Type>(m_currentEditingIndex.data(NodeItem::Roles::ItemType).toInt());
     if (itemType == NodeItem::Type::TagItem) {
         auto index = m_currentEditingIndex;
         emit changeTagColorRequested(index);
@@ -195,8 +187,8 @@ void NodeTreeView::onChangeTagColorAction()
 
 void NodeTreeView::onRequestExpand(const QString &folderPath)
 {
-    auto m_model = dynamic_cast<NodeTreeModel *>(model());
-    expand(m_model->folderIndexFromIdPath(folderPath));
+    auto *nodeTreeModel = static_cast<NodeTreeModel *>(model());
+    expand(nodeTreeModel->folderIndexFromIdPath(folderPath));
 }
 
 void NodeTreeView::onUpdateAbsPath(const QString &oldPath, const QString &newPath)
@@ -212,8 +204,7 @@ void NodeTreeView::updateEditingIndex(QPoint pos)
     auto index = indexAt(pos);
     if (indexAt(pos) != m_currentEditingIndex && !m_isContextMenuOpened && !m_isEditing) {
         auto itemType = static_cast<NodeItem::Type>(index.data(NodeItem::Roles::ItemType).toInt());
-        if (itemType == NodeItem::Type::FolderItem || itemType == NodeItem::Type::TagItem
-            || itemType == NodeItem::Type::TrashButton
+        if (itemType == NodeItem::Type::FolderItem || itemType == NodeItem::Type::TagItem || itemType == NodeItem::Type::TrashButton
             || itemType == NodeItem::Type::AllNoteButton) {
             closePersistentEditor(m_currentEditingIndex);
             openPersistentEditor(index);
@@ -230,8 +221,7 @@ void NodeTreeView::closeCurrentEditor()
     m_currentEditingIndex = QModelIndex();
 }
 
-void NodeTreeView::selectionChanged(const QItemSelection &selected,
-                                    const QItemSelection &deselected)
+void NodeTreeView::selectionChanged(const QItemSelection &selected, const QItemSelection &deselected)
 {
     QTreeView::selectionChanged(selected, deselected);
     if (m_ignoreThisCurrentLoad) {
@@ -327,10 +317,8 @@ void NodeTreeView::dragMoveEvent(QDragMoveEvent *event)
                 return;
             }
         } else if (event->mimeData()->hasFormat(FOLDER_MIME)) {
-            auto trashRect =
-                    visualRect(dynamic_cast<NodeTreeModel *>(model())->getTrashButtonIndex());
-            if (event->position().toPoint().y() > (trashRect.y() + 5)
-                && event->position().toPoint().y() < (trashRect.bottom() - 5)) {
+            auto trashRect = visualRect(static_cast<NodeTreeModel *>(model())->getTrashButtonIndex());
+            if (event->position().toPoint().y() > (trashRect.y() + 5) && event->position().toPoint().y() < (trashRect.bottom() - 5)) {
                 setDropIndicatorShown(true);
                 QTreeView::dragMoveEvent(event);
                 return;
@@ -360,11 +348,9 @@ void NodeTreeView::dropEvent(QDropEvent *event)
     if (event->mimeData()->hasFormat(NOTE_MIME)) {
         auto dropIndex = indexAt(event->position().toPoint());
         if (dropIndex.isValid()) {
-            auto itemType =
-                    static_cast<NodeItem::Type>(dropIndex.data(NodeItem::Roles::ItemType).toInt());
+            auto itemType = static_cast<NodeItem::Type>(dropIndex.data(NodeItem::Roles::ItemType).toInt());
             bool ok = false;
-            auto idl = QString::fromUtf8(event->mimeData()->data(NOTE_MIME))
-                               .split(QStringLiteral(PATH_SEPARATOR));
+            auto idl = QString::fromUtf8(event->mimeData()->data(NOTE_MIME)).split(PATH_SEPARATOR);
             for (const auto &s : std::as_const(idl)) {
                 auto nodeId = s.toInt(&ok);
                 if (ok) {
@@ -393,8 +379,7 @@ void NodeTreeView::setIsEditing(bool newIsEditing)
 void NodeTreeView::onRenameFolderFinished(const QString &newName)
 {
     if (m_currentEditingIndex.isValid()) {
-        auto itemType = static_cast<NodeItem::Type>(
-                m_currentEditingIndex.data(NodeItem::Roles::ItemType).toInt());
+        auto itemType = static_cast<NodeItem::Type>(m_currentEditingIndex.data(NodeItem::Roles::ItemType).toInt());
         if (itemType == NodeItem::Type::FolderItem) {
             QModelIndex index = m_currentEditingIndex;
             closeCurrentEditor();
@@ -410,8 +395,7 @@ void NodeTreeView::onRenameFolderFinished(const QString &newName)
 void NodeTreeView::onRenameTagFinished(const QString &newName)
 {
     if (m_currentEditingIndex.isValid()) {
-        auto itemType = static_cast<NodeItem::Type>(
-                m_currentEditingIndex.data(NodeItem::Roles::ItemType).toInt());
+        auto itemType = static_cast<NodeItem::Type>(m_currentEditingIndex.data(NodeItem::Roles::ItemType).toInt());
         if (itemType == NodeItem::Type::TagItem) {
             QModelIndex index = m_currentEditingIndex;
             closeCurrentEditor();
@@ -471,8 +455,7 @@ void NodeTreeView::onCustomContextMenu(QPoint point)
     }
 }
 
-void NodeTreeView::setTreeSeparator(const QVector<QModelIndex> &newTreeSeparator,
-                                    const QModelIndex &defaultNotesIndex)
+void NodeTreeView::setTreeSeparator(const QVector<QModelIndex> &newTreeSeparator, const QModelIndex &defaultNotesIndex)
 {
     for (const auto &sep : std::as_const(m_treeSeparator)) {
         closePersistentEditor(sep);
@@ -504,8 +487,7 @@ void NodeTreeView::mouseMoveEvent(QMouseEvent *event)
         }
         return;
     }
-    if (d->pressedIndex.isValid() && (state() != DragSelectingState)
-        && (event->buttons() != Qt::NoButton)) {
+    if (d->pressedIndex.isValid() && (state() != DragSelectingState) && (event->buttons() != Qt::NoButton)) {
         setState(DraggingState);
         return;
     }
@@ -518,12 +500,11 @@ void NodeTreeView::mousePressEvent(QMouseEvent *event)
     {
         auto index = indexAt(event->position().toPoint());
         if (index.isValid()) {
-            auto itemType =
-                    static_cast<NodeItem::Type>(index.data(NodeItem::Roles::ItemType).toInt());
+            auto itemType = static_cast<NodeItem::Type>(index.data(NodeItem::Roles::ItemType).toInt());
             switch (itemType) {
             case NodeItem::Type::FolderItem: {
                 auto rect = visualRect(index);
-                auto iconRect = QRect(rect.x() + 5, rect.y() + (rect.height() - 20) / 2, 20, 20);
+                auto iconRect = QRect(rect.x() + 5, rect.y() + ((rect.height() - 20) / 2), 20, 20);
                 if (iconRect.contains(event->position().toPoint())) {
                     if (isExpanded(index)) {
                         collapse(index);
@@ -538,8 +519,7 @@ void NodeTreeView::mousePressEvent(QMouseEvent *event)
             case NodeItem::Type::TagItem: {
                 auto oldIndexes = selectionModel()->selectedIndexes();
                 for (const auto &ix : std::as_const(oldIndexes)) {
-                    auto selectedItemType =
-                            static_cast<NodeItem::Type>(ix.data(NodeItem::Roles::ItemType).toInt());
+                    auto selectedItemType = static_cast<NodeItem::Type>(ix.data(NodeItem::Roles::ItemType).toInt());
                     if (selectedItemType != NodeItem::Type::TagItem) {
                         setCurrentIndex(QModelIndex());
                         clearSelection();
@@ -593,17 +573,15 @@ void NodeTreeView::mouseReleaseEvent(QMouseEvent *event)
         selectionModel()->select(m_needReleaseIndex, QItemSelectionModel::Deselect);
         if (selectionModel()->selectedIndexes().isEmpty()) {
             if (!m_isLastSelectedFolder) {
-                auto index = dynamic_cast<NodeTreeModel *>(model())->folderIndexFromIdPath(
-                        m_lastSelectFolder);
+                auto index = static_cast<NodeTreeModel *>(model())->folderIndexFromIdPath(m_lastSelectFolder);
                 if (index.isValid()) {
                     emit requestLoadLastSelectedNote();
                     setCurrentIndexC(index);
                 } else {
-                    setCurrentIndexC(
-                            dynamic_cast<NodeTreeModel *>(model())->getAllNotesButtonIndex());
+                    setCurrentIndexC(static_cast<NodeTreeModel *>(model())->getAllNotesButtonIndex());
                 }
             } else {
-                setCurrentIndexC(dynamic_cast<NodeTreeModel *>(model())->getAllNotesButtonIndex());
+                setCurrentIndexC(static_cast<NodeTreeModel *>(model())->getAllNotesButtonIndex());
             }
         }
     }

--- a/src/nodetreeview.cpp
+++ b/src/nodetreeview.cpp
@@ -84,7 +84,7 @@ void NodeTreeView::onDeleteNodeAction()
     auto itemType = static_cast<NodeItem::Type>(m_currentEditingIndex.data(NodeItem::Roles::ItemType).toInt());
     auto id = m_currentEditingIndex.data(NodeItem::Roles::NodeId).toInt();
     if (itemType == NodeItem::Type::FolderItem || itemType == NodeItem::Type::NoteItem) {
-        if (id > SpecialNodeID::DefaultNotesFolder) {
+        if (id > DEFAULT_NOTES_FOLDER_ID) {
             auto index = m_currentEditingIndex;
             emit deleteNodeRequested(index);
         }
@@ -242,7 +242,7 @@ void NodeTreeView::selectionChanged(const QItemSelection &selected, const QItemS
             auto folderPath = index.data(NodeItem::Roles::AbsPath).toString();
             m_lastSelectFolder = folderPath;
             m_isLastSelectedFolder = true;
-            emit loadNotesInFolderRequested(SpecialNodeID::RootFolder, true);
+            emit loadNotesInFolderRequested(ROOT_FOLDER_ID, true);
             emit saveSelected(true, NodePath::getAllNoteFolderPath(), {});
             return;
         }
@@ -250,7 +250,7 @@ void NodeTreeView::selectionChanged(const QItemSelection &selected, const QItemS
             auto folderPath = index.data(NodeItem::Roles::AbsPath).toString();
             m_lastSelectFolder = folderPath;
             m_isLastSelectedFolder = true;
-            emit loadNotesInFolderRequested(SpecialNodeID::TrashFolder, true);
+            emit loadNotesInFolderRequested(TRASH_FOLDER_ID, true);
             emit saveSelected(true, NodePath::getTrashFolderPath(), {});
             return;
         }
@@ -360,7 +360,7 @@ void NodeTreeView::dropEvent(QDropEvent *event)
                     } else if (itemType == NodeItem::Type::TagItem) {
                         emit addNoteToTag(nodeId, dropIndex.data(NodeItem::NodeId).toInt());
                     } else if (itemType == NodeItem::Type::TrashButton) {
-                        emit moveNodeRequested(nodeId, SpecialNodeID::TrashFolder);
+                        emit moveNodeRequested(nodeId, TRASH_FOLDER_ID);
                         event->acceptProposedAction();
                     }
                 }
@@ -435,7 +435,7 @@ void NodeTreeView::onCustomContextMenu(QPoint point)
         contextMenu->clear();
         if (itemType == NodeItem::Type::FolderItem) {
             auto id = index.data(NodeItem::Roles::NodeId).toInt();
-            if (id != SpecialNodeID::DefaultNotesFolder) {
+            if (id != DEFAULT_NOTES_FOLDER_ID) {
                 m_isContextMenuOpened = true;
                 contextMenu->addAction(renameFolderAction);
                 contextMenu->addAction(deleteFolderAction);

--- a/src/nodetreeview.cpp
+++ b/src/nodetreeview.cpp
@@ -31,45 +31,45 @@ NodeTreeView::NodeTreeView(QWidget *parent)
     setSelectionMode(QAbstractItemView::MultiSelection);
     setContextMenuPolicy(Qt::CustomContextMenu);
     connect(this, &QWidget::customContextMenuRequested, this, &NodeTreeView::onCustomContextMenu);
-    contextMenu = new QMenu(this);
-    renameFolderAction = new QAction(tr("Rename Folder"), this);
-    connect(renameFolderAction, &QAction::triggered, this, [this] {
+    m_contextMenu = new QMenu(this);
+    m_renameFolderAction = new QAction(tr("Rename Folder"), this);
+    connect(m_renameFolderAction, &QAction::triggered, this, [this] {
         setIsEditing(true);
         emit renameFolderRequested();
     });
-    deleteFolderAction = new QAction(tr("Delete Folder"), this);
-    connect(deleteFolderAction, &QAction::triggered, this, &NodeTreeView::onDeleteNodeAction);
-    addSubfolderAction = new QAction(tr("Add Subfolder"), this);
-    connect(addSubfolderAction, &QAction::triggered, this, &NodeTreeView::addFolderRequested);
+    m_deleteFolderAction = new QAction(tr("Delete Folder"), this);
+    connect(m_deleteFolderAction, &QAction::triggered, this, &NodeTreeView::onDeleteNodeAction);
+    m_addSubfolderAction = new QAction(tr("Add Subfolder"), this);
+    connect(m_addSubfolderAction, &QAction::triggered, this, &NodeTreeView::addFolderRequested);
 
-    renameTagAction = new QAction(tr("Rename Tag"), this);
-    connect(renameTagAction, &QAction::triggered, this, [this] {
+    m_renameTagAction = new QAction(tr("Rename Tag"), this);
+    connect(m_renameTagAction, &QAction::triggered, this, [this] {
         setIsEditing(true);
         emit renameTagRequested();
     });
-    changeTagColorAction = new QAction(tr("Change Tag Color"), this);
-    connect(changeTagColorAction, &QAction::triggered, this, &NodeTreeView::onChangeTagColorAction);
-    deleteTagAction = new QAction(tr("Delete Tag"), this);
-    connect(deleteTagAction, &QAction::triggered, this, &NodeTreeView::onDeleteNodeAction);
-    clearSelectionAction = new QAction(tr("Clear Selection"), this);
-    connect(clearSelectionAction, &QAction::triggered, this, [this] {
+    m_changeTagColorAction = new QAction(tr("Change Tag Color"), this);
+    connect(m_changeTagColorAction, &QAction::triggered, this, &NodeTreeView::onChangeTagColorAction);
+    m_deleteTagAction = new QAction(tr("Delete Tag"), this);
+    connect(m_deleteTagAction, &QAction::triggered, this, &NodeTreeView::onDeleteNodeAction);
+    m_clearSelectionAction = new QAction(tr("Clear Selection"), this);
+    connect(m_clearSelectionAction, &QAction::triggered, this, [this] {
         closeCurrentEditor();
         clearSelection();
         setCurrentIndexC(static_cast<NodeTreeModel *>(model())->getAllNotesButtonIndex());
     });
 
-    contextMenuTimer.setInterval(100);
-    contextMenuTimer.setSingleShot(true);
-    connect(&contextMenuTimer, &QTimer::timeout, this, [this] {
+    m_contextMenuTimer.setInterval(100);
+    m_contextMenuTimer.setSingleShot(true);
+    connect(&m_contextMenuTimer, &QTimer::timeout, this, [this] {
         if (!m_isEditing) {
             closeCurrentEditor();
         }
     });
 
-    connect(contextMenu, &QMenu::aboutToHide, this, [this] {
+    connect(m_contextMenu, &QMenu::aboutToHide, this, [this] {
         m_isContextMenuOpened = false;
         // this signal is emitted before QAction::triggered
-        contextMenuTimer.start();
+        m_contextMenuTimer.start();
     });
     connect(this, &NodeTreeView::expanded, this, &NodeTreeView::onExpanded);
     connect(this, &NodeTreeView::collapsed, this, &NodeTreeView::onCollapsed);
@@ -432,25 +432,25 @@ void NodeTreeView::onCustomContextMenu(QPoint point)
     QModelIndex index = indexAt(point);
     if (index.isValid()) {
         auto itemType = static_cast<NodeItem::Type>(index.data(NodeItem::Roles::ItemType).toInt());
-        contextMenu->clear();
+        m_contextMenu->clear();
         if (itemType == NodeItem::Type::FolderItem) {
             auto id = index.data(NodeItem::Roles::NodeId).toInt();
             if (id != DEFAULT_NOTES_FOLDER_ID) {
                 m_isContextMenuOpened = true;
-                contextMenu->addAction(renameFolderAction);
-                contextMenu->addAction(deleteFolderAction);
-                contextMenu->addSeparator();
-                contextMenu->addAction(addSubfolderAction);
-                contextMenu->exec(viewport()->mapToGlobal(point));
+                m_contextMenu->addAction(m_renameFolderAction);
+                m_contextMenu->addAction(m_deleteFolderAction);
+                m_contextMenu->addSeparator();
+                m_contextMenu->addAction(m_addSubfolderAction);
+                m_contextMenu->exec(viewport()->mapToGlobal(point));
             }
         } else if (itemType == NodeItem::Type::TagItem) {
             m_isContextMenuOpened = true;
-            contextMenu->addAction(renameTagAction);
-            contextMenu->addAction(changeTagColorAction);
-            contextMenu->addAction(clearSelectionAction);
-            contextMenu->addSeparator();
-            contextMenu->addAction(deleteTagAction);
-            contextMenu->exec(viewport()->mapToGlobal(point));
+            m_contextMenu->addAction(m_renameTagAction);
+            m_contextMenu->addAction(m_changeTagColorAction);
+            m_contextMenu->addAction(m_clearSelectionAction);
+            m_contextMenu->addSeparator();
+            m_contextMenu->addAction(m_deleteTagAction);
+            m_contextMenu->exec(viewport()->mapToGlobal(point));
         }
     }
 }

--- a/src/nodetreeview.h
+++ b/src/nodetreeview.h
@@ -23,8 +23,7 @@ class NodeTreeView : public QTreeView
 public:
     explicit NodeTreeView(QWidget *parent = nullptr);
 
-    void setTreeSeparator(const QVector<QModelIndex> &newTreeSeparator,
-                          const QModelIndex &defaultNotesIndex);
+    void setTreeSeparator(const QVector<QModelIndex> &newTreeSeparator, const QModelIndex &defaultNotesIndex);
     void setIsEditing(bool newIsEditing);
     void onRenameFolderFinished(const QString &newName);
     void onRenameTagFinished(const QString &newName);
@@ -53,10 +52,8 @@ signals:
     void renameFolderInDatabase(const QModelIndex &index, const QString &newName);
     void renameTagInDatabase(const QModelIndex &index, const QString &newName);
     void deleteNodeRequested(const QModelIndex &index);
-    void loadNotesInFolderRequested(int folderID, bool isRecursive, bool notInterested = false,
-                                    int scrollToId = SpecialNodeID::InvalidNodeId);
-    void loadNotesInTagsRequested(const QSet<int> &tagIds, bool notInterested = false,
-                                  int scrollToId = SpecialNodeID::InvalidNodeId);
+    void loadNotesInFolderRequested(int folderID, bool isRecursive, bool notInterested = false, int scrollToId = SpecialNodeID::InvalidNodeId);
+    void loadNotesInTagsRequested(const QSet<int> &tagIds, bool notInterested = false, int scrollToId = SpecialNodeID::InvalidNodeId);
     void moveNodeRequested(int node, int target);
     void renameTagRequested();
     void changeTagColorRequested(const QModelIndex &index);
@@ -98,8 +95,7 @@ private:
 
     // QAbstractItemView interface
 protected slots:
-    virtual void selectionChanged(const QItemSelection &selected,
-                                  const QItemSelection &deselected) override;
+    virtual void selectionChanged(const QItemSelection &selected, const QItemSelection &deselected) override;
     virtual void currentChanged(const QModelIndex &current, const QModelIndex &previous) override;
 
     // QWidget interface

--- a/src/nodetreeview.h
+++ b/src/nodetreeview.h
@@ -11,10 +11,10 @@ class QAction;
 class NodeTreeViewPrivate;
 struct NoteTreeConstant
 {
-    static constexpr int folderItemHeight = 30;
-    static constexpr int tagItemHeight = 30;
-    static constexpr int folderLabelHeight = 35;
-    static constexpr int tagLabelHeight = 35;
+    static constexpr int FOLDER_ITEM_HEIGHT = 30;
+    static constexpr int TAG_ITEM_HEIGHT = 30;
+    static constexpr int FOLDER_LABEL_HEIGHT = 35;
+    static constexpr int TAG_LABEL_HEIGHT = 35;
 };
 
 class NodeTreeView : public QTreeView
@@ -70,15 +70,15 @@ private slots:
     void onCollapsed(const QModelIndex &index);
 
 private:
-    QMenu *contextMenu;
-    QAction *renameFolderAction;
-    QAction *deleteFolderAction;
-    QAction *addSubfolderAction;
-    QAction *renameTagAction;
-    QAction *changeTagColorAction;
-    QAction *deleteTagAction;
-    QAction *clearSelectionAction;
-    QTimer contextMenuTimer;
+    QMenu *m_contextMenu;
+    QAction *m_renameFolderAction;
+    QAction *m_deleteFolderAction;
+    QAction *m_addSubfolderAction;
+    QAction *m_renameTagAction;
+    QAction *m_changeTagColorAction;
+    QAction *m_deleteTagAction;
+    QAction *m_clearSelectionAction;
+    QTimer m_contextMenuTimer;
     QVector<QModelIndex> m_treeSeparator;
     QModelIndex m_defaultNotesIndex;
     QModelIndex m_currentEditingIndex;
@@ -95,23 +95,23 @@ private:
 
     // QAbstractItemView interface
 protected slots:
-    virtual void selectionChanged(const QItemSelection &selected, const QItemSelection &deselected) override;
-    virtual void currentChanged(const QModelIndex &current, const QModelIndex &previous) override;
+    void selectionChanged(const QItemSelection &selected, const QItemSelection &deselected) override;
+    void currentChanged(const QModelIndex &current, const QModelIndex &previous) override;
 
     // QWidget interface
 protected:
-    virtual void dragEnterEvent(QDragEnterEvent *event) override;
-    virtual void dropEvent(QDropEvent *event) override;
-    virtual void dragMoveEvent(QDragMoveEvent *event) override;
-    virtual void mouseMoveEvent(QMouseEvent *event) override;
-    virtual void mousePressEvent(QMouseEvent *event) override;
-    virtual void mouseReleaseEvent(QMouseEvent *event) override;
-    virtual void mouseDoubleClickEvent(QMouseEvent *event) override;
-    virtual void leaveEvent(QEvent *event) override;
+    void dragEnterEvent(QDragEnterEvent *event) override;
+    void dropEvent(QDropEvent *event) override;
+    void dragMoveEvent(QDragMoveEvent *event) override;
+    void mouseMoveEvent(QMouseEvent *event) override;
+    void mousePressEvent(QMouseEvent *event) override;
+    void mouseReleaseEvent(QMouseEvent *event) override;
+    void mouseDoubleClickEvent(QMouseEvent *event) override;
+    void leaveEvent(QEvent *event) override;
 
     // QAbstractItemView interface
 public slots:
-    virtual void reset() override;
+    void reset() override;
 
 private:
     Q_DECLARE_PRIVATE(NodeTreeView)

--- a/src/nodetreeview.h
+++ b/src/nodetreeview.h
@@ -52,8 +52,8 @@ signals:
     void renameFolderInDatabase(const QModelIndex &index, const QString &newName);
     void renameTagInDatabase(const QModelIndex &index, const QString &newName);
     void deleteNodeRequested(const QModelIndex &index);
-    void loadNotesInFolderRequested(int folderID, bool isRecursive, bool notInterested = false, int scrollToId = SpecialNodeID::InvalidNodeId);
-    void loadNotesInTagsRequested(const QSet<int> &tagIds, bool notInterested = false, int scrollToId = SpecialNodeID::InvalidNodeId);
+    void loadNotesInFolderRequested(int folderID, bool isRecursive, bool notInterested = false, int scrollToId = INVALID_NODE_ID);
+    void loadNotesInTagsRequested(const QSet<int> &tagIds, bool notInterested = false, int scrollToId = INVALID_NODE_ID);
     void moveNodeRequested(int node, int target);
     void renameTagRequested();
     void changeTagColorRequested(const QModelIndex &index);

--- a/src/nodetreeview_p.h
+++ b/src/nodetreeview_p.h
@@ -1,7 +1,7 @@
-#ifndef NODETREEVIEW_P_H
-#define NODETREEVIEW_P_H
-#include <QtWidgets/private/qabstractitemview_p.h>
+#pragma once
 #include "nodetreeview.h"
+
+#include <QtWidgets/private/qabstractitemview_p.h>
 
 class NodeTreeViewPrivate : public QAbstractItemViewPrivate
 {
@@ -11,5 +11,3 @@ public:
     NodeTreeViewPrivate() : QAbstractItemViewPrivate(){};
     virtual ~NodeTreeViewPrivate() { }
 };
-
-#endif // NODETREEVIEW_P_H

--- a/src/nodetreeview_p.h
+++ b/src/nodetreeview_p.h
@@ -9,5 +9,5 @@ class NodeTreeViewPrivate : public QAbstractItemViewPrivate
 
 public:
     NodeTreeViewPrivate() : QAbstractItemViewPrivate(){};
-    virtual ~NodeTreeViewPrivate() { }
+    ~NodeTreeViewPrivate() override = default;
 };

--- a/src/noteeditorlogic.cpp
+++ b/src/noteeditorlogic.cpp
@@ -17,13 +17,10 @@
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 2, 0)
 
-NoteEditorLogic::NoteEditorLogic(CustomDocument *textEdit, QLabel *editorDateLabel,
-                                 QLineEdit *searchEdit, QWidget *kanbanWidget,
-                                 TagListView *tagListView, TagPool *tagPool, DBManager *dbManager,
-                                 QObject *parent)
+NoteEditorLogic::NoteEditorLogic(CustomDocument *textEdit, QLabel *editorDateLabel, QLineEdit *searchEdit, QWidget *kanbanWidget, TagListView *tagListView,
+                                 TagPool *tagPool, DBManager *dbManager, QObject *parent)
 #else
-NoteEditorLogic::NoteEditorLogic(CustomDocument *textEdit, QLabel *editorDateLabel,
-                                 QLineEdit *searchEdit, TagListView *tagListView, TagPool *tagPool,
+NoteEditorLogic::NoteEditorLogic(CustomDocument *textEdit, QLabel *editorDateLabel, QLineEdit *searchEdit, TagListView *tagListView, TagPool *tagPool,
                                  DBManager *dbManager, QObject *parent)
 #endif
     : QObject(parent),
@@ -42,8 +39,7 @@ NoteEditorLogic::NoteEditorLogic(CustomDocument *textEdit, QLabel *editorDateLab
       m_currentMinimumEditorPadding{ 0 }
 {
     connect(m_textEdit, &QTextEdit::textChanged, this, &NoteEditorLogic::onTextEditTextChanged);
-    connect(this, &NoteEditorLogic::requestCreateUpdateNote, m_dbManager,
-            &DBManager::onCreateUpdateRequestedNoteContent, Qt::QueuedConnection);
+    connect(this, &NoteEditorLogic::requestCreateUpdateNote, m_dbManager, &DBManager::onCreateUpdateRequestedNoteContent, Qt::QueuedConnection);
     // auto save timer
     m_autoSaveTimer.setSingleShot(true);
     m_autoSaveTimer.setInterval(50);
@@ -108,8 +104,7 @@ void NoteEditorLogic::showNotesInEditor(const QVector<NodeData> &notes)
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 2, 0)
         emit resetKanbanSettings();
-        emit checkMultipleNotesSelected(
-                QVariant(false)); // TODO: if not PRO version, should be true
+        emit checkMultipleNotesSelected(QVariant(false)); // TODO: if not PRO version, should be true
 #endif
 
         m_textEdit->blockSignals(true);
@@ -163,16 +158,13 @@ void NoteEditorLogic::showNotesInEditor(const QVector<NodeData> &notes)
         m_textEdit->blockSignals(true);
         auto verticalScrollBarValueToRestore = m_textEdit->verticalScrollBar()->value();
         m_textEdit->clear();
-        auto padding = m_currentAdaptableEditorPadding > m_currentMinimumEditorPadding
-                ? m_currentAdaptableEditorPadding
-                : m_currentMinimumEditorPadding;
+        auto padding = m_currentAdaptableEditorPadding > m_currentMinimumEditorPadding ? m_currentAdaptableEditorPadding : m_currentMinimumEditorPadding;
         QPixmap sep(QSize{ m_textEdit->width() - padding * 2 - 12, 4 });
         sep.fill(Qt::transparent);
         QPainter painter(&sep);
         painter.setPen(m_spacerColor);
         painter.drawRect(0, 1, sep.width(), 1);
-        m_textEdit->document()->addResource(QTextDocument::ImageResource, QUrl("mydata://sep.png"),
-                                            sep);
+        m_textEdit->document()->addResource(QTextDocument::ImageResource, QUrl("mydata://sep.png"), sep);
         for (int i = 0; i < notes.size(); ++i) {
             auto cursor = m_textEdit->textCursor();
             cursor.movePosition(QTextCursor::End);
@@ -235,14 +227,12 @@ void NoteEditorLogic::onTextEditTextChanged()
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 2, 0)
 
-void NoteEditorLogic::rearrangeTasksInTextEditor(int startLinePosition, int endLinePosition,
-                                                 int newLinePosition)
+void NoteEditorLogic::rearrangeTasksInTextEditor(int startLinePosition, int endLinePosition, int newLinePosition)
 {
     QTextDocument *document = m_textEdit->document();
     QTextCursor cursor(document);
     cursor.setPosition(document->findBlockByNumber(startLinePosition).position());
-    cursor.setPosition(document->findBlockByNumber(endLinePosition).position(),
-                       QTextCursor::KeepAnchor);
+    cursor.setPosition(document->findBlockByNumber(endLinePosition).position(), QTextCursor::KeepAnchor);
     cursor.movePosition(QTextCursor::EndOfBlock, QTextCursor::KeepAnchor);
     if (document->findBlockByNumber(endLinePosition + 1).isValid()) {
         cursor.movePosition(QTextCursor::NextCharacter, QTextCursor::KeepAnchor);
@@ -253,16 +243,13 @@ void NoteEditorLogic::rearrangeTasksInTextEditor(int startLinePosition, int endL
     if (newLinePosition <= startLinePosition) {
         cursor.setPosition(document->findBlockByLineNumber(newLinePosition).position());
     } else {
-        int newPositionBecauseOfRemoval =
-                newLinePosition - (endLinePosition - startLinePosition + 1);
+        int newPositionBecauseOfRemoval = newLinePosition - (endLinePosition - startLinePosition + 1);
         if (newPositionBecauseOfRemoval == document->lineCount()) {
-            cursor.setPosition(
-                    document->findBlockByLineNumber(newPositionBecauseOfRemoval - 1).position());
+            cursor.setPosition(document->findBlockByLineNumber(newPositionBecauseOfRemoval - 1).position());
             cursor.movePosition(QTextCursor::EndOfBlock);
             selectedText = "\n" + selectedText;
         } else {
-            cursor.setPosition(
-                    document->findBlockByLineNumber(newPositionBecauseOfRemoval).position());
+            cursor.setPosition(document->findBlockByLineNumber(newPositionBecauseOfRemoval).position());
         }
     }
     cursor.insertText(selectedText);
@@ -270,14 +257,12 @@ void NoteEditorLogic::rearrangeTasksInTextEditor(int startLinePosition, int endL
     checkForTasksInEditor();
 }
 
-void NoteEditorLogic::rearrangeColumnsInTextEditor(int startLinePosition, int endLinePosition,
-                                                   int newLinePosition)
+void NoteEditorLogic::rearrangeColumnsInTextEditor(int startLinePosition, int endLinePosition, int newLinePosition)
 {
     QTextDocument *document = m_textEdit->document();
     QTextCursor cursor(document);
     cursor.setPosition(document->findBlockByNumber(startLinePosition).position());
-    cursor.setPosition(document->findBlockByNumber(endLinePosition).position(),
-                       QTextCursor::KeepAnchor);
+    cursor.setPosition(document->findBlockByNumber(endLinePosition).position(), QTextCursor::KeepAnchor);
     cursor.movePosition(QTextCursor::EndOfBlock, QTextCursor::KeepAnchor);
     if (document->findBlockByNumber(endLinePosition + 1).isValid()) {
         cursor.movePosition(QTextCursor::NextCharacter, QTextCursor::KeepAnchor);
@@ -292,8 +277,7 @@ void NoteEditorLogic::rearrangeColumnsInTextEditor(int startLinePosition, int en
 
     if (startLinePosition < newLinePosition) {
         // Goes down
-        int newPositionBecauseOfRemoval =
-                newLinePosition - (endLinePosition - startLinePosition + 1);
+        int newPositionBecauseOfRemoval = newLinePosition - (endLinePosition - startLinePosition + 1);
         cursor.setPosition(document->findBlockByLineNumber(newPositionBecauseOfRemoval).position());
         cursor.movePosition(QTextCursor::EndOfBlock);
         cursor.insertText("\n" + selectedText);
@@ -362,8 +346,7 @@ void NoteEditorLogic::uncheckTaskInLine(int lineNumber)
     }
 }
 
-void NoteEditorLogic::replaceTextBetweenLines(int startLinePosition, int endLinePosition,
-                                              QString &newText)
+void NoteEditorLogic::replaceTextBetweenLines(int startLinePosition, int endLinePosition, QString &newText)
 {
     QTextDocument *document = m_textEdit->document();
     QTextBlock startBlock = document->findBlockByLineNumber(startLinePosition);
@@ -374,8 +357,7 @@ void NoteEditorLogic::replaceTextBetweenLines(int startLinePosition, int endLine
     cursor.insertText(newText);
 }
 
-void NoteEditorLogic::updateTaskText(int startLinePosition, int endLinePosition,
-                                     const QString &newText)
+void NoteEditorLogic::updateTaskText(int startLinePosition, int endLinePosition, const QString &newText)
 {
     QTextDocument *document = m_textEdit->document();
     QTextBlock block = document->findBlockByLineNumber(startLinePosition);
@@ -384,8 +366,7 @@ void NoteEditorLogic::updateTaskText(int startLinePosition, int endLinePosition,
         int indexOfTaskInLine = taskData["taskMatchIndex"];
         if (indexOfTaskInLine == -1)
             return;
-        QString taskExpressionText =
-                block.text().mid(0, taskData["taskMatchIndex"] + taskData["taskExpressionSize"]);
+        QString taskExpressionText = block.text().mid(0, taskData["taskMatchIndex"] + taskData["taskExpressionSize"]);
 
         QString newTextModified = newText;
         newTextModified.replace("\n\n", "\n");
@@ -445,8 +426,7 @@ void NoteEditorLogic::removeTextBetweenLines(int startLinePosition, int endLineP
     QTextDocument *document = m_textEdit->document();
     QTextCursor cursor(document);
     cursor.setPosition(document->findBlockByNumber(startLinePosition).position());
-    cursor.setPosition(document->findBlockByNumber(endLinePosition).position(),
-                       QTextCursor::KeepAnchor);
+    cursor.setPosition(document->findBlockByNumber(endLinePosition).position(), QTextCursor::KeepAnchor);
     cursor.movePosition(QTextCursor::EndOfBlock, QTextCursor::KeepAnchor);
     if (document->findBlockByNumber(endLinePosition + 1).isValid()) {
         cursor.movePosition(QTextCursor::NextCharacter, QTextCursor::KeepAnchor);
@@ -545,8 +525,7 @@ void NoteEditorLogic::addUntitledColumnToTextEditor(int startLinePosition)
     }
 }
 
-void NoteEditorLogic::appendNewColumn(QJsonArray &data, QJsonObject &currentColumn,
-                                      QString &currentTitle, QJsonArray &tasks)
+void NoteEditorLogic::appendNewColumn(QJsonArray &data, QJsonObject &currentColumn, QString &currentTitle, QJsonArray &tasks)
 {
     if (!tasks.isEmpty()) {
         currentColumn["title"] = currentTitle;
@@ -617,9 +596,7 @@ bool NoteEditorLogic::checkForTasksInEditor()
 
             if (indexOfTaskInLine != -1) {
                 QJsonObject taskObject;
-                QString taskText =
-                        line.mid(indexOfTaskInLine + taskDataInLine["taskExpressionSize"])
-                                .trimmed();
+                QString taskText = line.mid(indexOfTaskInLine + taskDataInLine["taskExpressionSize"]).trimmed();
                 taskObject["text"] = taskText;
                 taskObject["checked"] = taskDataInLine["taskChecked"] == 1;
                 taskObject["taskStartLine"] = i;
@@ -631,8 +608,7 @@ bool NoteEditorLogic::checkForTasksInEditor()
             else if (!line.isEmpty() && isPreviousLineATask) {
                 if (tasks.size() > 0) {
                     QJsonObject newTask = tasks[tasks.size() - 1].toObject();
-                    QString newTaskText =
-                            QStringLiteral("%1  \n%2").arg(newTask["text"].toString(), lineTrimmed);
+                    QString newTaskText = QStringLiteral("%1  \n%2").arg(newTask["text"].toString(), lineTrimmed);
                     // For markdown rendering a line break needs two white spaces
                     newTask["text"] = newTaskText;
                     newTask["taskEndLine"] = i;
@@ -716,8 +692,7 @@ int NoteEditorLogic::currentEditingNoteId() const
 
 void NoteEditorLogic::saveNoteToDB()
 {
-    if (currentEditingNoteId() != SpecialNodeID::InvalidNodeId && m_isContentModified
-        && !m_currentNotes[0].isTempNote()) {
+    if (currentEditingNoteId() != SpecialNodeID::InvalidNodeId && m_isContentModified && !m_currentNotes[0].isTempNote()) {
         emit requestCreateUpdateNote(m_currentNotes[0]);
         m_isContentModified = false;
     }
@@ -780,9 +755,7 @@ QString NoteEditorLogic::getNthLine(const QString &str, int targetLineNumber)
     for (int i = 0; i <= str.length(); i++) {
         if (i == str.length() || str[i] == '\n') {
             lineCount++;
-            if (lineCount >= targetLineNumber
-                && (i - previousLineBreakIndex > 1
-                    || (i > 0 && i == str.length() && str[i - 1] != '\n'))) {
+            if (lineCount >= targetLineNumber && (i - previousLineBreakIndex > 1 || (i > 0 && i == str.length() && str[i - 1] != '\n'))) {
                 QString line = str.mid(previousLineBreakIndex + 1, i - previousLineBreakIndex - 1);
                 line = line.trimmed();
                 if (!line.isEmpty() && !line.startsWith("---") && !line.startsWith("```")) {
@@ -844,8 +817,7 @@ void NoteEditorLogic::setTheme(Theme::Value theme, QColor textColor, qreal fontS
     }
     if (currentEditingNoteId() != SpecialNodeID::InvalidNodeId) {
         int verticalScrollBarValueToRestore = m_textEdit->verticalScrollBar()->value();
-        m_textEdit->setText(
-                m_textEdit->toPlainText()); // TODO: Update the text color without setting the text
+        m_textEdit->setText(m_textEdit->toPlainText()); // TODO: Update the text color without setting the text
         m_textEdit->verticalScrollBar()->setValue(verticalScrollBarValueToRestore);
     } else {
         int verticalScrollBarValueToRestore = m_textEdit->verticalScrollBar()->value();

--- a/src/noteeditorlogic.cpp
+++ b/src/noteeditorlogic.cpp
@@ -51,7 +51,7 @@ NoteEditorLogic::NoteEditorLogic(CustomDocument *textEdit, QLabel *editorDateLab
     m_tagListView->setItemDelegate(m_tagListDelegate);
     connect(tagPool, &TagPool::dataUpdated, this, [this](int) { showTagListForCurrentNote(); });
     connect(m_textEdit->verticalScrollBar(), &QScrollBar::valueChanged, this, [this](int value) {
-        if (m_currentNotes.size() == 1 && m_currentNotes[0].id() != SpecialNodeID::InvalidNodeId) {
+        if (m_currentNotes.size() == 1 && m_currentNotes[0].id() != INVALID_NODE_ID) {
             m_currentNotes[0].setScrollBarPosition(value);
             emit updateNoteDataInList(m_currentNotes[0]);
             m_isContentModified = true;
@@ -97,8 +97,8 @@ void NoteEditorLogic::setMarkdownEnabled(bool enabled)
 void NoteEditorLogic::showNotesInEditor(const QVector<NodeData> &notes)
 {
     auto currentId = currentEditingNoteId();
-    if (notes.size() == 1 && notes[0].id() != SpecialNodeID::InvalidNodeId) {
-        if (currentId != SpecialNodeID::InvalidNodeId && notes[0].id() != currentId) {
+    if (notes.size() == 1 && notes[0].id() != INVALID_NODE_ID) {
+        if (currentId != INVALID_NODE_ID && notes[0].id() != currentId) {
             emit noteEditClosed(m_currentNotes[0], false);
         }
 
@@ -195,7 +195,7 @@ void NoteEditorLogic::showNotesInEditor(const QVector<NodeData> &notes)
 
 void NoteEditorLogic::onTextEditTextChanged()
 {
-    if (currentEditingNoteId() != SpecialNodeID::InvalidNodeId) {
+    if (currentEditingNoteId() != INVALID_NODE_ID) {
         m_textEdit->blockSignals(true);
         QString content = m_currentNotes[0].content();
         if (m_textEdit->toPlainText() != content) {
@@ -642,7 +642,7 @@ QDateTime NoteEditorLogic::getQDateTime(const QString &date)
 
 void NoteEditorLogic::showTagListForCurrentNote()
 {
-    if (currentEditingNoteId() != SpecialNodeID::InvalidNodeId) {
+    if (currentEditingNoteId() != INVALID_NODE_ID) {
         auto tagIds = m_currentNotes[0].tagIds();
         if (tagIds.count() > 0) {
             m_tagListView->setVisible(true);
@@ -687,12 +687,12 @@ int NoteEditorLogic::currentEditingNoteId() const
     if (isInEditMode()) {
         return m_currentNotes[0].id();
     }
-    return SpecialNodeID::InvalidNodeId;
+    return INVALID_NODE_ID;
 }
 
 void NoteEditorLogic::saveNoteToDB()
 {
-    if (currentEditingNoteId() != SpecialNodeID::InvalidNodeId && m_isContentModified && !m_currentNotes[0].isTempNote()) {
+    if (currentEditingNoteId() != INVALID_NODE_ID && m_isContentModified && !m_currentNotes[0].isTempNote()) {
         emit requestCreateUpdateNote(m_currentNotes[0]);
         m_isContentModified = false;
     }
@@ -700,7 +700,7 @@ void NoteEditorLogic::saveNoteToDB()
 
 void NoteEditorLogic::closeEditor()
 {
-    if (currentEditingNoteId() != SpecialNodeID::InvalidNodeId) {
+    if (currentEditingNoteId() != INVALID_NODE_ID) {
         saveNoteToDB();
         emit noteEditClosed(m_currentNotes[0], false);
     }
@@ -731,7 +731,7 @@ void NoteEditorLogic::deleteCurrentNote()
         m_textEdit->clearFocus();
         m_textEdit->blockSignals(false);
         emit noteEditClosed(noteNeedDeleted, true);
-    } else if (currentEditingNoteId() != SpecialNodeID::InvalidNodeId) {
+    } else if (currentEditingNoteId() != INVALID_NODE_ID) {
         auto noteNeedDeleted = m_currentNotes[0];
         saveNoteToDB();
         m_currentNotes.clear();
@@ -815,7 +815,7 @@ void NoteEditorLogic::setTheme(Theme::Value theme, QColor textColor, qreal fontS
         break;
     }
     }
-    if (currentEditingNoteId() != SpecialNodeID::InvalidNodeId) {
+    if (currentEditingNoteId() != INVALID_NODE_ID) {
         int verticalScrollBarValueToRestore = m_textEdit->verticalScrollBar()->value();
         m_textEdit->setText(m_textEdit->toPlainText()); // TODO: Update the text color without setting the text
         m_textEdit->verticalScrollBar()->setValue(verticalScrollBarValueToRestore);
@@ -858,7 +858,7 @@ void NoteEditorLogic::highlightSearch() const
 
 bool NoteEditorLogic::isTempNote() const
 {
-    if (currentEditingNoteId() != SpecialNodeID::InvalidNodeId && m_currentNotes[0].isTempNote()) {
+    if (currentEditingNoteId() != INVALID_NODE_ID && m_currentNotes[0].isTempNote()) {
         return true;
     }
     return false;

--- a/src/noteeditorlogic.h
+++ b/src/noteeditorlogic.h
@@ -31,13 +31,11 @@ class NoteEditorLogic : public QObject
     Q_OBJECT
 public:
 #if QT_VERSION >= QT_VERSION_CHECK(6, 2, 0)
-    explicit NoteEditorLogic(CustomDocument *textEdit, QLabel *editorDateLabel,
-                             QLineEdit *searchEdit, QWidget *kanbanWidget, TagListView *tagListView,
+    explicit NoteEditorLogic(CustomDocument *textEdit, QLabel *editorDateLabel, QLineEdit *searchEdit, QWidget *kanbanWidget, TagListView *tagListView,
                              TagPool *tagPool, DBManager *dbManager, QObject *parent = nullptr);
 
 #else
-    explicit NoteEditorLogic(CustomDocument *textEdit, QLabel *editorDateLabel,
-                             QLineEdit *searchEdit, TagListView *tagListView, TagPool *tagPool,
+    explicit NoteEditorLogic(CustomDocument *textEdit, QLabel *editorDateLabel, QLineEdit *searchEdit, TagListView *tagListView, TagPool *tagPool,
                              DBManager *dbManager, QObject *parent = nullptr);
 #endif
 
@@ -68,10 +66,8 @@ public slots:
     void onNoteTagListChanged(int noteId, const QSet<int> &tagIds);
 #if QT_VERSION >= QT_VERSION_CHECK(6, 2, 0)
     bool checkForTasksInEditor();
-    void rearrangeTasksInTextEditor(int startLinePosition, int endLinePosition,
-                                    int newLinePosition);
-    void rearrangeColumnsInTextEditor(int startLinePosition, int endLinePosition,
-                                      int newLinePosition);
+    void rearrangeTasksInTextEditor(int startLinePosition, int endLinePosition, int newLinePosition);
+    void rearrangeColumnsInTextEditor(int startLinePosition, int endLinePosition, int newLinePosition);
     void checkTaskInLine(int lineNumber);
     void uncheckTaskInLine(int lineNumber);
     void updateTaskText(int startLinePosition, int endLinePosition, const QString &newText);
@@ -104,14 +100,11 @@ private:
     static QDateTime getQDateTime(const QString &date);
     void showTagListForCurrentNote();
     bool isInEditMode() const;
-    QString moveTextToNewLinePosition(const QString &inputText, int startLinePosition,
-                                      int endLinePosition, int newLinePosition,
-                                      bool isColumns = false);
+    QString moveTextToNewLinePosition(const QString &inputText, int startLinePosition, int endLinePosition, int newLinePosition, bool isColumns = false);
     QMap<QString, int> getTaskDataInLine(const QString &line);
     void replaceTextBetweenLines(int startLinePosition, int endLinePosition, QString &newText);
     void removeTextBetweenLines(int startLinePosition, int endLinePosition);
-    void appendNewColumn(QJsonArray &data, QJsonObject &currentColumn, QString &currentTitle,
-                         QJsonArray &tasks);
+    void appendNewColumn(QJsonArray &data, QJsonObject &currentColumn, QString &currentTitle, QJsonArray &tasks);
     void addUntitledColumnToTextEditor(int startLinePosition);
 
 private:

--- a/src/noteeditorlogic.h
+++ b/src/noteeditorlogic.h
@@ -71,7 +71,7 @@ public slots:
     void checkTaskInLine(int lineNumber);
     void uncheckTaskInLine(int lineNumber);
     void updateTaskText(int startLinePosition, int endLinePosition, const QString &newText);
-    void addNewTask(int startLinePosition, const QString newTaskText);
+    void addNewTask(int startLinePosition, const QString &newTaskText);
     void removeTask(int startLinePosition, int endLinePosition);
     void addNewColumn(int startLinePosition, const QString &columnTitle);
     void removeColumn(int startLinePosition, int endLinePosition);

--- a/src/notelistdelegate.cpp
+++ b/src/notelistdelegate.cpp
@@ -94,7 +94,7 @@ void NoteListDelegate::setState(NoteListState NewState, QModelIndexList indexes)
         QSet<int> ids;
         for (const auto &index : std::as_const(indexes)) {
             auto noteId = index.data(NoteListModel::NoteID).toInt();
-            if (noteId != SpecialNodeID::InvalidNodeId) {
+            if (noteId != INVALID_NODE_ID) {
                 ids.insert(noteId);
             }
         }

--- a/src/notelistdelegate.cpp
+++ b/src/notelistdelegate.cpp
@@ -624,7 +624,7 @@ void NoteListDelegate::paintLabels(QPainter *painter, const QStyleOptionViewItem
 #else
                 int iconPointSizeOffset = -4;
 #endif
-                painter->setFont(FontLoader::getInstance().loadFont("Font Awesome 6 Free Solid", "",
+                painter->setFont(font_loader::loadFont("Font Awesome 6 Free Solid", "",
                                                                     14 + iconPointSizeOffset));
                 painter->setPen(QColor(68, 138, 201));
                 if (m_view->isPinnedNotesCollapsed()) {
@@ -684,7 +684,7 @@ void NoteListDelegate::paintLabels(QPainter *painter, const QStyleOptionViewItem
 #else
                 int iconPointSizeOffset = -4;
 #endif
-                painter->setFont(FontLoader::getInstance().loadFont("Font Awesome 6 Free Solid", "",
+                painter->setFont(font_loader::loadFont("Font Awesome 6 Free Solid", "",
                                                                     14 + iconPointSizeOffset));
                 painter->setPen(QColor(68, 138, 201));
                 if (m_view->isPinnedNotesCollapsed()) {
@@ -835,7 +835,7 @@ void NoteListDelegate::paintTagList(int top, QPainter *painter, const QStyleOpti
 #else
         int iconPointSizeOffset = -4;
 #endif
-        painter->setFont(FontLoader::getInstance().loadFont("Font Awesome 6 Free Solid", "",
+        painter->setFont(font_loader::loadFont("Font Awesome 6 Free Solid", "",
                                                             14 + iconPointSizeOffset));
         painter->drawText(iconRect, u8"\uf111"); // fa-circle
         painter->setBrush(m_titleColor);

--- a/src/notelistdelegate.h
+++ b/src/notelistdelegate.h
@@ -21,8 +21,7 @@ public:
     void setState(NoteListState NewState, QModelIndexList indexes);
     void setAnimationDuration(const int duration);
 
-    void paint(QPainter *painter, const QStyleOptionViewItem &option,
-               const QModelIndex &index) const override;
+    void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 
     QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 
@@ -45,8 +44,7 @@ public slots:
 
     // QAbstractItemDelegate interface
 public:
-    virtual QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option,
-                                  const QModelIndex &index) const override;
+    virtual QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
     const QModelIndex &hoveredIndex() const;
     bool shouldPaintSeparator(const QModelIndex &index, const NoteListModel &model) const;
 
@@ -55,13 +53,10 @@ signals:
     void animationFinished(NoteListState animationState);
 
 private:
-    void paintBackground(QPainter *painter, const QStyleOptionViewItem &option,
-                         const QModelIndex &index) const;
-    void paintLabels(QPainter *painter, const QStyleOptionViewItem &option,
-                     const QModelIndex &index) const;
+    void paintBackground(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
+    void paintLabels(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
     void paintSeparator(QPainter *painter, QRect rect, const QModelIndex &index) const;
-    void paintTagList(int top, QPainter *painter, const QStyleOptionViewItem &option,
-                      const QModelIndex &index) const;
+    void paintTagList(int top, QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
     QString parseDateTime(const QDateTime &dateTime) const;
     void setStateI(NoteListState NewState, const QModelIndexList &indexes);
 

--- a/src/notelistdelegate.h
+++ b/src/notelistdelegate.h
@@ -9,7 +9,7 @@
 
 class TagPool;
 class NoteListModel;
-enum class NoteListState { Normal, Insert, Remove, MoveOut, MoveIn };
+enum class NoteListState : uint8_t { Normal, Insert, Remove, MoveOut, MoveIn };
 
 class NoteListDelegate : public QStyledItemDelegate
 {
@@ -19,7 +19,7 @@ public:
     NoteListDelegate(NoteListView *view, TagPool *tagPool, QObject *parent = nullptr);
 
     void setState(NoteListState NewState, QModelIndexList indexes);
-    void setAnimationDuration(const int duration);
+    void setAnimationDuration(int duration);
 
     void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 
@@ -44,7 +44,7 @@ public slots:
 
     // QAbstractItemDelegate interface
 public:
-    virtual QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+    QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
     const QModelIndex &hoveredIndex() const;
     bool shouldPaintSeparator(const QModelIndex &index, const NoteListModel &model) const;
 
@@ -57,7 +57,6 @@ private:
     void paintLabels(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
     void paintSeparator(QPainter *painter, QRect rect, const QModelIndex &index) const;
     void paintTagList(int top, QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
-    QString parseDateTime(const QDateTime &dateTime) const;
     void setStateI(NoteListState NewState, const QModelIndexList &indexes);
 
     NoteListView *m_view;
@@ -70,7 +69,7 @@ private:
     QColor m_titleColor;
     QColor m_dateColor;
     QColor m_contentColor;
-    QColor m_ActiveColor;
+    QColor m_activeColor;
     QColor m_notActiveColor;
     QColor m_hoverColor;
     QColor m_applicationInactiveColor;
@@ -87,8 +86,8 @@ private:
     QTimeLine *m_timeLine;
     QModelIndexList m_animatedIndexes;
     QModelIndex m_hoveredIndex;
-    QMap<int, QSize> szMap;
-    QQueue<QPair<QSet<int>, NoteListState>> animationQueue;
+    QMap<int, QSize> m_sizeMap;
+    QQueue<QPair<QSet<int>, NoteListState>> m_animationQueue;
 };
 
 #endif // NOTELISTDELEGATE_H

--- a/src/notelistdelegateeditor.cpp
+++ b/src/notelistdelegateeditor.cpp
@@ -290,7 +290,7 @@ void NoteListDelegateEditor::paintLabels(QPainter *painter, const QStyleOptionVi
 #else
             int iconPointSizeOffset = -4;
 #endif
-            painter->setFont(FontLoader::getInstance().loadFont("Font Awesome 6 Free Solid", "",
+            painter->setFont(font_loader::loadFont("Font Awesome 6 Free Solid", "",
                                                                 14 + iconPointSizeOffset));
             painter->setPen(QColor(68, 138, 201));
             if (m_view->isPinnedNotesCollapsed()) {

--- a/src/notelistdelegateeditor.cpp
+++ b/src/notelistdelegateeditor.cpp
@@ -17,6 +17,7 @@
 #include "taglistmodel.h"
 #include "taglistdelegate.h"
 #include "fontloader.h"
+#include "utils.h"
 
 NoteListDelegateEditor::NoteListDelegateEditor(const NoteListDelegate *delegate, NoteListView *view, const QStyleOptionViewItem &option,
                                                const QModelIndex &index, TagPool *tagPool, QWidget *parent)
@@ -48,7 +49,7 @@ NoteListDelegateEditor::NoteListDelegateEditor(const NoteListDelegate *delegate,
       m_titleColor(26, 26, 26),
       m_dateColor(26, 26, 26),
       m_contentColor(142, 146, 150),
-      m_ActiveColor(218, 233, 239),
+      m_activeColor(218, 233, 239),
       m_notActiveColor(175, 212, 228),
       m_hoverColor(207, 207, 207),
       m_applicationInactiveColor(207, 207, 207),
@@ -81,11 +82,11 @@ NoteListDelegateEditor::NoteListDelegateEditor(const NoteListDelegate *delegate,
         }
         int fourthYOffset = 0;
         if ((noteListModel != nullptr) && noteListModel->isFirstUnpinnedNote(index)) {
-            fourthYOffset = NoteListConstant::unpinnedHeaderToNoteSpace;
+            fourthYOffset = note_list_constants::UNPINNED_HEADER_TO_NOTE_SPACE;
         }
         int fifthYOffset = 0;
         if ((noteListModel != nullptr) && noteListModel->hasPinnedNote() && !m_view->isPinnedNotesCollapsed() && noteListModel->isFirstUnpinnedNote(index)) {
-            fifthYOffset = NoteListConstant::lastPinnedToUnpinnedHeader;
+            fifthYOffset = note_list_constants::LAST_PINNED_TO_UNPINNED_HEADER;
         }
         int yOffsets = fourthYOffset + fifthYOffset;
 
@@ -102,11 +103,11 @@ NoteListDelegateEditor::NoteListDelegateEditor(const NoteListDelegate *delegate,
         }
         int fourthYOffset = 0;
         if ((noteListModel != nullptr) && noteListModel->isFirstUnpinnedNote(index)) {
-            fourthYOffset = NoteListConstant::unpinnedHeaderToNoteSpace;
+            fourthYOffset = note_list_constants::UNPINNED_HEADER_TO_NOTE_SPACE;
         }
         int fifthYOffset = 0;
         if ((noteListModel != nullptr) && noteListModel->hasPinnedNote() && !m_view->isPinnedNotesCollapsed() && noteListModel->isFirstUnpinnedNote(index)) {
-            fifthYOffset = NoteListConstant::lastPinnedToUnpinnedHeader;
+            fifthYOffset = note_list_constants::LAST_PINNED_TO_UNPINNED_HEADER;
         }
         int yOffsets = fourthYOffset + fifthYOffset;
 
@@ -143,7 +144,7 @@ void NoteListDelegateEditor::paintBackground(QPainter *painter, const QStyleOpti
     if (noteListModel->hasPinnedNote() && (noteListModel->isFirstPinnedNote(index) || noteListModel->isFirstUnpinnedNote(index))) {
         int fifthYOffset = 0;
         if (!m_view->isPinnedNotesCollapsed() && noteListModel->isFirstUnpinnedNote(index)) {
-            fifthYOffset = NoteListConstant::lastPinnedToUnpinnedHeader;
+            fifthYOffset = note_list_constants::LAST_PINNED_TO_UNPINNED_HEADER;
         }
         bufferRect.setY(bufferRect.y() + 25 + fifthYOffset);
     }
@@ -151,8 +152,8 @@ void NoteListDelegateEditor::paintBackground(QPainter *painter, const QStyleOpti
     if (m_view->selectionModel()->isSelected(index)) {
         if (qApp->applicationState() == Qt::ApplicationActive) {
             if (m_isActive) {
-                bufferPainter.fillRect(bufferRect, QBrush(m_ActiveColor));
-                m_tagListView->setBackground(m_ActiveColor);
+                bufferPainter.fillRect(bufferRect, QBrush(m_activeColor));
+                m_tagListView->setBackground(m_activeColor);
             } else {
                 bufferPainter.fillRect(bufferRect, QBrush(m_notActiveColor));
                 m_tagListView->setBackground(m_notActiveColor);
@@ -236,7 +237,7 @@ void NoteListDelegateEditor::paintLabels(QPainter *painter, const QStyleOptionVi
     QFontMetrics fmTitle(titleFont);
     QRect fmRectTitle = fmTitle.boundingRect(title);
 
-    QString date = parseDateTime(index.data(NoteListModel::NoteLastModificationDateTime).toDateTime());
+    QString date = utils::parseDateTime(index.data(NoteListModel::NoteLastModificationDateTime).toDateTime());
     QFontMetrics fmDate(m_dateFont);
     QRect fmRectDate = fmDate.boundingRect(date);
 
@@ -255,11 +256,11 @@ void NoteListDelegateEditor::paintLabels(QPainter *painter, const QStyleOptionVi
     auto const *noteListModel = static_cast<NoteListModel *>(m_view->model());
     int fifthYOffset = 0;
     if (noteListModel->hasPinnedNote() && !m_view->isPinnedNotesCollapsed() && noteListModel->isFirstUnpinnedNote(index)) {
-        fifthYOffset = NoteListConstant::lastPinnedToUnpinnedHeader;
+        fifthYOffset = note_list_constants::LAST_PINNED_TO_UNPINNED_HEADER;
     }
     if (noteListModel->hasPinnedNote()) {
         if (noteListModel->isFirstPinnedNote(index)) {
-            QRect headerRect(rowPosX + (NoteListConstant::leftOffsetX / 2), rowPosY, rowWidth - (NoteListConstant::leftOffsetX / 2), 25);
+            QRect headerRect(rowPosX + (note_list_constants::LEFT_OFFSET_X / 2), rowPosY, rowWidth - (note_list_constants::LEFT_OFFSET_X / 2), 25);
 #ifdef __APPLE__
             int iconPointSizeOffset = 0;
 #else
@@ -280,7 +281,7 @@ void NoteListDelegateEditor::paintLabels(QPainter *painter, const QStyleOptionVi
             rowPosY += 25;
         } else if (noteListModel->isFirstUnpinnedNote(index)) {
             rowPosY += fifthYOffset;
-            QRect headerRect(rowPosX + (NoteListConstant::leftOffsetX / 2), rowPosY, rowWidth - (NoteListConstant::leftOffsetX / 2), 25);
+            QRect headerRect(rowPosX + (note_list_constants::LEFT_OFFSET_X / 2), rowPosY, rowWidth - (note_list_constants::LEFT_OFFSET_X / 2), 25);
             painter->setPen(m_contentColor);
             painter->setFont(m_headerFont);
             painter->drawText(headerRect, Qt::AlignLeft | Qt::AlignVCenter, "Notes");
@@ -295,32 +296,32 @@ void NoteListDelegateEditor::paintLabels(QPainter *painter, const QStyleOptionVi
     }
     int secondYOffset = 0;
     if (index.row() > 0) {
-        secondYOffset = NoteListConstant::nextNoteOffset;
+        secondYOffset = note_list_constants::NEXT_NOTE_OFFSET;
     }
     int thirdYOffset = 0;
     if ((noteListModel != nullptr) && noteListModel->isFirstPinnedNote(index)) {
-        thirdYOffset = NoteListConstant::pinnedHeaderToNoteSpace;
+        thirdYOffset = note_list_constants::PINNED_HEADER_TO_NOTE_SPACE;
     }
     int fourthYOffset = 0;
     if ((noteListModel != nullptr) && noteListModel->isFirstUnpinnedNote(index)) {
-        fourthYOffset = NoteListConstant::unpinnedHeaderToNoteSpace;
+        fourthYOffset = note_list_constants::UNPINNED_HEADER_TO_NOTE_SPACE;
     }
 
     int yOffsets = secondYOffset + thirdYOffset + fourthYOffset;
-    double titleRectPosX = rowPosX + NoteListConstant::leftOffsetX;
+    double titleRectPosX = rowPosX + note_list_constants::LEFT_OFFSET_X;
     double titleRectPosY = rowPosY;
-    double titleRectWidth = rowWidth - (2.0 * NoteListConstant::leftOffsetX);
-    double titleRectHeight = fmRectTitle.height() + NoteListConstant::topOffsetY + yOffsets;
+    double titleRectWidth = rowWidth - (2.0 * note_list_constants::LEFT_OFFSET_X);
+    double titleRectHeight = fmRectTitle.height() + note_list_constants::TOP_OFFSET_Y + yOffsets;
 
-    double dateRectPosX = rowPosX + NoteListConstant::leftOffsetX;
-    double dateRectPosY = rowPosY + fmRectTitle.height() + NoteListConstant::topOffsetY + yOffsets;
-    double dateRectWidth = rowWidth - (2.0 * NoteListConstant::leftOffsetX);
-    double dateRectHeight = fmRectDate.height() + NoteListConstant::titleDateSpace;
+    double dateRectPosX = rowPosX + note_list_constants::LEFT_OFFSET_X;
+    double dateRectPosY = rowPosY + fmRectTitle.height() + note_list_constants::TOP_OFFSET_Y + yOffsets;
+    double dateRectWidth = rowWidth - (2.0 * note_list_constants::LEFT_OFFSET_X);
+    double dateRectHeight = fmRectDate.height() + note_list_constants::TITLE_DATE_SPACE;
 
-    double contentRectPosX = rowPosX + NoteListConstant::leftOffsetX;
-    double contentRectPosY = rowPosY + fmRectTitle.height() + fmRectDate.height() + NoteListConstant::topOffsetY + yOffsets;
-    double contentRectWidth = rowWidth - (2.0 * NoteListConstant::leftOffsetX);
-    double contentRectHeight = fmRectContent.height() + NoteListConstant::dateDescSpace;
+    double contentRectPosX = rowPosX + note_list_constants::LEFT_OFFSET_X;
+    double contentRectPosY = rowPosY + fmRectTitle.height() + fmRectDate.height() + note_list_constants::TOP_OFFSET_Y + yOffsets;
+    double contentRectWidth = rowWidth - (2.0 * note_list_constants::LEFT_OFFSET_X);
+    double contentRectHeight = fmRectContent.height() + note_list_constants::DATE_DESC_SPACE;
 
     double folderNameRectPosX = 0;
     double folderNameRectPosY = 0;
@@ -328,10 +329,10 @@ void NoteListDelegateEditor::paintLabels(QPainter *painter, const QStyleOptionVi
     double folderNameRectHeight = 0;
 
     if (m_delegate->isInAllNotes()) {
-        folderNameRectPosX = rowPosX + NoteListConstant::leftOffsetX + 20;
-        folderNameRectPosY = rowPosY + fmRectContent.height() + fmRectTitle.height() + fmRectDate.height() + NoteListConstant::topOffsetY + yOffsets;
-        folderNameRectWidth = rowWidth - 2.0 * NoteListConstant::leftOffsetX;
-        folderNameRectHeight = fmRectParentName.height() + NoteListConstant::descFolderSpace;
+        folderNameRectPosX = rowPosX + note_list_constants::LEFT_OFFSET_X + 20;
+        folderNameRectPosY = rowPosY + fmRectContent.height() + fmRectTitle.height() + fmRectDate.height() + note_list_constants::TOP_OFFSET_Y + yOffsets;
+        folderNameRectWidth = rowWidth - 2.0 * note_list_constants::LEFT_OFFSET_X;
+        folderNameRectHeight = fmRectParentName.height() + note_list_constants::DESC_FOLDER_SPACE;
     }
     auto drawStr = [painter](double posX, double posY, double width, double height, QColor color, const QFont &font, const QString &str) {
         QRectF rect(posX, posY, width, height);
@@ -346,7 +347,8 @@ void NoteListDelegateEditor::paintLabels(QPainter *painter, const QStyleOptionVi
     drawStr(titleRectPosX, titleRectPosY, titleRectWidth, titleRectHeight, m_titleColor, titleFont, title);
     drawStr(dateRectPosX, dateRectPosY, dateRectWidth, dateRectHeight, m_dateColor, m_dateFont, date);
     if (m_delegate->isInAllNotes()) {
-        painter->drawImage(QRect(rowPosX + NoteListConstant::leftOffsetX, folderNameRectPosY + NoteListConstant::descFolderSpace, 16, 16), m_folderIcon);
+        painter->drawImage(QRect(rowPosX + note_list_constants::LEFT_OFFSET_X, folderNameRectPosY + note_list_constants::DESC_FOLDER_SPACE, 16, 16),
+                           m_folderIcon);
         drawStr(folderNameRectPosX, folderNameRectPosY, folderNameRectWidth, folderNameRectHeight, m_contentColor, titleFont, parentName);
     }
     drawStr(contentRectPosX, contentRectPosY, contentRectWidth, contentRectHeight, m_contentColor, titleFont, content);
@@ -358,31 +360,12 @@ void NoteListDelegateEditor::paintSeparator(QPainter *painter, const QStyleOptio
     Q_UNUSED(option);
 
     painter->setPen(QPen(m_separatorColor));
-    const int leftOffsetX = NoteListConstant::leftOffsetX;
+    const int leftOffsetX = note_list_constants::LEFT_OFFSET_X;
     int posX1 = rect().x() + leftOffsetX;
     int posX2 = rect().x() + rect().width() - leftOffsetX - 1;
     int posY = rect().y() + rect().height() - 1;
 
     painter->drawLine(QPoint(posX1, posY), QPoint(posX2, posY));
-}
-
-QString NoteListDelegateEditor::parseDateTime(const QDateTime &dateTime) const
-{
-    QLocale usLocale(QLocale("en_US"));
-
-    auto currDateTime = QDateTime::currentDateTime();
-
-    if (dateTime.date() == currDateTime.date()) {
-        return usLocale.toString(dateTime.time(), "h:mm A");
-    }
-    if (dateTime.daysTo(currDateTime) == 1) {
-        return "Yesterday";
-    }
-    if (dateTime.daysTo(currDateTime) >= 2 && dateTime.daysTo(currDateTime) <= 7) {
-        return usLocale.toString(dateTime.date(), "dddd");
-    }
-
-    return dateTime.date().toString("M/d/yy");
 }
 
 bool NoteListDelegateEditor::underMouseC() const
@@ -428,16 +411,16 @@ void NoteListDelegateEditor::resizeEvent(QResizeEvent *event)
         }
         int fourthYOffset = 0;
         if (noteListModel->isFirstUnpinnedNote(idx)) {
-            fourthYOffset = NoteListConstant::unpinnedHeaderToNoteSpace;
+            fourthYOffset = note_list_constants::UNPINNED_HEADER_TO_NOTE_SPACE;
         }
         int fifthYOffset = 0;
         if (noteListModel->hasPinnedNote() && !m_view->isPinnedNotesCollapsed() && noteListModel->isFirstUnpinnedNote(idx)) {
-            fifthYOffset = NoteListConstant::lastPinnedToUnpinnedHeader;
+            fifthYOffset = note_list_constants::LAST_PINNED_TO_UNPINNED_HEADER;
         }
         int yOffsets = fourthYOffset + fifthYOffset;
         y += yOffsets;
 
-        m_tagListView->setGeometry(NoteListConstant::leftOffsetX - 5, y + 5, rect().width() - 15, m_tagListView->height());
+        m_tagListView->setGeometry(note_list_constants::LEFT_OFFSET_X - 5, y + 5, rect().width() - 15, m_tagListView->height());
     } else {
         int y = 70;
         auto const *noteListModel = static_cast<NoteListModel *>(m_view->model());
@@ -447,17 +430,17 @@ void NoteListDelegateEditor::resizeEvent(QResizeEvent *event)
         }
         int fourthYOffset = 0;
         if (noteListModel->isFirstUnpinnedNote(idx)) {
-            fourthYOffset = NoteListConstant::unpinnedHeaderToNoteSpace;
+            fourthYOffset = note_list_constants::UNPINNED_HEADER_TO_NOTE_SPACE;
         }
         int fifthYOffset = 0;
         if (noteListModel->hasPinnedNote() && !m_view->isPinnedNotesCollapsed() && noteListModel->isFirstUnpinnedNote(idx)) {
-            fifthYOffset = NoteListConstant::lastPinnedToUnpinnedHeader;
+            fifthYOffset = note_list_constants::LAST_PINNED_TO_UNPINNED_HEADER;
         }
         int yOffsets = fourthYOffset + fifthYOffset;
 
         y += yOffsets;
 
-        m_tagListView->setGeometry(NoteListConstant::leftOffsetX - 5, y, rect().width() - 15, m_tagListView->height());
+        m_tagListView->setGeometry(note_list_constants::LEFT_OFFSET_X - 5, y, rect().width() - 15, m_tagListView->height());
     }
     recalculateSize();
 }
@@ -531,27 +514,27 @@ void NoteListDelegateEditor::recalculateSize()
     }
     int secondYOffset = 0;
     if (idx.row() > 0) {
-        secondYOffset = NoteListConstant::nextNoteOffset;
+        secondYOffset = note_list_constants::NEXT_NOTE_OFFSET;
     }
     int thirdYOffset = 0;
     if (noteListModel->isFirstPinnedNote(idx)) {
-        thirdYOffset = NoteListConstant::pinnedHeaderToNoteSpace;
+        thirdYOffset = note_list_constants::PINNED_HEADER_TO_NOTE_SPACE;
     }
     int fourthYOffset = 0;
     if (noteListModel->isFirstUnpinnedNote(idx)) {
-        fourthYOffset = NoteListConstant::unpinnedHeaderToNoteSpace;
+        fourthYOffset = note_list_constants::UNPINNED_HEADER_TO_NOTE_SPACE;
     }
 
     int fifthYOffset = 0;
     if (noteListModel->hasPinnedNote() && !m_view->isPinnedNotesCollapsed() && noteListModel->isFirstUnpinnedNote(idx)) {
-        fifthYOffset = NoteListConstant::lastPinnedToUnpinnedHeader;
+        fifthYOffset = note_list_constants::LAST_PINNED_TO_UNPINNED_HEADER;
     }
 
     int yOffsets = secondYOffset + thirdYOffset + fourthYOffset + fifthYOffset;
     if (m_delegate->isInAllNotes()) {
-        result.setHeight(result.height() - 2 + NoteListConstant::lastElSepSpace + yOffsets);
+        result.setHeight(result.height() - 2 + note_list_constants::LAST_EL_SEP_SPACE + yOffsets);
     } else {
-        result.setHeight(result.height() - 10 + NoteListConstant::lastElSepSpace + yOffsets);
+        result.setHeight(result.height() - 10 + note_list_constants::LAST_EL_SEP_SPACE + yOffsets);
     }
     emit updateSizeHint(m_id, result, idx);
 }
@@ -579,7 +562,7 @@ void NoteListDelegateEditor::setTheme(Theme::Value theme)
         m_titleColor = QColor(26, 26, 26);
         m_dateColor = QColor(26, 26, 26);
         m_defaultColor = QColor(247, 247, 247);
-        m_ActiveColor = QColor(218, 233, 239);
+        m_activeColor = QColor(218, 233, 239);
         m_notActiveColor = QColor(175, 212, 228);
         m_hoverColor = QColor(207, 207, 207);
         m_applicationInactiveColor = QColor(207, 207, 207);
@@ -590,7 +573,7 @@ void NoteListDelegateEditor::setTheme(Theme::Value theme)
         m_titleColor = QColor(212, 212, 212);
         m_dateColor = QColor(212, 212, 212);
         m_defaultColor = QColor(25, 25, 25);
-        m_ActiveColor = QColor(35, 52, 69, 127);
+        m_activeColor = QColor(35, 52, 69, 127);
         m_notActiveColor = QColor(35, 52, 69);
         m_hoverColor = QColor(35, 52, 69);
         m_applicationInactiveColor = QColor(35, 52, 69);
@@ -601,7 +584,7 @@ void NoteListDelegateEditor::setTheme(Theme::Value theme)
         m_titleColor = QColor(26, 26, 26);
         m_dateColor = QColor(26, 26, 26);
         m_defaultColor = QColor(251, 240, 217);
-        m_ActiveColor = QColor(218, 233, 239);
+        m_activeColor = QColor(218, 233, 239);
         m_notActiveColor = QColor(175, 212, 228);
         m_hoverColor = QColor(207, 207, 207);
         m_applicationInactiveColor = QColor(207, 207, 207);

--- a/src/notelistdelegateeditor.cpp
+++ b/src/notelistdelegateeditor.cpp
@@ -18,10 +18,8 @@
 #include "taglistdelegate.h"
 #include "fontloader.h"
 
-NoteListDelegateEditor::NoteListDelegateEditor(const NoteListDelegate *delegate, NoteListView *view,
-                                               const QStyleOptionViewItem &option,
-                                               const QModelIndex &index, TagPool *tagPool,
-                                               QWidget *parent)
+NoteListDelegateEditor::NoteListDelegateEditor(const NoteListDelegate *delegate, NoteListView *view, const QStyleOptionViewItem &option,
+                                               const QModelIndex &index, TagPool *tagPool, QWidget *parent)
     : QWidget(parent),
       m_delegate(delegate),
       m_option(option),
@@ -29,12 +27,9 @@ NoteListDelegateEditor::NoteListDelegateEditor(const NoteListDelegate *delegate,
       m_view(view),
       m_tagPool{ tagPool },
 #ifdef __APPLE__
-      m_displayFont(QFont(QStringLiteral("SF Pro Text")).exactMatch()
-                            ? QStringLiteral("SF Pro Text")
-                            : QStringLiteral("Roboto")),
+      m_displayFont(QFont(QStringLiteral("SF Pro Text")).exactMatch() ? QStringLiteral("SF Pro Text") : QStringLiteral("Roboto")),
 #elif _WIN32
-      m_displayFont(QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI")
-                                                                   : QStringLiteral("Roboto")),
+      m_displayFont(QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI") : QStringLiteral("Roboto")),
 #else
       m_displayFont(QStringLiteral("Roboto")),
 #endif
@@ -77,21 +72,19 @@ NoteListDelegateEditor::NoteListDelegateEditor(const NoteListDelegate *delegate,
     m_tagListModel->setModelData(index.data(NoteListModel::NoteTagsList).value<QSet<int>>());
     if (m_delegate->isInAllNotes()) {
         int y = 90;
-        auto model = dynamic_cast<NoteListModel *>(m_view->model());
-        if (model) {
-            auto m_index = model->getNoteIndex(m_id);
-            if (model->hasPinnedNote()
-                && (model->isFirstPinnedNote(m_index) || model->isFirstUnpinnedNote(m_index))) {
+        auto const *noteListModel = static_cast<NoteListModel *>(m_view->model());
+        if (noteListModel != nullptr) {
+            auto idx = noteListModel->getNoteIndex(m_id);
+            if (noteListModel->hasPinnedNote() && (noteListModel->isFirstPinnedNote(idx) || noteListModel->isFirstUnpinnedNote(idx))) {
                 y += 25;
             }
         }
         int fourthYOffset = 0;
-        if (model && model->isFirstUnpinnedNote(index)) {
+        if ((noteListModel != nullptr) && noteListModel->isFirstUnpinnedNote(index)) {
             fourthYOffset = NoteListConstant::unpinnedHeaderToNoteSpace;
         }
         int fifthYOffset = 0;
-        if (model && model->hasPinnedNote() && !m_view->isPinnedNotesCollapsed()
-            && model->isFirstUnpinnedNote(index)) {
+        if ((noteListModel != nullptr) && noteListModel->hasPinnedNote() && !m_view->isPinnedNotesCollapsed() && noteListModel->isFirstUnpinnedNote(index)) {
             fifthYOffset = NoteListConstant::lastPinnedToUnpinnedHeader;
         }
         int yOffsets = fourthYOffset + fifthYOffset;
@@ -100,21 +93,19 @@ NoteListDelegateEditor::NoteListDelegateEditor(const NoteListDelegate *delegate,
         m_tagListView->setGeometry(10, y - 5, rect().width() - 15, m_tagListView->height());
     } else {
         int y = 70;
-        auto model = dynamic_cast<NoteListModel *>(m_view->model());
-        if (model) {
-            auto m_index = model->getNoteIndex(m_id);
-            if (model->hasPinnedNote()
-                && (model->isFirstPinnedNote(m_index) || model->isFirstUnpinnedNote(m_index))) {
+        auto const *noteListModel = static_cast<NoteListModel *>(m_view->model());
+        if (noteListModel != nullptr) {
+            auto idx = noteListModel->getNoteIndex(m_id);
+            if (noteListModel->hasPinnedNote() && (noteListModel->isFirstPinnedNote(idx) || noteListModel->isFirstUnpinnedNote(idx))) {
                 y += 25;
             }
         }
         int fourthYOffset = 0;
-        if (model && model->isFirstUnpinnedNote(index)) {
+        if ((noteListModel != nullptr) && noteListModel->isFirstUnpinnedNote(index)) {
             fourthYOffset = NoteListConstant::unpinnedHeaderToNoteSpace;
         }
         int fifthYOffset = 0;
-        if (model && model->hasPinnedNote() && !m_view->isPinnedNotesCollapsed()
-            && model->isFirstUnpinnedNote(index)) {
+        if ((noteListModel != nullptr) && noteListModel->hasPinnedNote() && !m_view->isPinnedNotesCollapsed() && noteListModel->isFirstUnpinnedNote(index)) {
             fifthYOffset = NoteListConstant::lastPinnedToUnpinnedHeader;
         }
         int yOffsets = fourthYOffset + fifthYOffset;
@@ -123,12 +114,11 @@ NoteListDelegateEditor::NoteListDelegateEditor(const NoteListDelegate *delegate,
         m_tagListView->setGeometry(10, y - 5, rect().width() - 15, m_tagListView->height());
     }
     connect(m_tagListView->verticalScrollBar(), &QScrollBar::valueChanged, this, [this] {
-        auto idx = dynamic_cast<NoteListModel *>(m_view->model())->getNoteIndex(m_id);
-        dynamic_cast<NoteListModel *>(m_view->model())
-                ->setData(idx, getScrollBarPos(), NoteListModel::NoteTagListScrollbarPos);
+        auto idx = static_cast<NoteListModel *>(m_view->model())->getNoteIndex(m_id);
+        static_cast<NoteListModel *>(m_view->model())->setData(idx, getScrollBarPos(), NoteListModel::NoteTagListScrollbarPos);
     });
     QTimer::singleShot(0, this, [this] {
-        auto idx = dynamic_cast<NoteListModel *>(m_view->model())->getNoteIndex(m_id);
+        auto idx = static_cast<NoteListModel *>(m_view->model())->getNoteIndex(m_id);
         setScrollBarPos(idx.data(NoteListModel::NoteTagListScrollbarPos).toInt());
     });
     m_view->setEditorWidget(m_id, this);
@@ -141,8 +131,7 @@ NoteListDelegateEditor::~NoteListDelegateEditor()
     m_view->unsetEditorWidget(m_id, nullptr);
 }
 
-void NoteListDelegateEditor::paintBackground(QPainter *painter, const QStyleOptionViewItem &option,
-                                             const QModelIndex &index) const
+void NoteListDelegateEditor::paintBackground(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
 {
     auto bufferSize = rect().size();
     QPixmap buffer{ bufferSize };
@@ -150,12 +139,10 @@ void NoteListDelegateEditor::paintBackground(QPainter *painter, const QStyleOpti
     QPainter bufferPainter{ &buffer };
     bufferPainter.setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform);
     QRect bufferRect = buffer.rect();
-    auto model = dynamic_cast<NoteListModel *>(m_view->model());
-    if (model && model->hasPinnedNote()
-        && (model->isFirstPinnedNote(index) || model->isFirstUnpinnedNote(index))) {
+    auto const *noteListModel = static_cast<NoteListModel *>(m_view->model());
+    if (noteListModel->hasPinnedNote() && (noteListModel->isFirstPinnedNote(index) || noteListModel->isFirstUnpinnedNote(index))) {
         int fifthYOffset = 0;
-        if (model && model->hasPinnedNote() && !m_view->isPinnedNotesCollapsed()
-            && model->isFirstUnpinnedNote(index)) {
+        if (!m_view->isPinnedNotesCollapsed() && noteListModel->isFirstUnpinnedNote(index)) {
             fifthYOffset = NoteListConstant::lastPinnedToUnpinnedHeader;
         }
         bufferRect.setY(bufferRect.y() + 25 + fifthYOffset);
@@ -186,17 +173,11 @@ void NoteListDelegateEditor::paintBackground(QPainter *painter, const QStyleOpti
             m_tagListView->setBackground(m_hoverColor);
         }
     } else {
-        if (m_view->isPinnedNotesCollapsed() && !isPinned) {
-            bufferPainter.fillRect(bufferRect, QBrush(m_defaultColor));
-            m_tagListView->setBackground(m_defaultColor);
-        } else {
-            bufferPainter.fillRect(bufferRect, QBrush(m_defaultColor));
-            m_tagListView->setBackground(m_defaultColor);
-        }
+        bufferPainter.fillRect(bufferRect, QBrush(m_defaultColor));
+        m_tagListView->setBackground(m_defaultColor);
     }
     if (m_view->isDragging() && !isPinned && !m_view->isDraggingInsidePinned()) {
-        if (model && model->isFirstUnpinnedNote(index)
-            && (index.row() == (model->rowCount() - 1))) {
+        if ((noteListModel != nullptr) && noteListModel->isFirstUnpinnedNote(index) && (index.row() == (noteListModel->rowCount() - 1))) {
             auto rect = bufferRect;
             rect.setHeight(4);
             bufferPainter.fillRect(rect, QBrush("#d6d5d5"));
@@ -209,7 +190,7 @@ void NoteListDelegateEditor::paintBackground(QPainter *painter, const QStyleOpti
             rect = bufferRect;
             rect.setTop(rect.bottom() - 3);
             bufferPainter.fillRect(rect, QBrush("#d6d5d5"));
-        } else if (model && model->isFirstUnpinnedNote(index)) {
+        } else if ((noteListModel != nullptr) && noteListModel->isFirstUnpinnedNote(index)) {
             auto rect = bufferRect;
             rect.setHeight(4);
             bufferPainter.fillRect(rect, QBrush("#d6d5d5"));
@@ -219,7 +200,7 @@ void NoteListDelegateEditor::paintBackground(QPainter *painter, const QStyleOpti
             rect = bufferRect;
             rect.setLeft(rect.right() - 3);
             bufferPainter.fillRect(rect, QBrush("#d6d5d5"));
-        } else if (model && (index.row() == (model->rowCount() - 1))) {
+        } else if ((noteListModel != nullptr) && (index.row() == (noteListModel->rowCount() - 1))) {
             auto rect = bufferRect;
             rect.setTop(rect.bottom() - 3);
             bufferPainter.fillRect(rect, QBrush("#d6d5d5"));
@@ -238,28 +219,24 @@ void NoteListDelegateEditor::paintBackground(QPainter *painter, const QStyleOpti
             bufferPainter.fillRect(rect, QBrush("#d6d5d5"));
         }
     }
-    if (model && m_delegate && m_delegate->shouldPaintSeparator(index, *model)) {
+    if ((noteListModel != nullptr) && (m_delegate != nullptr) && m_delegate->shouldPaintSeparator(index, *noteListModel)) {
         paintSeparator(&bufferPainter, option, index);
     }
 
     auto rowHeight = rect().height();
-    painter->drawPixmap(rect(), buffer,
-                        QRect{ 0, bufferSize.height() - rowHeight, rect().width(), rowHeight });
+    painter->drawPixmap(rect(), buffer, QRect{ 0, bufferSize.height() - rowHeight, rect().width(), rowHeight });
 }
 
-void NoteListDelegateEditor::paintLabels(QPainter *painter, const QStyleOptionViewItem &option,
-                                         const QModelIndex &index) const
+void NoteListDelegateEditor::paintLabels(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
 {
     Q_UNUSED(option);
 
     QString title{ index.data(NoteListModel::NoteFullTitle).toString() };
-    QFont titleFont =
-            m_view->selectionModel()->isSelected(index) ? m_titleSelectedFont : m_titleFont;
+    QFont titleFont = m_view->selectionModel()->isSelected(index) ? m_titleSelectedFont : m_titleFont;
     QFontMetrics fmTitle(titleFont);
     QRect fmRectTitle = fmTitle.boundingRect(title);
 
-    QString date =
-            parseDateTime(index.data(NoteListModel::NoteLastModificationDateTime).toDateTime());
+    QString date = parseDateTime(index.data(NoteListModel::NoteLastModificationDateTime).toDateTime());
     QFontMetrics fmDate(m_dateFont);
     QRect fmRectDate = fmDate.boundingRect(date);
 
@@ -275,23 +252,20 @@ void NoteListDelegateEditor::paintLabels(QPainter *painter, const QStyleOptionVi
     double rowPosX = rect().x();
     double rowPosY = rect().y();
     double rowWidth = rect().width();
-    auto model = dynamic_cast<NoteListModel *>(m_view->model());
+    auto const *noteListModel = static_cast<NoteListModel *>(m_view->model());
     int fifthYOffset = 0;
-    if (model && model->hasPinnedNote() && !m_view->isPinnedNotesCollapsed()
-        && model->isFirstUnpinnedNote(index)) {
+    if (noteListModel->hasPinnedNote() && !m_view->isPinnedNotesCollapsed() && noteListModel->isFirstUnpinnedNote(index)) {
         fifthYOffset = NoteListConstant::lastPinnedToUnpinnedHeader;
     }
-    if (model && model->hasPinnedNote()) {
-        if (model->isFirstPinnedNote(index)) {
-            QRect headerRect(rowPosX + NoteListConstant::leftOffsetX / 2, rowPosY,
-                             rowWidth - NoteListConstant::leftOffsetX / 2, 25);
+    if (noteListModel->hasPinnedNote()) {
+        if (noteListModel->isFirstPinnedNote(index)) {
+            QRect headerRect(rowPosX + (NoteListConstant::leftOffsetX / 2), rowPosY, rowWidth - (NoteListConstant::leftOffsetX / 2), 25);
 #ifdef __APPLE__
             int iconPointSizeOffset = 0;
 #else
             int iconPointSizeOffset = -4;
 #endif
-            painter->setFont(font_loader::loadFont("Font Awesome 6 Free Solid", "",
-                                                                14 + iconPointSizeOffset));
+            painter->setFont(font_loader::loadFont("Font Awesome 6 Free Solid", "", 14 + iconPointSizeOffset));
             painter->setPen(QColor(68, 138, 201));
             if (m_view->isPinnedNotesCollapsed()) {
                 painter->drawText(QRect(headerRect.right() - 25, headerRect.y() + 5, 16, 16),
@@ -304,10 +278,9 @@ void NoteListDelegateEditor::paintLabels(QPainter *painter, const QStyleOptionVi
             painter->setFont(m_headerFont);
             painter->drawText(headerRect, Qt::AlignLeft | Qt::AlignVCenter, "Pinned");
             rowPosY += 25;
-        } else if (model->isFirstUnpinnedNote(index)) {
+        } else if (noteListModel->isFirstUnpinnedNote(index)) {
             rowPosY += fifthYOffset;
-            QRect headerRect(rowPosX + NoteListConstant::leftOffsetX / 2, rowPosY,
-                             rowWidth - NoteListConstant::leftOffsetX / 2, 25);
+            QRect headerRect(rowPosX + (NoteListConstant::leftOffsetX / 2), rowPosY, rowWidth - (NoteListConstant::leftOffsetX / 2), 25);
             painter->setPen(m_contentColor);
             painter->setFont(m_headerFont);
             painter->drawText(headerRect, Qt::AlignLeft | Qt::AlignVCenter, "Notes");
@@ -325,29 +298,28 @@ void NoteListDelegateEditor::paintLabels(QPainter *painter, const QStyleOptionVi
         secondYOffset = NoteListConstant::nextNoteOffset;
     }
     int thirdYOffset = 0;
-    if (model && model->isFirstPinnedNote(index)) {
+    if ((noteListModel != nullptr) && noteListModel->isFirstPinnedNote(index)) {
         thirdYOffset = NoteListConstant::pinnedHeaderToNoteSpace;
     }
     int fourthYOffset = 0;
-    if (model && model->isFirstUnpinnedNote(index)) {
+    if ((noteListModel != nullptr) && noteListModel->isFirstUnpinnedNote(index)) {
         fourthYOffset = NoteListConstant::unpinnedHeaderToNoteSpace;
     }
 
     int yOffsets = secondYOffset + thirdYOffset + fourthYOffset;
     double titleRectPosX = rowPosX + NoteListConstant::leftOffsetX;
     double titleRectPosY = rowPosY;
-    double titleRectWidth = rowWidth - 2.0 * NoteListConstant::leftOffsetX;
+    double titleRectWidth = rowWidth - (2.0 * NoteListConstant::leftOffsetX);
     double titleRectHeight = fmRectTitle.height() + NoteListConstant::topOffsetY + yOffsets;
 
     double dateRectPosX = rowPosX + NoteListConstant::leftOffsetX;
     double dateRectPosY = rowPosY + fmRectTitle.height() + NoteListConstant::topOffsetY + yOffsets;
-    double dateRectWidth = rowWidth - 2.0 * NoteListConstant::leftOffsetX;
+    double dateRectWidth = rowWidth - (2.0 * NoteListConstant::leftOffsetX);
     double dateRectHeight = fmRectDate.height() + NoteListConstant::titleDateSpace;
 
     double contentRectPosX = rowPosX + NoteListConstant::leftOffsetX;
-    double contentRectPosY = rowPosY + fmRectTitle.height() + fmRectDate.height()
-            + NoteListConstant::topOffsetY + yOffsets;
-    double contentRectWidth = rowWidth - 2.0 * NoteListConstant::leftOffsetX;
+    double contentRectPosY = rowPosY + fmRectTitle.height() + fmRectDate.height() + NoteListConstant::topOffsetY + yOffsets;
+    double contentRectWidth = rowWidth - (2.0 * NoteListConstant::leftOffsetX);
     double contentRectHeight = fmRectContent.height() + NoteListConstant::dateDescSpace;
 
     double folderNameRectPosX = 0;
@@ -357,13 +329,11 @@ void NoteListDelegateEditor::paintLabels(QPainter *painter, const QStyleOptionVi
 
     if (m_delegate->isInAllNotes()) {
         folderNameRectPosX = rowPosX + NoteListConstant::leftOffsetX + 20;
-        folderNameRectPosY = rowPosY + fmRectContent.height() + fmRectTitle.height()
-                + fmRectDate.height() + NoteListConstant::topOffsetY + yOffsets;
+        folderNameRectPosY = rowPosY + fmRectContent.height() + fmRectTitle.height() + fmRectDate.height() + NoteListConstant::topOffsetY + yOffsets;
         folderNameRectWidth = rowWidth - 2.0 * NoteListConstant::leftOffsetX;
         folderNameRectHeight = fmRectParentName.height() + NoteListConstant::descFolderSpace;
     }
-    auto drawStr = [painter](double posX, double posY, double width, double height, QColor color,
-                             const QFont &font, const QString &str) {
+    auto drawStr = [painter](double posX, double posY, double width, double height, QColor color, const QFont &font, const QString &str) {
         QRectF rect(posX, posY, width, height);
         painter->setPen(color);
         painter->setFont(font);
@@ -373,23 +343,16 @@ void NoteListDelegateEditor::paintLabels(QPainter *painter, const QStyleOptionVi
     // draw title & date
     title = fmTitle.elidedText(title, Qt::ElideRight, int(titleRectWidth));
     content = fmContent.elidedText(content, Qt::ElideRight, int(titleRectWidth));
-    drawStr(titleRectPosX, titleRectPosY, titleRectWidth, titleRectHeight, m_titleColor, titleFont,
-            title);
-    drawStr(dateRectPosX, dateRectPosY, dateRectWidth, dateRectHeight, m_dateColor, m_dateFont,
-            date);
+    drawStr(titleRectPosX, titleRectPosY, titleRectWidth, titleRectHeight, m_titleColor, titleFont, title);
+    drawStr(dateRectPosX, dateRectPosY, dateRectWidth, dateRectHeight, m_dateColor, m_dateFont, date);
     if (m_delegate->isInAllNotes()) {
-        painter->drawImage(QRect(rowPosX + NoteListConstant::leftOffsetX,
-                                 folderNameRectPosY + NoteListConstant::descFolderSpace, 16, 16),
-                           m_folderIcon);
-        drawStr(folderNameRectPosX, folderNameRectPosY, folderNameRectWidth, folderNameRectHeight,
-                m_contentColor, titleFont, parentName);
+        painter->drawImage(QRect(rowPosX + NoteListConstant::leftOffsetX, folderNameRectPosY + NoteListConstant::descFolderSpace, 16, 16), m_folderIcon);
+        drawStr(folderNameRectPosX, folderNameRectPosY, folderNameRectWidth, folderNameRectHeight, m_contentColor, titleFont, parentName);
     }
-    drawStr(contentRectPosX, contentRectPosY, contentRectWidth, contentRectHeight, m_contentColor,
-            titleFont, content);
+    drawStr(contentRectPosX, contentRectPosY, contentRectWidth, contentRectHeight, m_contentColor, titleFont, content);
 }
 
-void NoteListDelegateEditor::paintSeparator(QPainter *painter, const QStyleOptionViewItem &option,
-                                            const QModelIndex &index) const
+void NoteListDelegateEditor::paintSeparator(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
 {
     Q_UNUSED(index)
     Q_UNUSED(option);
@@ -411,9 +374,11 @@ QString NoteListDelegateEditor::parseDateTime(const QDateTime &dateTime) const
 
     if (dateTime.date() == currDateTime.date()) {
         return usLocale.toString(dateTime.time(), "h:mm A");
-    } else if (dateTime.daysTo(currDateTime) == 1) {
+    }
+    if (dateTime.daysTo(currDateTime) == 1) {
         return "Yesterday";
-    } else if (dateTime.daysTo(currDateTime) >= 2 && dateTime.daysTo(currDateTime) <= 7) {
+    }
+    if (dateTime.daysTo(currDateTime) >= 2 && dateTime.daysTo(currDateTime) <= 7) {
         return usLocale.toString(dateTime.date(), "dddd");
     }
 
@@ -433,9 +398,9 @@ QPixmap NoteListDelegateEditor::renderToPixmap()
     painter.setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform);
     QStyleOptionViewItem opt = m_option;
     opt.rect.setWidth(m_option.rect.width() - m_rowRightOffset);
-    auto m_index = dynamic_cast<NoteListModel *>(m_view->model())->getNoteIndex(m_id);
-    paintBackground(&painter, opt, m_index);
-    paintLabels(&painter, m_option, m_index);
+    auto const idx = static_cast<NoteListModel *>(m_view->model())->getNoteIndex(m_id);
+    paintBackground(&painter, opt, idx);
+    paintLabels(&painter, m_option, idx);
     return result;
 }
 
@@ -445,9 +410,9 @@ void NoteListDelegateEditor::paintEvent(QPaintEvent *event)
     painter.setRenderHint(QPainter::Antialiasing);
     QStyleOptionViewItem opt = m_option;
     opt.rect.setWidth(m_option.rect.width() - m_rowRightOffset);
-    auto m_index = dynamic_cast<NoteListModel *>(m_view->model())->getNoteIndex(m_id);
-    paintBackground(&painter, opt, m_index);
-    paintLabels(&painter, m_option, m_index);
+    auto const idx = static_cast<NoteListModel *>(m_view->model())->getNoteIndex(m_id);
+    paintBackground(&painter, opt, idx);
+    paintLabels(&painter, m_option, idx);
     QWidget::paintEvent(event);
 }
 
@@ -456,52 +421,43 @@ void NoteListDelegateEditor::resizeEvent(QResizeEvent *event)
     QWidget::resizeEvent(event);
     if (m_delegate->isInAllNotes()) {
         int y = 90;
-        auto model = dynamic_cast<NoteListModel *>(m_view->model());
-        if (model) {
-            auto m_index = model->getNoteIndex(m_id);
-            if (model->hasPinnedNote()
-                && (model->isFirstPinnedNote(m_index) || model->isFirstUnpinnedNote(m_index))) {
-                y += 25;
-            }
-            int fourthYOffset = 0;
-            if (model && model->isFirstUnpinnedNote(m_index)) {
-                fourthYOffset = NoteListConstant::unpinnedHeaderToNoteSpace;
-            }
-            int fifthYOffset = 0;
-            if (model && model->hasPinnedNote() && !m_view->isPinnedNotesCollapsed()
-                && model->isFirstUnpinnedNote(m_index)) {
-                fifthYOffset = NoteListConstant::lastPinnedToUnpinnedHeader;
-            }
-            int yOffsets = fourthYOffset + fifthYOffset;
-
-            y += yOffsets;
+        auto const *noteListModel = static_cast<NoteListModel *>(m_view->model());
+        auto const idx = noteListModel->getNoteIndex(m_id);
+        if (noteListModel->hasPinnedNote() && (noteListModel->isFirstPinnedNote(idx) || noteListModel->isFirstUnpinnedNote(idx))) {
+            y += 25;
         }
-        m_tagListView->setGeometry(NoteListConstant::leftOffsetX - 5, y + 5, rect().width() - 15,
-                                   m_tagListView->height());
+        int fourthYOffset = 0;
+        if (noteListModel->isFirstUnpinnedNote(idx)) {
+            fourthYOffset = NoteListConstant::unpinnedHeaderToNoteSpace;
+        }
+        int fifthYOffset = 0;
+        if (noteListModel->hasPinnedNote() && !m_view->isPinnedNotesCollapsed() && noteListModel->isFirstUnpinnedNote(idx)) {
+            fifthYOffset = NoteListConstant::lastPinnedToUnpinnedHeader;
+        }
+        int yOffsets = fourthYOffset + fifthYOffset;
+        y += yOffsets;
+
+        m_tagListView->setGeometry(NoteListConstant::leftOffsetX - 5, y + 5, rect().width() - 15, m_tagListView->height());
     } else {
         int y = 70;
-        auto model = dynamic_cast<NoteListModel *>(m_view->model());
-        if (model) {
-            auto m_index = model->getNoteIndex(m_id);
-            if (model->hasPinnedNote()
-                && (model->isFirstPinnedNote(m_index) || model->isFirstUnpinnedNote(m_index))) {
-                y += 25;
-            }
-            int fourthYOffset = 0;
-            if (model && model->isFirstUnpinnedNote(m_index)) {
-                fourthYOffset = NoteListConstant::unpinnedHeaderToNoteSpace;
-            }
-            int fifthYOffset = 0;
-            if (model && model->hasPinnedNote() && !m_view->isPinnedNotesCollapsed()
-                && model->isFirstUnpinnedNote(m_index)) {
-                fifthYOffset = NoteListConstant::lastPinnedToUnpinnedHeader;
-            }
-            int yOffsets = fourthYOffset + fifthYOffset;
-
-            y += yOffsets;
+        auto const *noteListModel = static_cast<NoteListModel *>(m_view->model());
+        auto const idx = noteListModel->getNoteIndex(m_id);
+        if (noteListModel->hasPinnedNote() && (noteListModel->isFirstPinnedNote(idx) || noteListModel->isFirstUnpinnedNote(idx))) {
+            y += 25;
         }
-        m_tagListView->setGeometry(NoteListConstant::leftOffsetX - 5, y, rect().width() - 15,
-                                   m_tagListView->height());
+        int fourthYOffset = 0;
+        if (noteListModel->isFirstUnpinnedNote(idx)) {
+            fourthYOffset = NoteListConstant::unpinnedHeaderToNoteSpace;
+        }
+        int fifthYOffset = 0;
+        if (noteListModel->hasPinnedNote() && !m_view->isPinnedNotesCollapsed() && noteListModel->isFirstUnpinnedNote(idx)) {
+            fifthYOffset = NoteListConstant::lastPinnedToUnpinnedHeader;
+        }
+        int yOffsets = fourthYOffset + fifthYOffset;
+
+        y += yOffsets;
+
+        m_tagListView->setGeometry(NoteListConstant::leftOffsetX - 5, y, rect().width() - 15, m_tagListView->height());
     }
     recalculateSize();
 }
@@ -532,12 +488,11 @@ void NoteListDelegateEditor::leaveEvent(QEvent *event)
 
 void NoteListDelegateEditor::dropEvent(QDropEvent *event)
 {
-    auto model = dynamic_cast<NoteListModel *>(m_view->model());
-    if (model) {
-        auto index = model->getNoteIndex(m_id);
+    auto *noteListModel = static_cast<NoteListModel *>(m_view->model());
+    if (noteListModel != nullptr) {
+        auto index = noteListModel->getNoteIndex(m_id);
         if (index.isValid()) {
-            model->dropMimeData(event->mimeData(), event->proposedAction(), index.row(), 0,
-                                QModelIndex());
+            noteListModel->dropMimeData(event->mimeData(), event->proposedAction(), index.row(), 0, QModelIndex());
         }
     }
 }
@@ -557,52 +512,48 @@ void NoteListDelegateEditor::recalculateSize()
     }
     result.setHeight(result.height() + m_tagListView->height() + 2);
     result.setWidth(rect().width());
-    auto model = dynamic_cast<NoteListModel *>(m_view->model());
-    if (model) {
-        auto m_index = model->getNoteIndex(m_id);
-        if (model->hasPinnedNote()
-            && (model->isFirstPinnedNote(m_index) || model->isFirstUnpinnedNote(m_index))) {
-            result.setHeight(result.height() + 25);
-        }
-        if (model->hasPinnedNote() && m_view->isPinnedNotesCollapsed()) {
-            auto isPinned = m_index.data(NoteListModel::NoteIsPinned).value<bool>();
-            if (isPinned) {
-                if (model->isFirstPinnedNote(m_index)) {
-                    result.setHeight(25);
-                } else {
-                    result.setHeight(0);
-                }
-            } /*else if (model->hasPinnedNote() && model->isFirstUnpinnedNote(m_index)) {
-                result.setHeight(result.height() + 25);
-            }*/
-        }
-        int secondYOffset = 0;
-        if (m_index.row() > 0) {
-            secondYOffset = NoteListConstant::nextNoteOffset;
-        }
-        int thirdYOffset = 0;
-        if (model && model->isFirstPinnedNote(m_index)) {
-            thirdYOffset = NoteListConstant::pinnedHeaderToNoteSpace;
-        }
-        int fourthYOffset = 0;
-        if (model && model->isFirstUnpinnedNote(m_index)) {
-            fourthYOffset = NoteListConstant::unpinnedHeaderToNoteSpace;
-        }
-
-        int fifthYOffset = 0;
-        if (model && model->hasPinnedNote() && !m_view->isPinnedNotesCollapsed()
-            && model->isFirstUnpinnedNote(m_index)) {
-            fifthYOffset = NoteListConstant::lastPinnedToUnpinnedHeader;
-        }
-
-        int yOffsets = secondYOffset + thirdYOffset + fourthYOffset + fifthYOffset;
-        if (m_delegate->isInAllNotes()) {
-            result.setHeight(result.height() - 2 + NoteListConstant::lastElSepSpace + yOffsets);
-        } else {
-            result.setHeight(result.height() - 10 + NoteListConstant::lastElSepSpace + yOffsets);
-        }
-        emit updateSizeHint(m_id, result, m_index);
+    auto const *noteListModel = static_cast<NoteListModel *>(m_view->model());
+    auto idx = noteListModel->getNoteIndex(m_id);
+    if (noteListModel->hasPinnedNote() && (noteListModel->isFirstPinnedNote(idx) || noteListModel->isFirstUnpinnedNote(idx))) {
+        result.setHeight(result.height() + 25);
     }
+    if (noteListModel->hasPinnedNote() && m_view->isPinnedNotesCollapsed()) {
+        auto isPinned = idx.data(NoteListModel::NoteIsPinned).value<bool>();
+        if (isPinned) {
+            if (noteListModel->isFirstPinnedNote(idx)) {
+                result.setHeight(25);
+            } else {
+                result.setHeight(0);
+            }
+        } /*else if (model->hasPinnedNote() && model->isFirstUnpinnedNote(m_index)) {
+            result.setHeight(result.height() + 25);
+        }*/
+    }
+    int secondYOffset = 0;
+    if (idx.row() > 0) {
+        secondYOffset = NoteListConstant::nextNoteOffset;
+    }
+    int thirdYOffset = 0;
+    if (noteListModel->isFirstPinnedNote(idx)) {
+        thirdYOffset = NoteListConstant::pinnedHeaderToNoteSpace;
+    }
+    int fourthYOffset = 0;
+    if (noteListModel->isFirstUnpinnedNote(idx)) {
+        fourthYOffset = NoteListConstant::unpinnedHeaderToNoteSpace;
+    }
+
+    int fifthYOffset = 0;
+    if (noteListModel->hasPinnedNote() && !m_view->isPinnedNotesCollapsed() && noteListModel->isFirstUnpinnedNote(idx)) {
+        fifthYOffset = NoteListConstant::lastPinnedToUnpinnedHeader;
+    }
+
+    int yOffsets = secondYOffset + thirdYOffset + fourthYOffset + fifthYOffset;
+    if (m_delegate->isInAllNotes()) {
+        result.setHeight(result.height() - 2 + NoteListConstant::lastElSepSpace + yOffsets);
+    } else {
+        result.setHeight(result.height() - 10 + NoteListConstant::lastElSepSpace + yOffsets);
+    }
+    emit updateSizeHint(m_id, result, idx);
 }
 
 void NoteListDelegateEditor::setScrollBarPos(int pos)

--- a/src/notelistdelegateeditor.h
+++ b/src/notelistdelegateeditor.h
@@ -11,19 +11,18 @@ class TagListModel;
 class TagListView;
 class TagListDelegate;
 class NoteListModel;
-struct NoteListConstant
-{
-    static constexpr int leftOffsetX = 20;
-    static constexpr int topOffsetY = 10; // space on top of title
-    static constexpr int titleDateSpace = 2; // space between title and date
-    static constexpr int dateDescSpace = 5; // space between date and description
-    static constexpr int descFolderSpace = 14; // space between description and folder name
-    static constexpr int lastElSepSpace = 12; // space between the last element and the separator
-    static constexpr int nextNoteOffset = 0; // space between the separator and the next note underneath it
-    static constexpr int pinnedHeaderToNoteSpace = 0; // space between Pinned label to the pinned list
-    static constexpr int unpinnedHeaderToNoteSpace = 0; // space between Notes label and the normal notes list
-    static constexpr int lastPinnedToUnpinnedHeader = 10; // space between the last pinned note to Notes label
-};
+namespace note_list_constants {
+auto constexpr LEFT_OFFSET_X = 20;
+auto constexpr TOP_OFFSET_Y = 10; // space on top of title
+auto constexpr TITLE_DATE_SPACE = 2; // space between title and date
+auto constexpr DATE_DESC_SPACE = 5; // space between date and description
+auto constexpr DESC_FOLDER_SPACE = 14; // space between description and folder name
+auto constexpr LAST_EL_SEP_SPACE = 12; // space between the last element and the separator
+auto constexpr NEXT_NOTE_OFFSET = 0; // space between the separator and the next note underneath it
+auto constexpr PINNED_HEADER_TO_NOTE_SPACE = 0; // space between Pinned label to the pinned list
+auto constexpr UNPINNED_HEADER_TO_NOTE_SPACE = 0; // space between Notes label and the normal notes list
+auto constexpr LAST_PINNED_TO_UNPINNED_HEADER = 10; // space between the last pinned note to Notes label
+} // namespace note_list_constants
 
 class NoteListDelegateEditor : public QWidget
 {
@@ -31,7 +30,7 @@ class NoteListDelegateEditor : public QWidget
 public:
     explicit NoteListDelegateEditor(const NoteListDelegate *delegate, NoteListView *view, const QStyleOptionViewItem &option, const QModelIndex &index,
                                     TagPool *tagPool, QWidget *parent = nullptr);
-    ~NoteListDelegateEditor();
+    ~NoteListDelegateEditor() override;
 
     void setRowRightOffset(int rowRightOffset);
     void setActive(bool isActive);
@@ -51,7 +50,6 @@ private:
     void paintBackground(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
     void paintLabels(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
     void paintSeparator(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
-    QString parseDateTime(const QDateTime &dateTime) const;
 
     const NoteListDelegate *m_delegate;
     QStyleOptionViewItem m_option;
@@ -67,7 +65,7 @@ private:
     QColor m_titleColor;
     QColor m_dateColor;
     QColor m_contentColor;
-    QColor m_ActiveColor;
+    QColor m_activeColor;
     QColor m_notActiveColor;
     QColor m_hoverColor;
     QColor m_applicationInactiveColor;
@@ -86,14 +84,14 @@ private:
     TagListDelegate *m_tagListDelegate;
     // QWidget interface
 protected:
-    virtual void paintEvent(QPaintEvent *event) override;
-    virtual void resizeEvent(QResizeEvent *event) override;
-    virtual void dragEnterEvent(QDragEnterEvent *event) override;
-    virtual void dragLeaveEvent(QDragLeaveEvent *event) override;
-    virtual void enterEvent(QEnterEvent *event) override;
+    void paintEvent(QPaintEvent *event) override;
+    void resizeEvent(QResizeEvent *event) override;
+    void dragEnterEvent(QDragEnterEvent *event) override;
+    void dragLeaveEvent(QDragLeaveEvent *event) override;
+    void enterEvent(QEnterEvent *event) override;
 
-    virtual void leaveEvent(QEvent *event) override;
-    virtual void dropEvent(QDropEvent *event) override;
+    void leaveEvent(QEvent *event) override;
+    void dropEvent(QDropEvent *event) override;
 };
 
 #endif // NOTELISTDELEGATEEDITOR_H

--- a/src/notelistdelegateeditor.h
+++ b/src/notelistdelegateeditor.h
@@ -19,22 +19,17 @@ struct NoteListConstant
     static constexpr int dateDescSpace = 5; // space between date and description
     static constexpr int descFolderSpace = 14; // space between description and folder name
     static constexpr int lastElSepSpace = 12; // space between the last element and the separator
-    static constexpr int nextNoteOffset =
-            0; // space between the separator and the next note underneath it
-    static constexpr int pinnedHeaderToNoteSpace =
-            0; // space between Pinned label to the pinned list
-    static constexpr int unpinnedHeaderToNoteSpace =
-            0; // space between Notes label and the normal notes list
-    static constexpr int lastPinnedToUnpinnedHeader =
-            10; // space between the last pinned note to Notes label
+    static constexpr int nextNoteOffset = 0; // space between the separator and the next note underneath it
+    static constexpr int pinnedHeaderToNoteSpace = 0; // space between Pinned label to the pinned list
+    static constexpr int unpinnedHeaderToNoteSpace = 0; // space between Notes label and the normal notes list
+    static constexpr int lastPinnedToUnpinnedHeader = 10; // space between the last pinned note to Notes label
 };
 
 class NoteListDelegateEditor : public QWidget
 {
     Q_OBJECT
 public:
-    explicit NoteListDelegateEditor(const NoteListDelegate *delegate, NoteListView *view,
-                                    const QStyleOptionViewItem &option, const QModelIndex &index,
+    explicit NoteListDelegateEditor(const NoteListDelegate *delegate, NoteListView *view, const QStyleOptionViewItem &option, const QModelIndex &index,
                                     TagPool *tagPool, QWidget *parent = nullptr);
     ~NoteListDelegateEditor();
 
@@ -53,12 +48,9 @@ signals:
     void nearDestroyed(int id, const QModelIndex &index);
 
 private:
-    void paintBackground(QPainter *painter, const QStyleOptionViewItem &option,
-                         const QModelIndex &index) const;
-    void paintLabels(QPainter *painter, const QStyleOptionViewItem &option,
-                     const QModelIndex &index) const;
-    void paintSeparator(QPainter *painter, const QStyleOptionViewItem &option,
-                        const QModelIndex &index) const;
+    void paintBackground(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
+    void paintLabels(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
+    void paintSeparator(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
     QString parseDateTime(const QDateTime &dateTime) const;
 
     const NoteListDelegate *m_delegate;

--- a/src/notelistmodel.cpp
+++ b/src/notelistmodel.cpp
@@ -90,7 +90,7 @@ void NoteListModel::setListNote(const QVector<NodeData> &notes, const ListViewIn
     m_pinnedList.clear();
     m_noteList.clear();
     m_listViewInfo = inf;
-    if ((!m_listViewInfo.isInTag) && (m_listViewInfo.parentFolderId != SpecialNodeID::TrashFolder)) {
+    if ((!m_listViewInfo.isInTag) && (m_listViewInfo.parentFolderId != TRASH_FOLDER_ID)) {
         for (const auto &note : std::as_const(notes)) {
             if (note.isPinnedNote()) {
                 m_pinnedList.append(note);
@@ -249,7 +249,7 @@ void NoteListModel::sort(int column, Qt::SortOrder order)
 {
     Q_UNUSED(column)
     Q_UNUSED(order)
-    if (m_listViewInfo.parentFolderId == SpecialNodeID::TrashFolder) {
+    if (m_listViewInfo.parentFolderId == TRASH_FOLDER_ID) {
         std::stable_sort(m_noteList.begin(), m_noteList.end(),
                          [](const NodeData &lhs, const NodeData &rhs) { return lhs.deletionDateTime() > rhs.deletionDateTime(); });
     } else {
@@ -296,7 +296,7 @@ void NoteListModel::updatePinnedRelativePosition()
 
 bool NoteListModel::isInAllNote() const
 {
-    return (!m_listViewInfo.isInTag) && (m_listViewInfo.parentFolderId == SpecialNodeID::RootFolder);
+    return (!m_listViewInfo.isInTag) && (m_listViewInfo.parentFolderId == ROOT_FOLDER_ID);
 }
 
 NodeData &NoteListModel::getRef(int row)
@@ -420,7 +420,7 @@ bool NoteListModel::dropMimeData(const QMimeData *mime, Qt::DropAction action, i
             note.setIsPinnedNote(false);
             emit requestUpdatePinned(note.id(), false);
             int destinationChild = 0;
-            if (m_listViewInfo.parentFolderId == SpecialNodeID::TrashFolder) {
+            if (m_listViewInfo.parentFolderId == TRASH_FOLDER_ID) {
                 auto lastMod = index.data(NoteDeletionDateTime).toDateTime();
                 for (destinationChild = 0; destinationChild < m_noteList.size(); ++destinationChild) {
                     if (m_noteList[destinationChild].deletionDateTime() <= lastMod) {
@@ -464,7 +464,7 @@ QModelIndex NoteListModel::getFirstUnpinnedNote() const
 
 bool NoteListModel::hasPinnedNote() const
 {
-    if ((!m_listViewInfo.isInTag) && (m_listViewInfo.parentFolderId == SpecialNodeID::TrashFolder)) {
+    if ((!m_listViewInfo.isInTag) && (m_listViewInfo.parentFolderId == TRASH_FOLDER_ID)) {
         // Trash don't have pinned note
         return false;
     }
@@ -524,7 +524,7 @@ void NoteListModel::setNotesIsPinned(const QModelIndexList &indexes, bool isPinn
                 continue;
             }
             int destinationChild = 0;
-            if (m_listViewInfo.parentFolderId == SpecialNodeID::TrashFolder) {
+            if (m_listViewInfo.parentFolderId == TRASH_FOLDER_ID) {
                 auto lastMod = index.data(NoteDeletionDateTime).toDateTime();
                 for (destinationChild = 0; destinationChild < m_noteList.size(); ++destinationChild) {
                     const auto &note = m_noteList[destinationChild];

--- a/src/notelistmodel.h
+++ b/src/notelistmodel.h
@@ -9,7 +9,7 @@ class NoteListModel : public QAbstractListModel
 {
     Q_OBJECT
 public:
-    enum NoteRoles {
+    enum NoteRoles : uint16_t {
         NoteID = Qt::UserRole + 1,
         NoteFullTitle,
         NoteCreationDateTime,
@@ -25,7 +25,7 @@ public:
     };
 
     explicit NoteListModel(QObject *parent = nullptr);
-    ~NoteListModel();
+    ~NoteListModel() override = default;
 
     QModelIndex addNote(const NodeData &note);
     QModelIndex insertNote(const NodeData &note, int row);

--- a/src/notelistmodel.h
+++ b/src/notelistmodel.h
@@ -33,8 +33,7 @@ public:
     QModelIndex getNoteIndex(int id) const;
     void setListNote(const QVector<NodeData> &notes, const ListViewInfo &inf);
     void removeNotes(const QModelIndexList &noteIndexes);
-    bool moveRow(const QModelIndex &sourceParent, int sourceRow,
-                 const QModelIndex &destinationParent, int destinationChild);
+    bool moveRow(const QModelIndex &sourceParent, int sourceRow, const QModelIndex &destinationParent, int destinationChild);
 
     void clearNotes();
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
@@ -44,12 +43,11 @@ public:
     void sort(int column, Qt::SortOrder order) override;
     void setNoteData(const QModelIndex &index, const NodeData &note);
 
-    virtual Qt::DropActions supportedDropActions() const override;
-    virtual Qt::DropActions supportedDragActions() const override;
-    virtual QStringList mimeTypes() const override;
-    virtual QMimeData *mimeData(const QModelIndexList &indexes) const override;
-    virtual bool dropMimeData(const QMimeData *mime, Qt::DropAction action, int row, int column,
-                              const QModelIndex &parent) override;
+    Qt::DropActions supportedDropActions() const override;
+    Qt::DropActions supportedDragActions() const override;
+    QStringList mimeTypes() const override;
+    QMimeData *mimeData(const QModelIndexList &indexes) const override;
+    bool dropMimeData(const QMimeData *mime, Qt::DropAction action, int row, int column, const QModelIndex &parent) override;
 
     bool noteIsHaveTag(const QModelIndex &index) const;
     bool isFirstPinnedNote(const QModelIndex &index) const;

--- a/src/notelistview.cpp
+++ b/src/notelistview.cpp
@@ -32,7 +32,7 @@ NoteListView::NoteListView(QWidget *parent)
       m_rowHeight(38),
       m_tagPool(nullptr),
       m_dbManager(nullptr),
-      m_currentFolderId{ SpecialNodeID::InvalidNodeId },
+      m_currentFolderId{ INVALID_NODE_ID },
       m_isInTrash{ false },
       m_isDragging{ false },
       m_isDraggingPinnedNotes{ false },
@@ -760,7 +760,7 @@ void NoteListView::onCustomContextMenu(QPoint point)
             m_deleteNoteAction->setText(tr("Delete Note"));
         }
         m_contextMenu->addAction(m_deleteNoteAction);
-        if ((!m_listViewInfo.isInTag) && (m_listViewInfo.parentFolderId != SpecialNodeID::TrashFolder)) {
+        if ((!m_listViewInfo.isInTag) && (m_listViewInfo.parentFolderId != TRASH_FOLDER_ID)) {
             m_contextMenu->addSeparator();
             if (notes.size() > 1) {
                 m_pinNoteAction->setText(tr("Pin Notes"));

--- a/src/notelistview.cpp
+++ b/src/notelistview.cpp
@@ -271,7 +271,7 @@ void NoteListView::mouseMoveEvent(QMouseEvent *event)
         QListView::mouseMoveEvent(event);
         return;
     }
-    if (event->buttons() & Qt::LeftButton) {
+    if ((event->buttons() & Qt::LeftButton) != 0U) {
         if ((event->position().toPoint() - m_dragStartPosition).manhattanLength() >= QApplication::startDragDistance()) {
             startDrag(Qt::MoveAction);
         }

--- a/src/notelistview.cpp
+++ b/src/notelistview.cpp
@@ -719,7 +719,7 @@ void NoteListView::onCustomContextMenu(QPoint point)
 #else
                 int iconPointSizeOffset = -4;
 #endif
-                painter.setFont(FontLoader::getInstance().loadFont("Font Awesome 6 Free Solid", "",
+                painter.setFont(font_loader::loadFont("Font Awesome 6 Free Solid", "",
                                                                    24 + iconPointSizeOffset));
                 painter.drawText(iconRect, u8"\uf111"); // fa-circle
                 return QIcon{ pix };

--- a/src/notelistview.h
+++ b/src/notelistview.h
@@ -8,7 +8,7 @@
 
 class TagPool;
 class NoteListViewPrivate;
-enum class NoteListState;
+enum class NoteListState : uint8_t;
 
 enum class ShowAction : uint8_t { NotInit, ShowPin, ShowBoth, ShowUnpin };
 
@@ -18,7 +18,7 @@ class NoteListView : public QListView
 
 public:
     explicit NoteListView(QWidget *parent = nullptr);
-    ~NoteListView();
+    ~NoteListView() override;
 
     void animateAddedRow(const QModelIndexList &indexes);
     void setAnimationEnabled(bool isEnabled);

--- a/src/notelistview.h
+++ b/src/notelistview.h
@@ -10,6 +10,8 @@ class TagPool;
 class NoteListViewPrivate;
 enum class NoteListState;
 
+enum class ShowAction : uint8_t { NotInit, ShowPin, ShowBoth, ShowUnpin };
+
 class NoteListView : public QListView
 {
     Q_OBJECT
@@ -38,7 +40,7 @@ public:
     bool isPinnedNotesCollapsed() const;
     void setIsPinnedNotesCollapsed(bool newIsPinnedNotesCollapsed);
     void setCurrentIndexC(const QModelIndex &index);
-    QModelIndexList selectedIndex() const;
+    QModelIndexList getSelectedIndex() const;
     bool isDraggingInsidePinned() const;
 
 public slots:
@@ -51,13 +53,13 @@ protected:
     void mousePressEvent(QMouseEvent *e) override;
     void mouseReleaseEvent(QMouseEvent *e) override;
     bool viewportEvent(QEvent *e) override;
-    virtual void dragEnterEvent(QDragEnterEvent *event) override;
-    virtual void dragMoveEvent(QDragMoveEvent *event) override;
+    void dragEnterEvent(QDragEnterEvent *event) override;
+    void dragMoveEvent(QDragMoveEvent *event) override;
 
     // QAbstractScrollArea interface
 protected:
-    virtual void scrollContentsBy(int dx, int dy) override;
-    virtual void startDrag(Qt::DropActions supportedActions) override;
+    void scrollContentsBy(int dx, int dy) override;
+    void startDrag(Qt::DropActions supportedActions) override;
 
 public slots:
     void rowsAboutToBeMoved(const QModelIndexList &source);
@@ -86,13 +88,13 @@ private:
     bool m_isMousePressed;
     bool m_mousePressHandled;
     int m_rowHeight;
-    QMenu *contextMenu;
+    QMenu *m_contextMenu;
     QMenu *m_tagsMenu;
-    QAction *deleteNoteAction;
-    QAction *restoreNoteAction;
-    QAction *pinNoteAction;
-    QAction *unpinNoteAction;
-    QAction *newNoteAction;
+    QAction *m_deleteNoteAction;
+    QAction *m_restoreNoteAction;
+    QAction *m_pinNoteAction;
+    QAction *m_unpinNoteAction;
+    QAction *m_newNoteAction;
     TagPool *m_tagPool;
     DBManager *m_dbManager;
     int m_currentFolderId;
@@ -111,16 +113,15 @@ private:
     void setupSignalsSlots();
     void setupStyleSheet();
 
-    void addNotesToTag(QSet<int> notesId, int tagId);
-    void removeNotesFromTag(QSet<int> notesId, int tagId);
+    void addNotesToTag(QSet<int> const &notesId, int tagId);
+    void removeNotesFromTag(QSet<int> const &notesId, int tagId);
 
 private:
     Q_DECLARE_PRIVATE(NoteListView)
 
     // QAbstractItemView interface
 protected slots:
-    void selectionChanged(const QItemSelection &selected,
-                          const QItemSelection &deselected) override;
+    void selectionChanged(const QItemSelection &selected, const QItemSelection &deselected) override;
 };
 
 #endif // NOTELISTVIEW_H

--- a/src/notelistview_p.h
+++ b/src/notelistview_p.h
@@ -1,7 +1,7 @@
-#ifndef NOTELISTVIEW_P_H
-#define NOTELISTVIEW_P_H
-#include <QtWidgets/private/qabstractitemview_p.h>
+#pragma once
 #include "notelistview.h"
+
+#include <QtWidgets/private/qabstractitemview_p.h>
 
 class NoteListViewPrivate : public QAbstractItemViewPrivate
 {
@@ -13,5 +13,3 @@ public:
     QPixmap renderToPixmap(const QModelIndexList &indexes, QRect *r) const;
     QStyleOptionViewItem viewOptionsV1() const;
 };
-
-#endif // NOTELISTVIEW_P_H

--- a/src/notelistview_p.h
+++ b/src/notelistview_p.h
@@ -9,7 +9,7 @@ class NoteListViewPrivate : public QAbstractItemViewPrivate
 
 public:
     NoteListViewPrivate() : QAbstractItemViewPrivate(){};
-    virtual ~NoteListViewPrivate() { }
+    ~NoteListViewPrivate() override = default;
     QPixmap renderToPixmap(const QModelIndexList &indexes, QRect *r) const;
     QStyleOptionViewItem viewOptionsV1() const;
 };

--- a/src/pushbuttontype.cpp
+++ b/src/pushbuttontype.cpp
@@ -6,37 +6,37 @@ PushButtonType::PushButtonType(QWidget *parent) : QPushButton(parent) { }
 bool PushButtonType::event(QEvent *event)
 {
     if (event->type() == QEvent::MouseButtonPress) {
-        setIcon(pressedIcon);
+        setIcon(m_pressedIcon);
     }
     if (event->type() == QEvent::MouseButtonRelease) {
         if (underMouse()) {
-            setIcon(hoveredIcon);
+            setIcon(m_hoveredIcon);
         } else {
-            setIcon(normalIcon);
+            setIcon(m_normalIcon);
         }
     }
     if (event->type() == QEvent::Enter) {
-        setIcon(hoveredIcon);
+        setIcon(m_hoveredIcon);
     }
 
     if (event->type() == QEvent::Leave) {
-        setIcon(normalIcon);
+        setIcon(m_normalIcon);
     }
     return QPushButton::event(event);
 }
 
 void PushButtonType::setPressedIcon(const QIcon &newPressedIcon)
 {
-    pressedIcon = newPressedIcon;
+    m_pressedIcon = newPressedIcon;
 }
 
 void PushButtonType::setHoveredIcon(const QIcon &newHoveredIcon)
 {
-    hoveredIcon = newHoveredIcon;
+    m_hoveredIcon = newHoveredIcon;
 }
 
 void PushButtonType::setNormalIcon(const QIcon &newNormalIcon)
 {
-    normalIcon = newNormalIcon;
+    m_normalIcon = newNormalIcon;
     setIcon(newNormalIcon);
 }

--- a/src/pushbuttontype.h
+++ b/src/pushbuttontype.h
@@ -17,9 +17,9 @@ protected:
     bool event(QEvent *event) override;
 
 private:
-    QIcon normalIcon;
-    QIcon hoveredIcon;
-    QIcon pressedIcon;
+    QIcon m_normalIcon;
+    QIcon m_hoveredIcon;
+    QIcon m_pressedIcon;
 };
 
 #endif // PUSHBUTTONTYPE_H

--- a/src/singleinstance.cpp
+++ b/src/singleinstance.cpp
@@ -7,7 +7,7 @@ SingleInstance::SingleInstance(QObject *parent) : QObject(parent)
 
 void SingleInstance::listen(const QString &name)
 {
-    m_server.removeServer(name);
+    QLocalServer::removeServer(name);
     m_server.listen(name);
 }
 

--- a/src/singleinstance.h
+++ b/src/singleinstance.h
@@ -9,10 +9,10 @@ class SingleInstance : public QObject
 {
     Q_OBJECT
 public:
-    explicit SingleInstance(QObject *parent = 0);
+    explicit SingleInstance(QObject *parent = nullptr);
 
     void listen(const QString &name);
-    bool hasPrevious(const QString &name);
+    static bool hasPrevious(const QString &name);
 
 signals:
     void newInstance();

--- a/src/splitterstyle.cpp
+++ b/src/splitterstyle.cpp
@@ -5,8 +5,7 @@ SplitterStyle::SplitterStyle(QObject *parent) : QProxyStyle()
     setParent(parent); // to ensure proper object destruction
 }
 
-void SplitterStyle::drawControl(ControlElement element, const QStyleOption *opt, QPainter *p,
-                                const QWidget *w) const
+void SplitterStyle::drawControl(ControlElement element, const QStyleOption *opt, QPainter *p, const QWidget *w) const
 {
     if (element != QStyle::CE_Splitter) {
         QProxyStyle::drawControl(element, opt, p, w);

--- a/src/splitterstyle.h
+++ b/src/splitterstyle.h
@@ -7,11 +7,10 @@ class SplitterStyle : public QProxyStyle
 {
     Q_OBJECT
 public:
-    SplitterStyle(QObject *parent);
+    explicit SplitterStyle(QObject *parent);
 
 public:
-    void drawControl(ControlElement element, const QStyleOption *opt, QPainter *p,
-                     const QWidget *w) const override;
+    void drawControl(ControlElement element, const QStyleOption *opt, QPainter *p, const QWidget *w) const override;
 };
 
 #endif // SPLITTERSTYLE_H

--- a/src/tagdata.cpp
+++ b/src/tagdata.cpp
@@ -1,9 +1,6 @@
 #include "tagdata.h"
 
-TagData::TagData()
-    : m_id{ SpecialTagID::InvalidTagId }, m_relativePosition{ -1 }, m_childNotesCount{ 0 }
-{
-}
+TagData::TagData() : m_id{ SpecialTagID::InvalidTagId }, m_relativePosition{ -1 }, m_childNotesCount{ 0 } { }
 
 int TagData::id() const
 {

--- a/src/tagdata.cpp
+++ b/src/tagdata.cpp
@@ -1,6 +1,6 @@
 #include "tagdata.h"
 
-TagData::TagData() : m_id{ SpecialTagID::InvalidTagId }, m_relativePosition{ -1 }, m_childNotesCount{ 0 } { }
+TagData::TagData() : m_id{ INVALID_TAG_ID }, m_relativePosition{ -1 }, m_childNotesCount{ 0 } { }
 
 int TagData::id() const
 {

--- a/src/tagdata.h
+++ b/src/tagdata.h
@@ -4,10 +4,8 @@
 #include <QString>
 #include <QMetaClassInfo>
 
-namespace SpecialTagID {
-enum Value {
-    InvalidTagId = -1,
-};
+namespace {
+auto constexpr INVALID_TAG_ID = -1;
 }
 
 class TagData

--- a/src/taglistdelegate.cpp
+++ b/src/taglistdelegate.cpp
@@ -49,7 +49,7 @@ void TagListDelegate::paint(QPainter *painter, const QStyleOptionViewItem &optio
 #else
     int iconPointSizeOffset = -4;
 #endif
-    painter->setFont(FontLoader::getInstance().loadFont("Font Awesome 6 Free Solid", "",
+    painter->setFont(font_loader::loadFont("Font Awesome 6 Free Solid", "",
                                                         12 + iconPointSizeOffset));
     painter->drawText(iconRect, u8"\uf111"); // fa-circle
     painter->setBrush(m_titleColor);

--- a/src/taglistdelegate.cpp
+++ b/src/taglistdelegate.cpp
@@ -7,12 +7,9 @@
 TagListDelegate::TagListDelegate(QObject *parent)
     : QStyledItemDelegate(parent),
 #ifdef __APPLE__
-      m_displayFont(QFont(QStringLiteral("SF Pro Text")).exactMatch()
-                            ? QStringLiteral("SF Pro Text")
-                            : QStringLiteral("Roboto")),
+      m_displayFont(QFont(QStringLiteral("SF Pro Text")).exactMatch() ? QStringLiteral("SF Pro Text") : QStringLiteral("Roboto")),
 #elif _WIN32
-      m_displayFont(QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI")
-                                                                   : QStringLiteral("Roboto")),
+      m_displayFont(QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI") : QStringLiteral("Roboto")),
 #else
       m_displayFont(QStringLiteral("Roboto")),
 #endif
@@ -26,12 +23,11 @@ TagListDelegate::TagListDelegate(QObject *parent)
 {
 }
 
-void TagListDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option,
-                            const QModelIndex &index) const
+void TagListDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
 {
     painter->setRenderHint(QPainter::Antialiasing);
-    auto name = index.data(TagListModel::NameRole).toString();
-    auto color = index.data(TagListModel::ColorRole).toString();
+    auto name = index.data(static_cast<int>(TagListModel::TagListRole::NameRole)).toString();
+    auto color = index.data(static_cast<int>(TagListModel::TagListRole::ColorRole)).toString();
 
     auto rect = option.rect;
     rect.setHeight(20);
@@ -42,15 +38,14 @@ void TagListDelegate::paint(QPainter *painter, const QStyleOptionViewItem &optio
     } else {
         painter->fillPath(path, QColor(218, 235, 248));
     }
-    auto iconRect = QRect(rect.x() + 5, rect.y() + (rect.height() - 12) / 2, 12, 12);
+    auto iconRect = QRect(rect.x() + 5, rect.y() + ((rect.height() - 12) / 2), 12, 12);
     painter->setPen(QColor(color));
 #ifdef __APPLE__
     int iconPointSizeOffset = 0;
 #else
     int iconPointSizeOffset = -4;
 #endif
-    painter->setFont(font_loader::loadFont("Font Awesome 6 Free Solid", "",
-                                                        12 + iconPointSizeOffset));
+    painter->setFont(font_loader::loadFont("Font Awesome 6 Free Solid", "", 12 + iconPointSizeOffset));
     painter->drawText(iconRect, u8"\uf111"); // fa-circle
     painter->setBrush(m_titleColor);
     painter->setPen(m_titleColor);
@@ -66,7 +61,7 @@ QSize TagListDelegate::sizeHint(const QStyleOptionViewItem &option, const QModel
     Q_UNUSED(option);
     QSize size;
     size.setHeight(20);
-    auto name = index.data(TagListModel::NameRole).toString();
+    auto name = index.data(static_cast<int>(TagListModel::TagListRole::NameRole)).toString();
     QFontMetrics fmName(m_titleFont);
     QRect fmRectName = fmName.boundingRect(name);
     size.setWidth(5 + 12 + 5 + fmRectName.width() + 7);

--- a/src/taglistdelegate.h
+++ b/src/taglistdelegate.h
@@ -12,10 +12,8 @@ public:
 
     // QAbstractItemDelegate interface
 public:
-    virtual void paint(QPainter *painter, const QStyleOptionViewItem &option,
-                       const QModelIndex &index) const override;
-    virtual QSize sizeHint(const QStyleOptionViewItem &option,
-                           const QModelIndex &index) const override;
+    virtual void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+    virtual QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const override;
     void setTheme(Theme::Value theme);
 
 private:

--- a/src/taglistdelegate.h
+++ b/src/taglistdelegate.h
@@ -12,8 +12,8 @@ public:
 
     // QAbstractItemDelegate interface
 public:
-    virtual void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
-    virtual QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+    void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+    QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const override;
     void setTheme(Theme::Value theme);
 
 private:

--- a/src/taglistmodel.cpp
+++ b/src/taglistmodel.cpp
@@ -1,7 +1,6 @@
 #include "taglistmodel.h"
 #include "tagpool.h"
 #include <QDebug>
-#include "nodepath.h"
 
 TagListModel::TagListModel(QObject *parent) : QAbstractListModel(parent), m_tagPool{ nullptr } { }
 
@@ -19,7 +18,7 @@ void TagListModel::setTagPool(TagPool *tagPool)
 
 void TagListModel::setModelData(const QSet<int> &data)
 {
-    if (!m_tagPool) {
+    if (m_tagPool == nullptr) {
         qDebug() << __FUNCTION__ << "Tag pool is not init yet";
         return;
     }
@@ -31,7 +30,7 @@ void TagListModel::setModelData(const QSet<int> &data)
 
 void TagListModel::addTag(int tagId)
 {
-    if (!m_tagPool) {
+    if (m_tagPool == nullptr) {
         qDebug() << __FUNCTION__ << "Tag pool is not init yet";
         return;
     }
@@ -53,17 +52,18 @@ int TagListModel::rowCount(const QModelIndex &parent) const
 QVariant TagListModel::data(const QModelIndex &index, int role) const
 {
     if (!index.isValid()) {
-        return QVariant();
+        return {};
     }
     const TagData &tag = m_data[index.row()];
-    if (role == IdRole) {
+    switch (static_cast<TagListRole>(role)) {
+    case TagListRole::IdRole:
         return tag.id();
-    } else if (role == NameRole) {
+    case TagListRole::NameRole:
         return tag.name();
-    } else if (role == ColorRole) {
+    case TagListRole::ColorRole:
         return tag.color();
     }
-    return QVariant();
+    return {};
 }
 
 void TagListModel::updateTagData()

--- a/src/taglistmodel.h
+++ b/src/taglistmodel.h
@@ -10,13 +10,19 @@ class TagListModel : public QAbstractListModel
 {
     Q_OBJECT
 public:
-    enum TagListRoles { IdRole = Qt::UserRole + 1, NameRole, ColorRole };
-    TagListModel(QObject *parent = nullptr);
+    enum class TagListRole : std::uint16_t {
+        IdRole = Qt::UserRole + 1,
+        NameRole,
+        ColorRole,
+    };
+
+    explicit TagListModel(QObject *parent);
     void setTagPool(TagPool *tagPool);
     void setModelData(const QSet<int> &data);
     void addTag(int tagId);
-    int rowCount(const QModelIndex &parent = QModelIndex()) const;
-    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
+
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
 
 private:
     TagPool *m_tagPool;

--- a/src/taglistview.cpp
+++ b/src/taglistview.cpp
@@ -42,7 +42,7 @@ void TagListView::reset()
 {
     QListView::reset();
     auto sz = sizeHint();
-    if (!model() || model()->rowCount() == 0) {
+    if ((model() == nullptr) || model()->rowCount() == 0) {
         sz.setHeight(0);
     } else {
         auto firstIndex = model()->index(0, 0);

--- a/src/taglistview.cpp
+++ b/src/taglistview.cpp
@@ -25,16 +25,15 @@ void TagListView::setBackground(const QColor color)
 {
     if (m_backgroundColor != color) {
         m_backgroundColor = color;
-        QString ss = QStringLiteral(
-                R"(QListView { background: %1; } )"
-                R"(QScrollBar::handle:vertical:hover { background: rgb(170, 170, 171); } )"
-                R"(QScrollBar::handle:vertical:pressed { background: rgb(149, 149, 149); } )"
-                R"(QScrollBar::handle:vertical { border-radius: 4px; background: rgb(188, 188, 188); min-height: 20px; }  )"
-                R"(QScrollBar::vertical {border-radius: 4px; width: 8px; color: rgba(255, 255, 255,0);} )"
-                R"(QScrollBar {margin: 0; background: transparent;} )"
-                R"(QScrollBar:hover { background-color: rgb(217, 217, 217);})"
-                R"(QScrollBar::add-line:vertical { width:0px; height: 0px; subcontrol-position: bottom; subcontrol-origin: margin; }  )"
-                R"(QScrollBar::sub-line:vertical { width:0px; height: 0px; subcontrol-position: top; subcontrol-origin: margin; })");
+        QString ss = QStringLiteral(R"(QListView { background: %1; } )"
+                                    R"(QScrollBar::handle:vertical:hover { background: rgb(170, 170, 171); } )"
+                                    R"(QScrollBar::handle:vertical:pressed { background: rgb(149, 149, 149); } )"
+                                    R"(QScrollBar::handle:vertical { border-radius: 4px; background: rgb(188, 188, 188); min-height: 20px; }  )"
+                                    R"(QScrollBar::vertical {border-radius: 4px; width: 8px; color: rgba(255, 255, 255,0);} )"
+                                    R"(QScrollBar {margin: 0; background: transparent;} )"
+                                    R"(QScrollBar:hover { background-color: rgb(217, 217, 217);})"
+                                    R"(QScrollBar::add-line:vertical { width:0px; height: 0px; subcontrol-position: bottom; subcontrol-origin: margin; }  )"
+                                    R"(QScrollBar::sub-line:vertical { width:0px; height: 0px; subcontrol-position: top; subcontrol-origin: margin; })");
         setStyleSheet(ss.arg(m_backgroundColor.name()));
     }
 }

--- a/src/taglistview.h
+++ b/src/taglistview.h
@@ -9,19 +9,19 @@ class TagListView : public QListView
 public:
     explicit TagListView(QWidget *parent = nullptr);
     void setTheme(Theme::Value theme);
-    void setBackground(const QColor color);
+    void setBackground(QColor color);
 signals:
     // QAbstractItemView interface
 public slots:
-    virtual void reset() override;
+    void reset() override;
 
     // QWidget interface
 protected:
-    virtual void resizeEvent(QResizeEvent *event) override;
-    virtual void mousePressEvent(QMouseEvent *event) override;
-    virtual void mouseReleaseEvent(QMouseEvent *event) override;
-    virtual void mouseDoubleClickEvent(QMouseEvent *event) override;
-    virtual void mouseMoveEvent(QMouseEvent *event) override;
+    void resizeEvent(QResizeEvent *event) override;
+    void mousePressEvent(QMouseEvent *event) override;
+    void mouseReleaseEvent(QMouseEvent *event) override;
+    void mouseDoubleClickEvent(QMouseEvent *event) override;
+    void mouseMoveEvent(QMouseEvent *event) override;
 
 private:
     QColor m_backgroundColor;

--- a/src/tagpool.cpp
+++ b/src/tagpool.cpp
@@ -14,12 +14,9 @@ TagPool::TagPool(DBManager *dbManager, QObject *parent) : QObject(parent), m_dbM
             },
             Qt::QueuedConnection);
     connect(m_dbManager, &DBManager::tagAdded, this, &TagPool::onTagAdded, Qt::QueuedConnection);
-    connect(m_dbManager, &DBManager::tagRemoved, this, &TagPool::onTagDeleted,
-            Qt::QueuedConnection);
-    connect(m_dbManager, &DBManager::tagRenamed, this, &TagPool::onTagRenamed,
-            Qt::QueuedConnection);
-    connect(m_dbManager, &DBManager::tagColorChanged, this, &TagPool::onTagColorChanged,
-            Qt::QueuedConnection);
+    connect(m_dbManager, &DBManager::tagRemoved, this, &TagPool::onTagDeleted, Qt::QueuedConnection);
+    connect(m_dbManager, &DBManager::tagRenamed, this, &TagPool::onTagRenamed, Qt::QueuedConnection);
+    connect(m_dbManager, &DBManager::tagColorChanged, this, &TagPool::onTagColorChanged, Qt::QueuedConnection);
 }
 
 void TagPool::setTagPool(const QMap<int, TagData> &newPool)

--- a/src/tagtreedelegateeditor.cpp
+++ b/src/tagtreedelegateeditor.cpp
@@ -12,19 +12,15 @@
 #include "notelistview.h"
 #include "fontloader.h"
 
-TagTreeDelegateEditor::TagTreeDelegateEditor(QTreeView *view, const QStyleOptionViewItem &option,
-                                             const QModelIndex &index, QListView *listView,
+TagTreeDelegateEditor::TagTreeDelegateEditor(QTreeView *view, const QStyleOptionViewItem &option, const QModelIndex &index, QListView *listView,
                                              QWidget *parent)
     : QWidget(parent),
       m_option(option),
       m_index(index),
 #ifdef __APPLE__
-      m_displayFont(QFont(QStringLiteral("SF Pro Text")).exactMatch()
-                            ? QStringLiteral("SF Pro Text")
-                            : QStringLiteral("Roboto")),
+      m_displayFont(QFont(QStringLiteral("SF Pro Text")).exactMatch() ? QStringLiteral("SF Pro Text") : QStringLiteral("Roboto")),
 #elif _WIN32
-      m_displayFont(QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI")
-                                                                   : QStringLiteral("Roboto")),
+      m_displayFont(QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI") : QStringLiteral("Roboto")),
 #else
       m_displayFont(QStringLiteral("Roboto")),
 #endif
@@ -55,16 +51,15 @@ TagTreeDelegateEditor::TagTreeDelegateEditor(QTreeView *view, const QStyleOption
     m_label->setSizePolicy(labelPolicy);
     m_label->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
     connect(m_label, &LabelEditType::editingStarted, this, [this] {
-        auto tree_view = dynamic_cast<NodeTreeView *>(m_view);
+        auto tree_view = static_cast<NodeTreeView *>(m_view);
         tree_view->setIsEditing(true);
     });
     connect(m_label, &LabelEditType::editingFinished, this, [this](const QString &label) {
-        auto tree_view = dynamic_cast<NodeTreeView *>(m_view);
+        auto tree_view = static_cast<NodeTreeView *>(m_view);
         tree_view->onRenameTagFinished(label);
         tree_view->setIsEditing(false);
     });
-    connect(dynamic_cast<NodeTreeView *>(m_view), &NodeTreeView::renameTagRequested, m_label,
-            &LabelEditType::openEditor);
+    connect(static_cast<NodeTreeView *>(m_view), &NodeTreeView::renameTagRequested, m_label, &LabelEditType::openEditor);
     layout->addWidget(m_label);
     m_contextButton = new PushButtonType(parent);
     m_contextButton->setMaximumSize({ 33, 25 });
@@ -101,17 +96,15 @@ TagTreeDelegateEditor::TagTreeDelegateEditor(QTreeView *view, const QStyleOption
 #else
     int pointSizeOffset = -4;
 #endif
-    m_contextButton->setFont(font_loader::loadFont("Font Awesome 6 Free Solid", "",
-                                                                14 + pointSizeOffset));
+    m_contextButton->setFont(font_loader::loadFont("Font Awesome 6 Free Solid", "", 14 + pointSizeOffset));
     m_contextButton->setText(u8"\uf141"); // fa-ellipsis-h
 
     connect(m_contextButton, &QPushButton::clicked, m_view, [this](bool) {
-        auto tree_view = dynamic_cast<NodeTreeView *>(m_view);
+        auto tree_view = static_cast<NodeTreeView *>(m_view);
         if (!m_view->selectionModel()->selectedIndexes().contains(m_index)) {
             tree_view->setCurrentIndexC(m_index);
         }
-        tree_view->onCustomContextMenu(tree_view->visualRect(m_index).topLeft()
-                                       + m_contextButton->geometry().bottomLeft());
+        tree_view->onCustomContextMenu(tree_view->visualRect(m_index).topLeft() + m_contextButton->geometry().bottomLeft());
     });
     layout->addWidget(m_contextButton, 0, Qt::AlignRight);
     layout->addSpacing(5);
@@ -127,14 +120,11 @@ void TagTreeDelegateEditor::updateDelegate()
 
     if (m_view->selectionModel()->selectedIndexes().contains(m_index)) {
         labelStyle = QStringLiteral("QLabel{color: rgb(%1, %2, %3);}")
-                             .arg(QString::number(m_titleSelectedColor.red()),
-                                  QString::number(m_titleSelectedColor.green()),
+                             .arg(QString::number(m_titleSelectedColor.red()), QString::number(m_titleSelectedColor.green()),
                                   QString::number(m_titleSelectedColor.blue()));
     } else {
         labelStyle = QStringLiteral("QLabel{color: rgb(%1, %2, %3);}")
-                             .arg(QString::number(m_titleColor.red()),
-                                  QString::number(m_titleColor.green()),
-                                  QString::number(m_titleColor.blue()));
+                             .arg(QString::number(m_titleColor.red()), QString::number(m_titleColor.green()), QString::number(m_titleColor.blue()));
     }
     m_label->setText(displayName);
 
@@ -150,7 +140,7 @@ void TagTreeDelegateEditor::paintEvent(QPaintEvent *event)
     if (m_view->selectionModel()->selectedIndexes().contains(m_index)) {
         painter.fillRect(rect(), QBrush(m_activeColor));
     } else {
-        auto listView = dynamic_cast<NoteListView *>(m_listView);
+        auto const *listView = static_cast<NoteListView *>(m_listView);
         if (listView->isDragging()) {
             if (m_theme == Theme::Dark) {
                 painter.fillRect(rect(), QBrush(QColor(35, 52, 69)));
@@ -170,8 +160,7 @@ void TagTreeDelegateEditor::paintEvent(QPaintEvent *event)
 #else
     int iconPointSizeOffset = -4;
 #endif
-    painter.setFont(font_loader::loadFont("Font Awesome 6 Free Solid", "",
-                                                       16 + iconPointSizeOffset));
+    painter.setFont(font_loader::loadFont("Font Awesome 6 Free Solid", "", 16 + iconPointSizeOffset));
     painter.drawText(iconRect, u8"\uf111"); // fa-circle
     QWidget::paintEvent(event);
 }
@@ -180,7 +169,7 @@ void TagTreeDelegateEditor::mouseDoubleClickEvent(QMouseEvent *event)
 {
     auto iconRect = QRect(rect().x() + 10, rect().y() + (rect().height() - 14) / 2, 14, 14);
     if (iconRect.contains(event->position().toPoint())) {
-        dynamic_cast<NodeTreeView *>(m_view)->onChangeTagColorAction();
+        static_cast<NodeTreeView *>(m_view)->onChangeTagColorAction();
     } else if (m_label->geometry().contains(event->position().toPoint())) {
         m_label->openEditor();
     } else {

--- a/src/tagtreedelegateeditor.cpp
+++ b/src/tagtreedelegateeditor.cpp
@@ -101,7 +101,7 @@ TagTreeDelegateEditor::TagTreeDelegateEditor(QTreeView *view, const QStyleOption
 #else
     int pointSizeOffset = -4;
 #endif
-    m_contextButton->setFont(FontLoader::getInstance().loadFont("Font Awesome 6 Free Solid", "",
+    m_contextButton->setFont(font_loader::loadFont("Font Awesome 6 Free Solid", "",
                                                                 14 + pointSizeOffset));
     m_contextButton->setText(u8"\uf141"); // fa-ellipsis-h
 
@@ -170,7 +170,7 @@ void TagTreeDelegateEditor::paintEvent(QPaintEvent *event)
 #else
     int iconPointSizeOffset = -4;
 #endif
-    painter.setFont(FontLoader::getInstance().loadFont("Font Awesome 6 Free Solid", "",
+    painter.setFont(font_loader::loadFont("Font Awesome 6 Free Solid", "",
                                                        16 + iconPointSizeOffset));
     painter.drawText(iconRect, u8"\uf111"); // fa-circle
     QWidget::paintEvent(event);

--- a/src/tagtreedelegateeditor.cpp
+++ b/src/tagtreedelegateeditor.cpp
@@ -37,7 +37,7 @@ TagTreeDelegateEditor::TagTreeDelegateEditor(QTreeView *view, const QStyleOption
       m_listView(listView)
 {
     setContentsMargins(0, 0, 0, 0);
-    auto layout = new QHBoxLayout(this);
+    auto *layout = new QHBoxLayout(this);
     layout->setContentsMargins(22, 0, 0, 0);
     layout->setSpacing(5);
     setLayout(layout);
@@ -51,13 +51,13 @@ TagTreeDelegateEditor::TagTreeDelegateEditor(QTreeView *view, const QStyleOption
     m_label->setSizePolicy(labelPolicy);
     m_label->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
     connect(m_label, &LabelEditType::editingStarted, this, [this] {
-        auto tree_view = static_cast<NodeTreeView *>(m_view);
-        tree_view->setIsEditing(true);
+        auto *treeView = static_cast<NodeTreeView *>(m_view);
+        treeView->setIsEditing(true);
     });
     connect(m_label, &LabelEditType::editingFinished, this, [this](const QString &label) {
-        auto tree_view = static_cast<NodeTreeView *>(m_view);
-        tree_view->onRenameTagFinished(label);
-        tree_view->setIsEditing(false);
+        auto *treeView = static_cast<NodeTreeView *>(m_view);
+        treeView->onRenameTagFinished(label);
+        treeView->setIsEditing(false);
     });
     connect(static_cast<NodeTreeView *>(m_view), &NodeTreeView::renameTagRequested, m_label, &LabelEditType::openEditor);
     layout->addWidget(m_label);
@@ -152,7 +152,7 @@ void TagTreeDelegateEditor::paintEvent(QPaintEvent *event)
         }
     }
 
-    auto iconRect = QRect(rect().x() + 22, rect().y() + (rect().height() - 14) / 2, 16, 16);
+    auto iconRect = QRect(rect().x() + 22, rect().y() + ((rect().height() - 14) / 2), 16, 16);
     auto tagColor = m_index.data(NodeItem::Roles::TagColor).toString();
     painter.setPen(QColor(tagColor));
 #ifdef __APPLE__
@@ -167,7 +167,7 @@ void TagTreeDelegateEditor::paintEvent(QPaintEvent *event)
 
 void TagTreeDelegateEditor::mouseDoubleClickEvent(QMouseEvent *event)
 {
-    auto iconRect = QRect(rect().x() + 10, rect().y() + (rect().height() - 14) / 2, 14, 14);
+    auto iconRect = QRect(rect().x() + 10, rect().y() + ((rect().height() - 14) / 2), 14, 14);
     if (iconRect.contains(event->position().toPoint())) {
         static_cast<NodeTreeView *>(m_view)->onChangeTagColorAction();
     } else if (m_label->geometry().contains(event->position().toPoint())) {

--- a/src/tagtreedelegateeditor.h
+++ b/src/tagtreedelegateeditor.h
@@ -39,8 +39,8 @@ private:
 
     // QWidget interface
 protected:
-    virtual void paintEvent(QPaintEvent *event) override;
-    virtual void mouseDoubleClickEvent(QMouseEvent *event) override;
+    void paintEvent(QPaintEvent *event) override;
+    void mouseDoubleClickEvent(QMouseEvent *event) override;
 };
 
 #endif // TAGTREEDELEGATEEDITOR_H

--- a/src/tagtreedelegateeditor.h
+++ b/src/tagtreedelegateeditor.h
@@ -17,8 +17,7 @@ class TagTreeDelegateEditor : public QWidget
 {
     Q_OBJECT
 public:
-    explicit TagTreeDelegateEditor(QTreeView *view, const QStyleOptionViewItem &option,
-                                   const QModelIndex &index, QListView *listView,
+    explicit TagTreeDelegateEditor(QTreeView *view, const QStyleOptionViewItem &option, const QModelIndex &index, QListView *listView,
                                    QWidget *parent = nullptr);
     void setTheme(Theme::Value theme);
 

--- a/src/trashbuttondelegateeditor.cpp
+++ b/src/trashbuttondelegateeditor.cpp
@@ -3,24 +3,18 @@
 #include <QDebug>
 #include <QTreeView>
 #include "nodetreemodel.h"
-#include "nodetreeview.h"
 #include "notelistview.h"
 #include "fontloader.h"
 
-TrashButtonDelegateEditor::TrashButtonDelegateEditor(QTreeView *view,
-                                                     const QStyleOptionViewItem &option,
-                                                     const QModelIndex &index, QListView *listView,
+TrashButtonDelegateEditor::TrashButtonDelegateEditor(QTreeView *view, const QStyleOptionViewItem &option, const QModelIndex &index, QListView *listView,
                                                      QWidget *parent)
     : QWidget(parent),
       m_option(option),
       m_index(index),
 #ifdef __APPLE__
-      m_displayFont(QFont(QStringLiteral("SF Pro Text")).exactMatch()
-                            ? QStringLiteral("SF Pro Text")
-                            : QStringLiteral("Roboto")),
+      m_displayFont(QFont(QStringLiteral("SF Pro Text")).exactMatch() ? QStringLiteral("SF Pro Text") : QStringLiteral("Roboto")),
 #elif _WIN32
-      m_displayFont(QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI")
-                                                                   : QStringLiteral("Roboto")),
+      m_displayFont(QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI") : QStringLiteral("Roboto")),
 #else
       m_displayFont(QStringLiteral("Roboto")),
 #endif
@@ -39,7 +33,8 @@ TrashButtonDelegateEditor::TrashButtonDelegateEditor(QTreeView *view,
       m_numberOfNotesColor(26, 26, 26, 127),
       m_numberOfNotesSelectedColor(255, 255, 255),
       m_view(view),
-      m_listView(listView)
+      m_listView(listView),
+      m_theme(Theme::Light)
 {
     setContentsMargins(0, 0, 0, 0);
 }
@@ -47,7 +42,7 @@ TrashButtonDelegateEditor::TrashButtonDelegateEditor(QTreeView *view,
 void TrashButtonDelegateEditor::paintEvent(QPaintEvent *event)
 {
     QPainter painter(this);
-    auto iconRect = QRect(rect().x() + 22, rect().y() + 2 + (rect().height() - 20) / 2, 18, 20);
+    auto iconRect = QRect(rect().x() + 22, rect().y() + 2 + ((rect().height() - 20) / 2), 18, 20);
     auto iconPath = m_index.data(NodeItem::Roles::Icon).toString();
     auto displayName = m_index.data(NodeItem::Roles::DisplayText).toString();
     QRect nameRect(rect());
@@ -57,7 +52,7 @@ void TrashButtonDelegateEditor::paintEvent(QPaintEvent *event)
         painter.fillRect(rect(), QBrush(m_activeColor));
         painter.setPen(m_titleSelectedColor);
     } else {
-        auto listView = dynamic_cast<NoteListView *>(m_listView);
+        auto const *listView = static_cast<NoteListView *>(m_listView);
         if (listView->isDragging()) {
             if (m_theme == Theme::Dark) {
                 painter.fillRect(rect(), QBrush(QColor(35, 52, 69)));
@@ -74,8 +69,7 @@ void TrashButtonDelegateEditor::paintEvent(QPaintEvent *event)
 #else
     int iconPointSizeOffset = -4;
 #endif
-    painter.setFont(font_loader::loadFont("Font Awesome 6 Free Solid", "",
-                                                       16 + iconPointSizeOffset));
+    painter.setFont(font_loader::loadFont("Font Awesome 6 Free Solid", "", 16 + iconPointSizeOffset));
     painter.drawText(iconRect, iconPath); // fa-trash
 
     if (m_view->selectionModel()->isSelected(m_index)) {
@@ -96,8 +90,7 @@ void TrashButtonDelegateEditor::paintEvent(QPaintEvent *event)
         painter.setPen(m_numberOfNotesColor);
     }
     painter.setFont(m_numberOfNotesFont);
-    painter.drawText(childCountRect, Qt::AlignHCenter | Qt::AlignVCenter,
-                     QString::number(childCount));
+    painter.drawText(childCountRect, Qt::AlignHCenter | Qt::AlignVCenter, QString::number(childCount));
     QWidget::paintEvent(event);
 }
 

--- a/src/trashbuttondelegateeditor.cpp
+++ b/src/trashbuttondelegateeditor.cpp
@@ -74,7 +74,7 @@ void TrashButtonDelegateEditor::paintEvent(QPaintEvent *event)
 #else
     int iconPointSizeOffset = -4;
 #endif
-    painter.setFont(FontLoader::getInstance().loadFont("Font Awesome 6 Free Solid", "",
+    painter.setFont(font_loader::loadFont("Font Awesome 6 Free Solid", "",
                                                        16 + iconPointSizeOffset));
     painter.drawText(iconRect, iconPath); // fa-trash
 

--- a/src/trashbuttondelegateeditor.h
+++ b/src/trashbuttondelegateeditor.h
@@ -36,7 +36,7 @@ private:
     Theme::Value m_theme;
     // QWidget interface
 protected:
-    virtual void paintEvent(QPaintEvent *event) override;
+    void paintEvent(QPaintEvent *event) override;
 };
 
 #endif // TRASHBUTTONDELEGATEEDITOR_H

--- a/src/trashbuttondelegateeditor.h
+++ b/src/trashbuttondelegateeditor.h
@@ -14,8 +14,7 @@ class TrashButtonDelegateEditor : public QWidget
 {
     Q_OBJECT
 public:
-    explicit TrashButtonDelegateEditor(QTreeView *view, const QStyleOptionViewItem &option,
-                                       const QModelIndex &index, QListView *listView,
+    explicit TrashButtonDelegateEditor(QTreeView *view, const QStyleOptionViewItem &option, const QModelIndex &index, QListView *listView,
                                        QWidget *parent = nullptr);
     void setTheme(Theme::Value theme);
 

--- a/src/treeviewlogic.cpp
+++ b/src/treeviewlogic.cpp
@@ -209,15 +209,15 @@ void TreeViewLogic::onAddTagRequested()
     TagData newTag;
     newTag.setName(m_treeModel->getNewTagPlaceholderName());
     // random color generator
-    const double lower_bound = 0;
-    const double upper_bound = 1;
-    static std::uniform_real_distribution<double> unif(lower_bound, upper_bound);
-    static std::random_device rand_dev;
-    static std::mt19937 rand_engine(rand_dev());
-    double rand = unif(rand_engine);
+    const double lowerBound = 0;
+    const double upperBound = 1;
+    static std::uniform_real_distribution<double> unif(lowerBound, upperBound);
+    static std::random_device randDev;
+    static std::mt19937 randEngine(randDev());
+    double rand = unif(randEngine);
     int h = rand * 359;
     int s = 255;
-    int v = 128 + rand * 127;
+    int v = 128 + (rand * 127);
     auto color = QColor::fromHsv(h, s, v);
 
     newTag.setColor(color.name());

--- a/src/treeviewlogic.cpp
+++ b/src/treeviewlogic.cpp
@@ -69,7 +69,7 @@ void TreeViewLogic::loadTreeModel(const NodeTagTreeData &treeData)
     {
         NodeData node;
         QMetaObject::invokeMethod(m_dbManager, "getChildNotesCountFolder", Qt::BlockingQueuedConnection, Q_RETURN_ARG(NodeData, node),
-                                  Q_ARG(int, SpecialNodeID::RootFolder));
+                                  Q_ARG(int, ROOT_FOLDER_ID));
         auto index = m_treeModel->getAllNotesButtonIndex();
         if (index.isValid()) {
             m_treeModel->setData(index, node.childNotesCount(), NodeItem::Roles::ChildCount);
@@ -78,7 +78,7 @@ void TreeViewLogic::loadTreeModel(const NodeTagTreeData &treeData)
     {
         NodeData node;
         QMetaObject::invokeMethod(m_dbManager, "getChildNotesCountFolder", Qt::BlockingQueuedConnection, Q_RETURN_ARG(NodeData, node),
-                                  Q_ARG(int, SpecialNodeID::TrashFolder));
+                                  Q_ARG(int, TRASH_FOLDER_ID));
         auto index = m_treeModel->getTrashButtonIndex();
         if (index.isValid()) {
             m_treeModel->setData(index, node.childNotesCount(), NodeItem::Roles::ChildCount);
@@ -126,17 +126,17 @@ void TreeViewLogic::onAddFolderRequested(bool fromPlusButton)
             currentIndex = m_treeView->currentIndex();
         }
     }
-    int parentId = SpecialNodeID::RootFolder;
+    int parentId = ROOT_FOLDER_ID;
     NodeItem::Type currentType = NodeItem::AllNoteButton;
     QString currentAbsPath;
-    int currentTagId = SpecialNodeID::InvalidNodeId;
+    int currentTagId = INVALID_NODE_ID;
     if (currentIndex.isValid() && !fromPlusButton) {
         auto type = static_cast<NodeItem::Type>(currentIndex.data(NodeItem::Roles::ItemType).toInt());
         if (type == NodeItem::FolderItem) {
             parentId = currentIndex.data(NodeItem::Roles::NodeId).toInt();
             // we don't allow subfolder under default notes folder
-            if (parentId == SpecialNodeID::DefaultNotesFolder) {
-                parentId = SpecialNodeID::RootFolder;
+            if (parentId == DEFAULT_NOTES_FOLDER_ID) {
+                parentId = ROOT_FOLDER_ID;
             }
         } else if (type == NodeItem::NoteItem) {
             qDebug() << "Can create folder under this item";
@@ -159,7 +159,7 @@ void TreeViewLogic::onAddFolderRequested(bool fromPlusButton)
     QDateTime noteDate = QDateTime::currentDateTime();
     newFolder.setCreationDateTime(noteDate);
     newFolder.setLastModificationDateTime(noteDate);
-    if (parentId != SpecialNodeID::RootFolder) {
+    if (parentId != ROOT_FOLDER_ID) {
         newFolder.setFullTitle(m_treeModel->getNewFolderPlaceholderName(currentIndex));
     } else {
         newFolder.setFullTitle(m_treeModel->getNewFolderPlaceholderName(m_treeModel->rootIndex()));
@@ -173,14 +173,14 @@ void TreeViewLogic::onAddFolderRequested(bool fromPlusButton)
     hs[NodeItem::Roles::DisplayText] = newFolder.fullTitle();
     hs[NodeItem::Roles::NodeId] = newlyCreatedNodeId;
 
-    if (parentId != SpecialNodeID::RootFolder) {
+    if (parentId != ROOT_FOLDER_ID) {
         hs[NodeItem::Roles::AbsPath] = currentIndex.data(NodeItem::Roles::AbsPath).toString() + PATH_SEPARATOR + QString::number(newlyCreatedNodeId);
         m_treeModel->appendChildNodeToParent(currentIndex, hs);
         if (!m_treeView->isExpanded(currentIndex)) {
             m_treeView->expand(currentIndex);
         }
     } else {
-        hs[NodeItem::Roles::AbsPath] = PATH_SEPARATOR + QString::number(SpecialNodeID::RootFolder) + PATH_SEPARATOR + QString::number(newlyCreatedNodeId);
+        hs[NodeItem::Roles::AbsPath] = PATH_SEPARATOR + QString::number(ROOT_FOLDER_ID) + PATH_SEPARATOR + QString::number(newlyCreatedNodeId);
         m_treeModel->appendChildNodeToParent(m_treeModel->rootIndex(), hs);
     }
     if (fromPlusButton) {
@@ -245,7 +245,7 @@ void TreeViewLogic::onDeleteFolderRequested(const QModelIndex &index)
                                      "any subfolders will be deleted.");
     if (btn == QMessageBox::Yes) {
         auto id = index.data(NodeItem::Roles::NodeId).toInt();
-        if (id < SpecialNodeID::DefaultNotesFolder) {
+        if (id < DEFAULT_NOTES_FOLDER_ID) {
             qDebug() << __FUNCTION__ << "Failed while trying to delete folder with id" << id;
             return;
         }
@@ -305,9 +305,9 @@ void TreeViewLogic::onChildNotesCountChangedTag(int tagId, int notesCount)
 void TreeViewLogic::onChildNoteCountChangedFolder(int folderId, const QString &absPath, int notesCount)
 {
     QModelIndex index;
-    if (folderId == SpecialNodeID::RootFolder) {
+    if (folderId == ROOT_FOLDER_ID) {
         index = m_treeModel->getAllNotesButtonIndex();
-    } else if (folderId == SpecialNodeID::TrashFolder) {
+    } else if (folderId == TRASH_FOLDER_ID) {
         index = m_treeModel->getTrashButtonIndex();
     } else {
         index = m_treeModel->folderIndexFromIdPath(absPath);
@@ -325,9 +325,9 @@ void TreeViewLogic::openFolder(int id)
         qDebug() << __FUNCTION__ << "Target is not folder!";
         return;
     }
-    if (target.id() == SpecialNodeID::TrashFolder) {
+    if (target.id() == TRASH_FOLDER_ID) {
         m_treeView->setCurrentIndexC(m_treeModel->getTrashButtonIndex());
-    } else if (target.id() == SpecialNodeID::RootFolder) {
+    } else if (target.id() == ROOT_FOLDER_ID) {
         m_treeView->setCurrentIndexC(m_treeModel->getAllNotesButtonIndex());
     } else {
         auto index = m_treeModel->folderIndexFromIdPath(target.absolutePath());

--- a/src/treeviewlogic.cpp
+++ b/src/treeviewlogic.cpp
@@ -11,8 +11,7 @@
 #include <QApplication>
 #include "customapplicationstyle.h"
 
-TreeViewLogic::TreeViewLogic(NodeTreeView *treeView, NodeTreeModel *treeModel, DBManager *dbManager,
-                             NoteListView *listView, QObject *parent)
+TreeViewLogic::TreeViewLogic(NodeTreeView *treeView, NodeTreeModel *treeModel, DBManager *dbManager, NoteListView *listView, QObject *parent)
     : QObject(parent),
       m_treeView{ treeView },
       m_treeModel{ treeModel },
@@ -26,66 +25,42 @@ TreeViewLogic::TreeViewLogic(NodeTreeView *treeView, NodeTreeModel *treeModel, D
 {
     m_treeDelegate = new NodeTreeDelegate(m_treeView, m_treeView, m_listView);
     m_treeView->setItemDelegate(m_treeDelegate);
-    connect(m_dbManager, &DBManager::nodesTagTreeReceived, this, &TreeViewLogic::loadTreeModel,
-            Qt::QueuedConnection);
-    connect(m_treeModel, &NodeTreeModel::topLevelItemLayoutChanged, this,
-            &TreeViewLogic::updateTreeViewSeparator);
-    connect(m_treeView, &NodeTreeView::addFolderRequested, this,
-            [this] { onAddFolderRequested(false); });
-    connect(m_treeDelegate, &NodeTreeDelegate::addFolderRequested, this,
-            [this] { onAddFolderRequested(true); });
-    connect(m_treeDelegate, &NodeTreeDelegate::addTagRequested, this,
-            &TreeViewLogic::onAddTagRequested);
-    connect(m_treeView, &NodeTreeView::renameFolderInDatabase, this,
-            &TreeViewLogic::onRenameNodeRequestedFromTreeView);
-    connect(m_treeView, &NodeTreeView::renameTagInDatabase, this,
-            &TreeViewLogic::onRenameTagRequestedFromTreeView);
-    connect(this, &TreeViewLogic::requestRenameNodeInDB, m_dbManager, &DBManager::renameNode,
-            Qt::QueuedConnection);
-    connect(this, &TreeViewLogic::requestRenameTagInDB, m_dbManager, &DBManager::renameTag,
-            Qt::QueuedConnection);
-    connect(m_treeView, &NodeTreeView::deleteNodeRequested, this,
-            &TreeViewLogic::onDeleteFolderRequested);
-    connect(m_treeView, &NodeTreeView::changeTagColorRequested, this,
-            &TreeViewLogic::onChangeTagColorRequested);
-    connect(m_treeView, &NodeTreeView::deleteTagRequested, this,
-            &TreeViewLogic::onDeleteTagRequested);
-    connect(this, &TreeViewLogic::requestChangeTagColorInDB, m_dbManager,
-            &DBManager::changeTagColor, Qt::QueuedConnection);
-    connect(this, &TreeViewLogic::requestMoveNodeInDB, m_dbManager, &DBManager::moveNode,
-            Qt::QueuedConnection);
+    connect(m_dbManager, &DBManager::nodesTagTreeReceived, this, &TreeViewLogic::loadTreeModel, Qt::QueuedConnection);
+    connect(m_treeModel, &NodeTreeModel::topLevelItemLayoutChanged, this, &TreeViewLogic::updateTreeViewSeparator);
+    connect(m_treeView, &NodeTreeView::addFolderRequested, this, [this] { onAddFolderRequested(false); });
+    connect(m_treeDelegate, &NodeTreeDelegate::addFolderRequested, this, [this] { onAddFolderRequested(true); });
+    connect(m_treeDelegate, &NodeTreeDelegate::addTagRequested, this, &TreeViewLogic::onAddTagRequested);
+    connect(m_treeView, &NodeTreeView::renameFolderInDatabase, this, &TreeViewLogic::onRenameNodeRequestedFromTreeView);
+    connect(m_treeView, &NodeTreeView::renameTagInDatabase, this, &TreeViewLogic::onRenameTagRequestedFromTreeView);
+    connect(this, &TreeViewLogic::requestRenameNodeInDB, m_dbManager, &DBManager::renameNode, Qt::QueuedConnection);
+    connect(this, &TreeViewLogic::requestRenameTagInDB, m_dbManager, &DBManager::renameTag, Qt::QueuedConnection);
+    connect(m_treeView, &NodeTreeView::deleteNodeRequested, this, &TreeViewLogic::onDeleteFolderRequested);
+    connect(m_treeView, &NodeTreeView::changeTagColorRequested, this, &TreeViewLogic::onChangeTagColorRequested);
+    connect(m_treeView, &NodeTreeView::deleteTagRequested, this, &TreeViewLogic::onDeleteTagRequested);
+    connect(this, &TreeViewLogic::requestChangeTagColorInDB, m_dbManager, &DBManager::changeTagColor, Qt::QueuedConnection);
+    connect(this, &TreeViewLogic::requestMoveNodeInDB, m_dbManager, &DBManager::moveNode, Qt::QueuedConnection);
     connect(m_treeView, &NodeTreeView::moveNodeRequested, this, [this](int nodeId, int targetId) {
         onMoveNodeRequested(nodeId, targetId);
         emit noteMoved(nodeId, targetId);
     });
     connect(m_treeView, &NodeTreeView::addNoteToTag, this, &TreeViewLogic::addNoteToTag);
     connect(m_treeModel, &NodeTreeModel::requestExpand, m_treeView, &NodeTreeView::onRequestExpand);
-    connect(m_treeModel, &NodeTreeModel::requestUpdateAbsPath, m_treeView,
-            &NodeTreeView::onUpdateAbsPath);
-    connect(m_treeModel, &NodeTreeModel::requestMoveNode, this,
-            &TreeViewLogic::onMoveNodeRequested);
-    connect(m_treeModel, &NodeTreeModel::requestUpdateNodeRelativePosition, m_dbManager,
-            &DBManager::updateRelPosNode, Qt::QueuedConnection);
-    connect(m_treeModel, &NodeTreeModel::requestUpdateTagRelativePosition, m_dbManager,
-            &DBManager::updateRelPosTag, Qt::QueuedConnection);
-    connect(m_treeModel, &NodeTreeModel::dropFolderSuccessful, m_treeView,
-            &NodeTreeView::onFolderDropSuccessful);
-    connect(m_treeModel, &NodeTreeModel::dropTagsSuccessful, m_treeView,
-            &NodeTreeView::onTagsDropSuccessful);
-    connect(m_treeModel, &NodeTreeModel::requestMoveFolderToTrash, this,
-            &TreeViewLogic::onDeleteFolderRequested);
-    connect(m_dbManager, &DBManager::childNotesCountUpdatedFolder, this,
-            &TreeViewLogic::onChildNoteCountChangedFolder);
-    connect(m_dbManager, &DBManager::childNotesCountUpdatedTag, this,
-            &TreeViewLogic::onChildNotesCountChangedTag);
+    connect(m_treeModel, &NodeTreeModel::requestUpdateAbsPath, m_treeView, &NodeTreeView::onUpdateAbsPath);
+    connect(m_treeModel, &NodeTreeModel::requestMoveNode, this, &TreeViewLogic::onMoveNodeRequested);
+    connect(m_treeModel, &NodeTreeModel::requestUpdateNodeRelativePosition, m_dbManager, &DBManager::updateRelPosNode, Qt::QueuedConnection);
+    connect(m_treeModel, &NodeTreeModel::requestUpdateTagRelativePosition, m_dbManager, &DBManager::updateRelPosTag, Qt::QueuedConnection);
+    connect(m_treeModel, &NodeTreeModel::dropFolderSuccessful, m_treeView, &NodeTreeView::onFolderDropSuccessful);
+    connect(m_treeModel, &NodeTreeModel::dropTagsSuccessful, m_treeView, &NodeTreeView::onTagsDropSuccessful);
+    connect(m_treeModel, &NodeTreeModel::requestMoveFolderToTrash, this, &TreeViewLogic::onDeleteFolderRequested);
+    connect(m_dbManager, &DBManager::childNotesCountUpdatedFolder, this, &TreeViewLogic::onChildNoteCountChangedFolder);
+    connect(m_dbManager, &DBManager::childNotesCountUpdatedTag, this, &TreeViewLogic::onChildNotesCountChangedTag);
     m_style = new CustomApplicationStyle();
     qApp->setStyle(m_style);
 }
 
 void TreeViewLogic::updateTreeViewSeparator()
 {
-    m_treeView->setTreeSeparator(m_treeModel->getSeparatorIndex(),
-                                 m_treeModel->getDefaultNotesIndex());
+    m_treeView->setTreeSeparator(m_treeModel->getSeparatorIndex(), m_treeModel->getDefaultNotesIndex());
 }
 
 void TreeViewLogic::loadTreeModel(const NodeTagTreeData &treeData)
@@ -93,8 +68,7 @@ void TreeViewLogic::loadTreeModel(const NodeTagTreeData &treeData)
     m_treeModel->setTreeData(treeData);
     {
         NodeData node;
-        QMetaObject::invokeMethod(m_dbManager, "getChildNotesCountFolder",
-                                  Qt::BlockingQueuedConnection, Q_RETURN_ARG(NodeData, node),
+        QMetaObject::invokeMethod(m_dbManager, "getChildNotesCountFolder", Qt::BlockingQueuedConnection, Q_RETURN_ARG(NodeData, node),
                                   Q_ARG(int, SpecialNodeID::RootFolder));
         auto index = m_treeModel->getAllNotesButtonIndex();
         if (index.isValid()) {
@@ -103,8 +77,7 @@ void TreeViewLogic::loadTreeModel(const NodeTagTreeData &treeData)
     }
     {
         NodeData node;
-        QMetaObject::invokeMethod(m_dbManager, "getChildNotesCountFolder",
-                                  Qt::BlockingQueuedConnection, Q_RETURN_ARG(NodeData, node),
+        QMetaObject::invokeMethod(m_dbManager, "getChildNotesCountFolder", Qt::BlockingQueuedConnection, Q_RETURN_ARG(NodeData, node),
                                   Q_ARG(int, SpecialNodeID::TrashFolder));
         auto index = m_treeModel->getTrashButtonIndex();
         if (index.isValid()) {
@@ -158,8 +131,7 @@ void TreeViewLogic::onAddFolderRequested(bool fromPlusButton)
     QString currentAbsPath;
     int currentTagId = SpecialNodeID::InvalidNodeId;
     if (currentIndex.isValid() && !fromPlusButton) {
-        auto type =
-                static_cast<NodeItem::Type>(currentIndex.data(NodeItem::Roles::ItemType).toInt());
+        auto type = static_cast<NodeItem::Type>(currentIndex.data(NodeItem::Roles::ItemType).toInt());
         if (type == NodeItem::FolderItem) {
             parentId = currentIndex.data(NodeItem::Roles::NodeId).toInt();
             // we don't allow subfolder under default notes folder
@@ -173,8 +145,7 @@ void TreeViewLogic::onAddFolderRequested(bool fromPlusButton)
             currentIndex = m_treeModel->rootIndex();
         }
     } else {
-        currentType =
-                static_cast<NodeItem::Type>(currentIndex.data(NodeItem::Roles::ItemType).toInt());
+        currentType = static_cast<NodeItem::Type>(currentIndex.data(NodeItem::Roles::ItemType).toInt());
         if (currentType == NodeItem::FolderItem) {
             currentAbsPath = currentIndex.data(NodeItem::Roles::AbsPath).toString();
         } else if (currentType == NodeItem::TagItem) {
@@ -184,7 +155,7 @@ void TreeViewLogic::onAddFolderRequested(bool fromPlusButton)
     }
     int newlyCreatedNodeId;
     NodeData newFolder;
-    newFolder.setNodeType(NodeData::Folder);
+    newFolder.setNodeType(NodeData::Type::Folder);
     QDateTime noteDate = QDateTime::currentDateTime();
     newFolder.setCreationDateTime(noteDate);
     newFolder.setLastModificationDateTime(noteDate);
@@ -195,8 +166,7 @@ void TreeViewLogic::onAddFolderRequested(bool fromPlusButton)
     }
     newFolder.setParentId(parentId);
 
-    QMetaObject::invokeMethod(m_dbManager, "addNode", Qt::BlockingQueuedConnection,
-                              Q_RETURN_ARG(int, newlyCreatedNodeId), Q_ARG(NodeData, newFolder));
+    QMetaObject::invokeMethod(m_dbManager, "addNode", Qt::BlockingQueuedConnection, Q_RETURN_ARG(int, newlyCreatedNodeId), Q_ARG(NodeData, newFolder));
 
     QHash<NodeItem::Roles, QVariant> hs;
     hs[NodeItem::Roles::ItemType] = NodeItem::Type::FolderItem;
@@ -204,15 +174,13 @@ void TreeViewLogic::onAddFolderRequested(bool fromPlusButton)
     hs[NodeItem::Roles::NodeId] = newlyCreatedNodeId;
 
     if (parentId != SpecialNodeID::RootFolder) {
-        hs[NodeItem::Roles::AbsPath] = currentIndex.data(NodeItem::Roles::AbsPath).toString()
-                + PATH_SEPARATOR + QString::number(newlyCreatedNodeId);
+        hs[NodeItem::Roles::AbsPath] = currentIndex.data(NodeItem::Roles::AbsPath).toString() + PATH_SEPARATOR + QString::number(newlyCreatedNodeId);
         m_treeModel->appendChildNodeToParent(currentIndex, hs);
         if (!m_treeView->isExpanded(currentIndex)) {
             m_treeView->expand(currentIndex);
         }
     } else {
-        hs[NodeItem::Roles::AbsPath] = PATH_SEPARATOR + QString::number(SpecialNodeID::RootFolder)
-                + PATH_SEPARATOR + QString::number(newlyCreatedNodeId);
+        hs[NodeItem::Roles::AbsPath] = PATH_SEPARATOR + QString::number(SpecialNodeID::RootFolder) + PATH_SEPARATOR + QString::number(newlyCreatedNodeId);
         m_treeModel->appendChildNodeToParent(m_treeModel->rootIndex(), hs);
     }
     if (fromPlusButton) {
@@ -253,8 +221,7 @@ void TreeViewLogic::onAddTagRequested()
     auto color = QColor::fromHsv(h, s, v);
 
     newTag.setColor(color.name());
-    QMetaObject::invokeMethod(m_dbManager, "addTag", Qt::BlockingQueuedConnection,
-                              Q_RETURN_ARG(int, newlyCreatedTagId), Q_ARG(TagData, newTag));
+    QMetaObject::invokeMethod(m_dbManager, "addTag", Qt::BlockingQueuedConnection, Q_RETURN_ARG(int, newlyCreatedTagId), Q_ARG(TagData, newTag));
 
     QHash<NodeItem::Roles, QVariant> hs;
     hs[NodeItem::Roles::ItemType] = NodeItem::Type::TagItem;
@@ -264,8 +231,7 @@ void TreeViewLogic::onAddTagRequested()
     m_treeModel->appendChildNodeToParent(m_treeModel->rootIndex(), hs);
 }
 
-void TreeViewLogic::onRenameNodeRequestedFromTreeView(const QModelIndex &index,
-                                                      const QString &newName)
+void TreeViewLogic::onRenameNodeRequestedFromTreeView(const QModelIndex &index, const QString &newName)
 {
     m_treeModel->setData(index, newName, NodeItem::Roles::DisplayText);
     auto id = index.data(NodeItem::Roles::NodeId).toInt();
@@ -284,18 +250,15 @@ void TreeViewLogic::onDeleteFolderRequested(const QModelIndex &index)
             return;
         }
         NodeData node;
-        QMetaObject::invokeMethod(m_dbManager, "getNode", Qt::BlockingQueuedConnection,
-                                  Q_RETURN_ARG(NodeData, node), Q_ARG(int, id));
+        QMetaObject::invokeMethod(m_dbManager, "getNode", Qt::BlockingQueuedConnection, Q_RETURN_ARG(NodeData, node), Q_ARG(int, id));
         auto parentPath = NodePath{ node.absolutePath() }.parentPath();
         auto parentIndex = m_treeModel->folderIndexFromIdPath(parentPath);
         if (parentIndex.isValid()) {
             m_treeModel->deleteRow(index, parentIndex);
-            QMetaObject::invokeMethod(m_dbManager, "moveFolderToTrash", Qt::QueuedConnection,
-                                      Q_ARG(NodeData, node));
+            QMetaObject::invokeMethod(m_dbManager, "moveFolderToTrash", Qt::QueuedConnection, Q_ARG(NodeData, node));
             m_treeView->setCurrentIndexC(m_treeModel->getAllNotesButtonIndex());
         } else {
-            qDebug() << __FUNCTION__ << "Parent index with path" << parentPath.path()
-                     << "is not valid";
+            qDebug() << __FUNCTION__ << "Parent index with path" << parentPath.path() << "is not valid";
         }
     } else {
         m_treeView->closePersistentEditor(m_treeModel->getTrashButtonIndex());
@@ -303,8 +266,7 @@ void TreeViewLogic::onDeleteFolderRequested(const QModelIndex &index)
     }
 }
 
-void TreeViewLogic::onRenameTagRequestedFromTreeView(const QModelIndex &index,
-                                                     const QString &newName)
+void TreeViewLogic::onRenameTagRequestedFromTreeView(const QModelIndex &index, const QString &newName)
 {
     m_treeModel->setData(index, newName, NodeItem::Roles::DisplayText);
     auto id = index.data(NodeItem::Roles::NodeId).toInt();
@@ -340,8 +302,7 @@ void TreeViewLogic::onChildNotesCountChangedTag(int tagId, int notesCount)
     }
 }
 
-void TreeViewLogic::onChildNoteCountChangedFolder(int folderId, const QString &absPath,
-                                                  int notesCount)
+void TreeViewLogic::onChildNoteCountChangedFolder(int folderId, const QString &absPath, int notesCount)
 {
     QModelIndex index;
     if (folderId == SpecialNodeID::RootFolder) {
@@ -359,9 +320,8 @@ void TreeViewLogic::onChildNoteCountChangedFolder(int folderId, const QString &a
 void TreeViewLogic::openFolder(int id)
 {
     NodeData target;
-    QMetaObject::invokeMethod(m_dbManager, "getNode", Qt::BlockingQueuedConnection,
-                              Q_RETURN_ARG(NodeData, target), Q_ARG(int, id));
-    if (target.nodeType() != NodeData::Folder) {
+    QMetaObject::invokeMethod(m_dbManager, "getNode", Qt::BlockingQueuedConnection, Q_RETURN_ARG(NodeData, target), Q_ARG(int, id));
+    if (target.nodeType() != NodeData::Type::Folder) {
         qDebug() << __FUNCTION__ << "Target is not folder!";
         return;
     }
@@ -382,10 +342,9 @@ void TreeViewLogic::openFolder(int id)
 void TreeViewLogic::onMoveNodeRequested(int nodeId, int targetId)
 {
     NodeData target;
-    QMetaObject::invokeMethod(m_dbManager, "getNode", Qt::BlockingQueuedConnection,
-                              Q_RETURN_ARG(NodeData, target), Q_ARG(int, targetId));
+    QMetaObject::invokeMethod(m_dbManager, "getNode", Qt::BlockingQueuedConnection, Q_RETURN_ARG(NodeData, target), Q_ARG(int, targetId));
     // only allow moving a node into a folder
-    if (target.nodeType() != NodeData::Folder) {
+    if (target.nodeType() != NodeData::Type::Folder) {
         qDebug() << __FUNCTION__ << "Target is not folder!";
         return;
     }
@@ -396,8 +355,7 @@ void TreeViewLogic::onMoveNodeRequested(int nodeId, int targetId)
     }
     // don't allow moving a node into the same parent
     NodeData node;
-    QMetaObject::invokeMethod(m_dbManager, "getNode", Qt::BlockingQueuedConnection,
-                              Q_RETURN_ARG(NodeData, node), Q_ARG(int, nodeId));
+    QMetaObject::invokeMethod(m_dbManager, "getNode", Qt::BlockingQueuedConnection, Q_RETURN_ARG(NodeData, node), Q_ARG(int, nodeId));
     if (node.parentId() == targetId) {
         qDebug() << __FUNCTION__ << "Can't move a node into the same parent";
         return;
@@ -412,8 +370,7 @@ void TreeViewLogic::setTheme(Theme::Value theme)
     m_style->setTheme(theme);
 }
 
-void TreeViewLogic::setLastSavedState(bool isLastSelectFolder, const QString &lastSelectFolder,
-                                      const QSet<int> &lastSelectTag,
+void TreeViewLogic::setLastSavedState(bool isLastSelectFolder, const QString &lastSelectFolder, const QSet<int> &lastSelectTag,
                                       const QStringList &expandedFolder)
 {
     m_isLastSelectFolder = isLastSelectFolder;

--- a/src/treeviewlogic.h
+++ b/src/treeviewlogic.h
@@ -16,13 +16,11 @@ class TreeViewLogic : public QObject
 {
     Q_OBJECT
 public:
-    explicit TreeViewLogic(NodeTreeView *treeView, NodeTreeModel *treeModel, DBManager *dbManager,
-                           NoteListView *listView, QObject *parent = nullptr);
+    explicit TreeViewLogic(NodeTreeView *treeView, NodeTreeModel *treeModel, DBManager *dbManager, NoteListView *listView, QObject *parent = nullptr);
     void openFolder(int id);
     void onMoveNodeRequested(int nodeId, int targetId);
     void setTheme(Theme::Value theme);
-    void setLastSavedState(bool isLastSelectFolder, const QString &lastSelectFolder,
-                           const QSet<int> &lastSelectTag, const QStringList &expandedFolder);
+    void setLastSavedState(bool isLastSelectFolder, const QString &lastSelectFolder, const QSet<int> &lastSelectTag, const QStringList &expandedFolder);
 private slots:
     void updateTreeViewSeparator();
     void loadTreeModel(const NodeTagTreeData &treeData);

--- a/src/updaterwindow.cpp
+++ b/src/updaterwindow.cpp
@@ -35,8 +35,7 @@ static QProcess XDGOPEN_PROCESS;
 /**
  * Indicates from where we should download the update definitions file
  */
-static const QString
-        UPDATES_URL("https://raw.githubusercontent.com/nuttyartist/notes/master/UPDATES_FOSS.json");
+static const QString UPDATES_URL("https://raw.githubusercontent.com/nuttyartist/notes/master/UPDATES_FOSS.json");
 
 /**
  * Initializes the window components and configures the QSimpleUpdater
@@ -66,12 +65,9 @@ UpdaterWindow::UpdaterWindow(QWidget *parent)
 
     /* Change fonts */
 #ifdef __APPLE__
-    QFont fontToUse = QFont(QStringLiteral("SF Pro Text")).exactMatch()
-            ? QStringLiteral("SF Pro Text")
-            : QStringLiteral("Roboto");
+    QFont fontToUse = QFont(QStringLiteral("SF Pro Text")).exactMatch() ? QStringLiteral("SF Pro Text") : QStringLiteral("Roboto");
 #elif _WIN32
-    QFont fontToUse = QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI")
-                                                                     : QStringLiteral("Roboto");
+    QFont fontToUse = QFont(QStringLiteral("Segoe UI")).exactMatch() ? QStringLiteral("Segoe UI") : QStringLiteral("Roboto");
 #else
     QFont fontToUse = QFont(QStringLiteral("Roboto"));
 #endif
@@ -85,8 +81,7 @@ UpdaterWindow::UpdaterWindow(QWidget *parent)
 
     /* Connect UI signals/slots */
     connect(m_ui->closeButton, &QPushButton::clicked, this, &UpdaterWindow::close);
-    connect(m_ui->updateButton, &QPushButton::clicked, this,
-            &UpdaterWindow::onDownloadButtonClicked);
+    connect(m_ui->updateButton, &QPushButton::clicked, this, &UpdaterWindow::onDownloadButtonClicked);
     connect(m_updater, &QSimpleUpdater::checkingFinished, this, &UpdaterWindow::onCheckFinished);
     connect(m_ui->checkBox, &QCheckBox::toggled, this, &UpdaterWindow::dontShowUpdateWindowChanged);
 
@@ -199,9 +194,8 @@ void UpdaterWindow::resetControls()
     if (m_ui->changelog->toPlainText().isEmpty()) {
         m_ui->changelog->setText("<p>No changelog found...</p>");
     } else {
-        m_ui->changelog->setText(changelogText.append(
-                "\n")); // Don't know why currently changelog box is disappearing at the bottom, so
-                        // I add a new line to see the text.
+        m_ui->changelog->setText(changelogText.append("\n")); // Don't know why currently changelog box is disappearing at the bottom, so
+                                                              // I add a new line to see the text.
     }
 
     /* Enable/disable update button */
@@ -287,16 +281,13 @@ void UpdaterWindow::startDownload(const QUrl &url)
     m_startTime = QDateTime::currentDateTime().toSecsSinceEpoch();
     QNetworkRequest netReq(url);
 
-    netReq.setAttribute(QNetworkRequest::RedirectPolicyAttribute,
-                        QNetworkRequest::NoLessSafeRedirectPolicy);
+    netReq.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
     m_reply = m_manager->get(netReq);
 
     /* Set file name */
     m_fileName = m_updater->getDownloadUrl(UPDATES_URL).split("/").last();
     if (m_fileName.isEmpty()) {
-        m_fileName = QStringLiteral("%1_Update_%2.bin")
-                             .arg(QCoreApplication::applicationName(),
-                                  m_updater->getLatestVersion(UPDATES_URL));
+        m_fileName = QStringLiteral("%1_Update_%2.bin").arg(QCoreApplication::applicationName(), m_updater->getLatestVersion(UPDATES_URL));
     }
 
     /* Prepare download directory */
@@ -450,8 +441,7 @@ void UpdaterWindow::calculateSizes(qint64 received, qint64 total)
     }
 
     /* Update the label text */
-    m_ui->downloadLabel->setText(tr("Downloading updates") + " (" + receivedSize + " " + tr("of")
-                                 + " " + totalSize + ")");
+    m_ui->downloadLabel->setText(tr("Downloading updates") + " (" + receivedSize + " " + tr("of") + " " + totalSize + ")");
 }
 
 /**
@@ -510,7 +500,7 @@ void UpdaterWindow::calculateTimeRemaining(qint64 received, qint64 total)
             } else {
                 timeString = tr("1 minute");
             }
-        } else if (timeRemaining <= 60) {
+        } else { // timeRemaining <= 60
             int seconds = int(timeRemaining + 0.5);
 
             if (seconds > 1) {
@@ -526,8 +516,7 @@ void UpdaterWindow::calculateTimeRemaining(qint64 received, qint64 total)
 
 void UpdaterWindow::onDownloadFinished()
 {
-    QString redirectedUrl =
-            m_reply->attribute(QNetworkRequest::RedirectionTargetAttribute).toString();
+    QString redirectedUrl = m_reply->attribute(QNetworkRequest::RedirectionTargetAttribute).toString();
 
     if (redirectedUrl.isEmpty()) {
         const QString filePath = m_downloadDir.filePath(m_fileName);
@@ -551,8 +540,7 @@ void UpdaterWindow::onDownloadFinished()
 void UpdaterWindow::mousePressEvent(QMouseEvent *event)
 {
     if (event->button() == Qt::LeftButton) {
-        if (event->position().x() < width() - 5 && event->position().x() > 5
-            && event->position().toPoint().y() < height() - 5
+        if (event->position().x() < width() - 5 && event->position().x() > 5 && event->position().toPoint().y() < height() - 5
             && event->position().toPoint().y() > 5) {
             m_canMoveWindow = !window()->windowHandle()->startSystemMove();
             m_mousePressX = event->position().toPoint().x();

--- a/src/updaterwindow.cpp
+++ b/src/updaterwindow.cpp
@@ -7,7 +7,7 @@
 #include "updaterwindow.h"
 #include "ui_updaterwindow.h"
 
-#include <math.h>
+#include <cmath>
 
 #include <QTimer>
 #include <QMessageBox>
@@ -400,8 +400,8 @@ void UpdaterWindow::openDownloadFolder(const QString &file)
                              QMessageBox::Ok);
 
     /* Get the full path list of the downloaded file */
-    QString native_path = QDir::toNativeSeparators(QDir(file).absolutePath());
-    QStringList directories = native_path.split(QDir::separator());
+    QString nativePath = QDir::toNativeSeparators(QDir(file).absolutePath());
+    QStringList directories = nativePath.split(QDir::separator());
 
     /* Remove file name from list to get the folder of the update file */
     directories.removeLast();

--- a/src/updaterwindow.h
+++ b/src/updaterwindow.h
@@ -10,7 +10,7 @@
 #include <QDialog>
 #include <QDir>
 
-namespace Ui {
+namespace Ui { // NOLINT(readability-identifier-naming)
 class UpdaterWindow;
 }
 
@@ -24,10 +24,10 @@ class UpdaterWindow : public QDialog
     Q_OBJECT
 
 public:
-    explicit UpdaterWindow(QWidget *parent = 0);
-    ~UpdaterWindow();
+    explicit UpdaterWindow(QWidget *parent = nullptr);
+    ~UpdaterWindow() override;
 
-    void setShowWindowDisable(const bool dontShowWindow);
+    void setShowWindowDisable(bool dontShowWindow);
 
 public slots:
     void checkForUpdates(bool force);
@@ -43,7 +43,7 @@ private slots:
     void startDownload(const QUrl &url);
     void openDownload(const QString &file);
     void onCheckFinished(const QString &url);
-    void onXdgOpenFinished(const int exitCode);
+    void onXdgOpenFinished(int exitCode);
     void openDownloadFolder(const QString &file);
     void calculateSizes(qint64 received, qint64 total);
     void updateProgress(qint64 received, qint64 total);

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <cmath>
+#include <QString>
+#include <QDateTime>
+
+namespace utils {
+
+/**
+ * @brief
+ *
+ * @param x
+ * @param center
+ * @param sigma
+ * @return double
+ */
+inline double gaussianDist(double x, double center, double sigma)
+{
+    return (1.0 / (2 * M_PI * pow(sigma, 2)) * exp(-pow(x - center, 2) / (2 * pow(sigma, 2))));
+}
+
+/**
+ * @brief
+ *
+ * @param dateTime
+ * @return QString
+ */
+inline QString parseDateTime(const QDateTime &dateTime)
+{
+    QLocale usLocale(QLocale("en_US"));
+
+    auto currDateTime = QDateTime::currentDateTime();
+
+    if (dateTime.date() == currDateTime.date()) {
+        return usLocale.toString(dateTime.time(), "h:mm A");
+    }
+    if (dateTime.daysTo(currDateTime) == 1) {
+        return "Yesterday";
+    }
+    if (dateTime.daysTo(currDateTime) >= 2 && dateTime.daysTo(currDateTime) <= 7) {
+        return usLocale.toString(dateTime.date(), "dddd");
+    }
+
+    return dateTime.date().toString("M/d/yy");
+}
+
+} // namespace utils


### PR DESCRIPTION
Command used:
```
cppcheck --enable=all --inconclusive --force --inline-suppr --library=qt --project=build/compile_commands.json --suppress="*:3rdParty*" --suppress="*:build/*" -i 3rdParty/ -i build --suppress=missingIncludeSystem --suppress=missing
Include --suppress=useStlAlgorithm --quiet -j$(nproc) --disable=unusedFunction --check-level=exhaustive  2>&1 | tee cppcheck.txt
```
All warnings are now fixed. 

The command has 3 suppresions:
* `--suppress=missingIncludeSystem`: because it can't find any Qt system libraries. Not sure how to fix this, we already pass `--library=qt`...
* `--suppress=missingInclude`: same reason
* `--suppress=useStlAlgorithm`: it often suggests changing a simple for-loop to a much less readable std::transform call.