### PR TITLE
Replace `QQuickView` with `QQuickWidget` for Kanban view

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,8 @@ set(QT_COMPONENTS
     Sql
     Test
     Widgets
-    Quick)
+    Quick
+    QuickWidgets)
 
 message(STATUS "Trying to find Qt 6...")
 find_package(QT NAMES Qt6 QUIET)
@@ -367,7 +368,8 @@ target_link_libraries(
          Qt${QT_VERSION_MAJOR}::Sql
          Qt${QT_VERSION_MAJOR}::Widgets
          Qt${QT_VERSION_MAJOR}::WidgetsPrivate
-         Qt${QT_VERSION_MAJOR}::Quick)
+         Qt${QT_VERSION_MAJOR}::Quick
+         Qt${QT_VERSION_MAJOR}::QuickWidgets)
 
 if(APPLE)
   set(COPYRIGHT_TEXT

--- a/packaging/windows/Notes_Inno_Script_Github.iss
+++ b/packaging/windows/Notes_Inno_Script_Github.iss
@@ -182,6 +182,7 @@ Source: "{#SourcePath}\Notes64\Qt6QuickLayouts.dll"; DestDir: "{app}"; Flags: ig
 Source: "{#SourcePath}\Notes64\Qt6QuickParticles.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: IsWin64; MinVersion: 10.0.17763
 Source: "{#SourcePath}\Notes64\Qt6QuickShapes.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: IsWin64; MinVersion: 10.0.17763
 Source: "{#SourcePath}\Notes64\Qt6QuickTemplates2.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: IsWin64; MinVersion: 10.0.17763
+Source: "{#SourcePath}\Notes64\Qt6QuickWidgets.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: IsWin64; MinVersion: 10.0.17763
 Source: "{#SourcePath}\Notes64\Qt6Sql.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: IsWin64; MinVersion: 10.0.17763
 Source: "{#SourcePath}\Notes64\Qt6Svg.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: IsWin64; MinVersion: 10.0.17763
 Source: "{#SourcePath}\Notes64\Qt6Widgets.dll"; DestDir: "{app}"; Flags: ignoreversion; Check: IsWin64; MinVersion: 10.0.17763

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -66,8 +66,7 @@ MainWindow::MainWindow(QWidget *parent)
       m_treeModel(new NodeTreeModel(this)),
       m_treeViewLogic(nullptr),
 #if QT_VERSION >= QT_VERSION_CHECK(6, 2, 0)
-      m_kanbanQuickView(nullptr),
-      m_kanbanWidget(this),
+      m_kanbanWidget(nullptr),
 #endif
       m_editorSettingsQuickView(nullptr),
       m_editorSettingsWidget(new QWidget(this)),
@@ -1205,11 +1204,11 @@ void MainWindow::setupKanbanView()
     // https://doc.qt.io/qt-6/qtquick-quickwidgets-qquickwidgetversuswindow-opengl-example.html
 
     QUrl source("qrc:/qt/qml/kanbanMain.qml");
-    m_kanbanQuickView.rootContext()->setContextProperty("noteEditorLogic", m_noteEditorLogic);
-    m_kanbanQuickView.rootContext()->setContextProperty("mainWindow", this);
-    m_kanbanQuickView.setSource(source);
-    m_kanbanQuickView.setResizeMode(QQuickView::SizeRootObjectToView);
-    m_kanbanWidget = QWidget::createWindowContainer(&m_kanbanQuickView, this);
+    m_kanbanWidget = new QQuickWidget(this);
+    m_kanbanWidget->rootContext()->setContextProperty("noteEditorLogic", m_noteEditorLogic);
+    m_kanbanWidget->rootContext()->setContextProperty("mainWindow", this);
+    m_kanbanWidget->setSource(source);
+    m_kanbanWidget->setResizeMode(QQuickWidget::SizeRootObjectToView);
     m_kanbanWidget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     m_kanbanWidget->hide();
     m_ui->verticalLayout_textEdit->insertWidget(m_ui->verticalLayout_textEdit->indexOf(m_textEdit), m_kanbanWidget);
@@ -1626,7 +1625,7 @@ void MainWindow::setupModelView()
     m_treeViewLogic = new TreeViewLogic(m_treeView, m_treeModel, m_dbManager, m_listView, this);
 #if QT_VERSION >= QT_VERSION_CHECK(6, 2, 0)
     m_noteEditorLogic = new NoteEditorLogic(m_textEdit, m_editorDateLabel, m_searchEdit, m_kanbanWidget, m_ui->tagListView, m_tagPool, m_dbManager, this);
-    m_kanbanQuickView.rootContext()->setContextProperty("noteEditorLogic", m_noteEditorLogic);
+    m_kanbanWidget->rootContext()->setContextProperty("noteEditorLogic", m_noteEditorLogic);
 #else
     m_noteEditorLogic = new NoteEditorLogic(m_textEdit, m_editorDateLabel, m_searchEdit, m_ui->tagListView, m_tagPool, m_dbManager, this);
 #endif

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -26,6 +26,7 @@
 #include <QtGlobal>
 #include <QWidget>
 #include <QQuickView>
+#include <QQuickWidget>
 #include <QQmlContext>
 #include <QVariant>
 #include <QJsonObject>
@@ -168,8 +169,7 @@ private:
     NodeTreeModel *m_treeModel;
     TreeViewLogic *m_treeViewLogic;
 #if QT_VERSION >= QT_VERSION_CHECK(6, 2, 0)
-    QQuickView m_kanbanQuickView;
-    QWidget *m_kanbanWidget;
+    QQuickWidget *m_kanbanWidget;
 #endif
     QQuickView m_editorSettingsQuickView;
     QWidget *m_editorSettingsWidget;


### PR DESCRIPTION
Qt docs note that `QWidget::createWindowContainer` has a number of [known limitations](https://doc.qt.io/qt-6/qwidget.html#createWindowContainer), with one of them being focus handling.

On Wayland, that limitation seems to be preventing us from typing anything into the Kanban view, because it never gains focus.

Fixes #617

---

I've tested this on Linux (on both X11 and Wayland sessions), Windows 10, and I didn't notice any difference in behavior compared to the previous approach.

I've also tested the pre-built DEB and RPM packages on their appropriate target distros.

cc @nuttyartist: Can you please test this on macOS? Thanks!

