### PR TITLE
Fix: macOS titlebar safe area margins for Qt 6.9.0+

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -358,6 +358,10 @@ void MainWindow::setupMainWindow()
     flags = Qt::Window; // cppcheck-suppress redundantInitialization // false positive
 #  endif
     setWindowFlags(flags);
+#else
+#  if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+    setAttribute(Qt::WA_ContentsMarginsRespectsSafeArea, false);
+#  endif
 #endif
 
 #if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)


### PR DESCRIPTION
Before:
<img width="1218" height="806" alt="Screenshot 2025-10-12 at 18 14 25" src="https://github.com/user-attachments/assets/006e9d7a-c388-4bb1-a14d-277df2eccff4" />
After:
<img width="1218" height="806" alt="Screenshot 2025-10-12 at 18 14 09" src="https://github.com/user-attachments/assets/53892891-6228-42ee-89e7-c8b501c43f91" />
