### PR TITLE
cmake: Search for private modules with Qt 6.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,11 @@ if(NOT DEFINED QT_VERSION_MAJOR OR QT_VERSION_MAJOR LESS 6)
   message(STATUS "Could not find Qt 6, aborting compilation.")
 endif()
 
+# https://doc.qt.io/qt-6/whatsnew610.html#build-system-changes
+if(QT_VERSION VERSION_GREATER_EQUAL 6.10)
+  list(APPEND QT_COMPONENTS CorePrivate GuiPrivate WidgetsPrivate)
+endif()
+
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS ${QT_COMPONENTS})
 
 message(STATUS "Success! Configuration details:")


### PR DESCRIPTION
According to [What's New in Qt 6.10](https://doc.qt.io/qt-6/whatsnew610.html#build-system-changes):

> Usage of a private Qt module Foo now requires a call to `find_package(Qt6 COMPONENTS FooPrivate)` to make the `Qt6::FooPrivate` target available.

Otherwise, the build complains about:

```
CMake Error at CMakeLists.txt:354 (target_link_libraries):
  Target "Notes" links to:

    Qt6::CorePrivate

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.
```