### PR TITLE
Add macOS-specific keyboard shortcuts for note navigation

### DIFF
--- a/docs/keyboard_shortcuts.md
+++ b/docs/keyboard_shortcuts.md
@@ -24,10 +24,10 @@ These shortcuts are meant to be used while the Notes window is currently focused
 | <kbd>Ctrl</kbd> + <kbd>E</kbd>                        | Clear the search bar                                          |
 | <kbd>Ctrl</kbd> + <kbd>↓</kbd> (or just <kbd>↓</kbd>) | Select note below                                             |
 | <kbd>Ctrl</kbd> + <kbd>↑</kbd> (or just <kbd>↑</kbd>) | Select note above                                             |
-| <kbd>Ctrl</kbd> + <kbd>↓</kbd> (macOS)             | Select note below                                             |
-| <kbd>Ctrl</kbd> + <kbd>↑</kbd> (macOS)             | Select note above                                             |
+| <kbd>Ctrl</kbd> + <kbd>↓</kbd> _(macOS)_              | Select note below                                             |
+| <kbd>Ctrl</kbd> + <kbd>↑</kbd> _(macOS)_              | Select note above                                             |
 | <kbd>Ctrl</kbd> + <kbd>Enter</kbd>                    | Focus on the text editor                                      |
-| <kbd>Ctrl</kbd> + <kbd>L</kbd> (macOS)             | Focus on the text editor                                      |
+| <kbd>Ctrl</kbd> + <kbd>L</kbd> _(macOS)_              | Focus on the text editor                                      |
 | <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>F</kbd>     | Toggle full screen mode                                       |
 | <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>K</kbd>     | Toggle kanban view                                            |
 | <kbd>F11</kbd>                                        | Toggle full screen mode                                       |

--- a/src/listviewlogic.cpp
+++ b/src/listviewlogic.cpp
@@ -191,7 +191,7 @@ void ListViewLogic::selectNoteUp()
 {
     // Ensure the list view has focus
     m_listView->setFocus();
-    
+
     auto currentIndex = m_listView->currentIndex();
     if (currentIndex.isValid()) {
         int currentRow = currentIndex.row();
@@ -214,7 +214,7 @@ void ListViewLogic::selectNoteDown()
 {
     // Ensure the list view has focus
     m_listView->setFocus();
-    
+
     auto currentIndex = m_listView->currentIndex();
     if (currentIndex.isValid()) {
         int currentRow = currentIndex.row();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -532,8 +532,8 @@ void MainWindow::setupKeyboardShortcuts()
     new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_D), this, SLOT(deleteSelectedNote()));
     new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_F), m_searchEdit, SLOT(setFocus()));
     new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_E), m_searchEdit, SLOT(clear()));
-    
-    // Add macOS-specific shortcuts for note navigation
+
+    // Shortcuts for note navigation
 #if defined(Q_OS_MACOS)
     new QShortcut(QKeySequence(Qt::META | Qt::Key_Down), this, SLOT(selectNoteDown()));
     new QShortcut(QKeySequence(Qt::META | Qt::Key_Up), this, SLOT(selectNoteUp()));
@@ -543,7 +543,7 @@ void MainWindow::setupKeyboardShortcuts()
     new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_Up), this, SLOT(selectNoteUp()));
     new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_L), this, SLOT(setFocusOnText()));
 #endif
-    
+
     new QShortcut(QKeySequence(Qt::Key_Down), this, SLOT(selectNoteDown()));
     new QShortcut(QKeySequence(Qt::Key_Up), this, SLOT(selectNoteUp()));
     new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_Enter), this, SLOT(setFocusOnText()));


### PR DESCRIPTION
## Description
This PR adds macOS-specific keyboard shortcuts for note navigation and improves the overall keyboard navigation experience. The changes ensure that keyboard shortcuts work consistently across different platforms and match user expectations on macOS.

### Changes Made
1. Added macOS-specific keyboard shortcuts:
   - `Control + ↑` to select note above   
   - `Control + ↓` to select note below
   - `Control + L` to focus on the text editor

2. Updated keyboard shortcuts documentation to reflect these changes.

## Testing
- Tested on macOS Sequoia (15.3)
- Verified that shortcuts work when:
  - Text editor is focused
  - List view is focused
  - Search bar is focused

## Related Issue
Fixes #186  - Command + arrows doesn't work on Mac

## Notes
The changes should maintain backward compatibility while improving the user experience for macOS users. The implementation uses the Control (called META in code) key, which is the standard approach for cross-platform applications.

This fix currently requires that the user disable the default macOS behavior of using `Control + ↑` for Mission Control and `Control + ↓` to show Application Windows by doing the following:
1. Open System Preferences -> Keyboard -> Keyboard Shortcuts... ->  Mission Control
2. Untick the `Mission Control` and `Application Windows`