### PR TITLE
CI/macOS: Update to macOS 15

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Install Qt 6 (homebrew)
         run: |
-          brew install ninja qt@6 
+          brew install qt@6
 
       - name: Setup CLang problem matcher
         # Technically, this action only supports GCC, but it seems to work well for Clang too.
@@ -96,7 +96,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          brew install create-dmg ninja
+          brew install create-dmg
 
       - name: Build (${{ matrix.build-type }})
         env:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -36,7 +36,6 @@ jobs:
         env:
           VERBOSE: 1
         run: |
-          export CMAKE_BUILD_PARALLEL_LEVEL=$(sysctl -n hw.logicalcpu)
           cmake . --warn-uninitialized --warn-unused-vars \
               -G Ninja -B build \
               -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
@@ -102,7 +101,6 @@ jobs:
         env:
           VERBOSE: 1
         run: |
-          export CMAKE_BUILD_PARALLEL_LEVEL=$(sysctl -n hw.logicalcpu)
           cmake . --warn-uninitialized --warn-unused-vars \
               -B build -G Ninja \
               -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 \

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -100,7 +100,6 @@ jobs:
 
       - name: Build (${{ matrix.build-type }})
         env:
-          TARGET_ARCH: x86_64;arm64
           VERBOSE: 1
         run: |
           export CMAKE_BUILD_PARALLEL_LEVEL=$(sysctl -n hw.logicalcpu)

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-13
+          - os: macos-15-intel
             build-type: debug
     steps:
       - name: Checkout code
@@ -53,7 +53,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-13
+          - os: macos-15-intel
             qt-version: 6.5.2
             build-type: release
     steps:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -161,9 +161,12 @@ jobs:
 
       - name: Install latest Inno Setup
         run: |
-          winget install --id JRSoftware.InnoSetup --exact --silent --source winget
-          # Add to PATH
-          Add-Content $env:GITHUB_PATH "$env:LOCALAPPDATA\Programs\Inno Setup 6"
+          # Only installs if Inno Setup's Compiler (ISCC.exe) is not already in the PATH environment variable.
+          if (-Not (Get-Command ISCC -ErrorAction SilentlyContinue)) {
+              winget install --id JRSoftware.InnoSetup --exact --silent --source winget
+              # Add to PATH
+              Add-Content $env:GITHUB_PATH "$env:LOCALAPPDATA\Programs\Inno Setup 6"
+          }
 
       - name: Create installer
         run: |

--- a/docs/build_on_macos.md
+++ b/docs/build_on_macos.md
@@ -26,12 +26,6 @@ git clone https://github.com/nuttyartist/notes.git --recurse-submodules
 cd notes
 ```
 
-Optionally, if you want to dedicate all cores of your CPU to build Notes much faster, set this environment variable:
-
-```shell
-export CMAKE_BUILD_PARALLEL_LEVEL=$(sysctl -n hw.logicalcpu)
-```
-
 After that, we're ready to build Notes!
 
 Invoke CMake to configure and build the project into a folder called `build`, in [`Release` mode](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html):


### PR DESCRIPTION
The macOS 13 runner is getting removed by GitHub in December 4th, 2025:

https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/

I decided to go with the `-intel` variant of macOS 15, because I think it makes sense to build for x86_64 for as long as we can, even though Apple is also retiring the architecture.

While I don't have a Mac to actually test the resulting binary, I've extracted the `Notes` binary from the DMG image on Linux and ran the `file` command on it, which looks okay:

```sh
$ 7z e Notes.dmg 'Notes/Notes Better.app/Contents/MacOS/Notes'
$ file Notes
Notes: Mach-O universal binary with 2 architectures: [x86_64:\012- Mach-O 64-bit x86_64 executable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|WEAK_DEFINES|BINDS_TO_WEAK|PIE>] [\012- arm64]
```

Still, it'd be great if @nuttyartist could test the resulting binary on both x86_64 and ARM64 Macs (if possible).

Thanks!