### PR TITLE
Fix note list rendering at fractional display scaling

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,9 +8,12 @@
 #include "singleinstance.h"
 #include <QApplication>
 #include <QFontDatabase>
+#include <QGuiApplication>
 
 int main(int argc, char *argv[])
 {
+    QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
+
     QApplication app(argc, argv);
     // Set application information
     QApplication::setApplicationName("Notes");

--- a/src/notelistdelegate.cpp
+++ b/src/notelistdelegate.cpp
@@ -294,11 +294,11 @@ QTimeLine::State NoteListDelegate::animationState()
 void NoteListDelegate::paintBackground(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
 {
     auto bufferSize = bufferSizeHint(option, index);
-    QPixmap buffer{ bufferSize };
+    QPixmap buffer = utils::makeDevicePixelRatioPixmap(bufferSize, m_view);
     buffer.fill(Qt::transparent);
     QPainter bufferPainter{ &buffer };
     bufferPainter.setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform);
-    QRect bufferRect = buffer.rect();
+    QRect bufferRect{ QPoint{}, bufferSize };
     auto isPinned = index.data(NoteListModel::NoteIsPinned).toBool();
     auto const *model = static_cast<NoteListModel *>(m_view->model());
     if (model->hasPinnedNote() && model->isFirstPinnedNote(index) && static_cast<NoteListView *>(m_view)->isPinnedNotesCollapsed()) {
@@ -419,7 +419,7 @@ void NoteListDelegate::paintLabels(QPainter *painter, const QStyleOptionViewItem
 {
     if (m_animatedIndexes.contains(index)) {
         auto bufferSize = bufferSizeHint(option, index);
-        QPixmap buffer{ bufferSize };
+        QPixmap buffer = utils::makeDevicePixelRatioPixmap(bufferSize, m_view);
         buffer.fill(Qt::transparent);
         QPainter bufferPainter{ &buffer };
         bufferPainter.setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform);

--- a/src/notelistdelegate.cpp
+++ b/src/notelistdelegate.cpp
@@ -298,7 +298,7 @@ void NoteListDelegate::paintBackground(QPainter *painter, const QStyleOptionView
     buffer.fill(Qt::transparent);
     QPainter bufferPainter{ &buffer };
     bufferPainter.setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform);
-    QRect bufferRect{ QPoint{}, bufferSize };
+    QRect bufferRect{ QPoint{ }, bufferSize };
     auto isPinned = index.data(NoteListModel::NoteIsPinned).toBool();
     auto const *model = static_cast<NoteListModel *>(m_view->model());
     if (model->hasPinnedNote() && model->isFirstPinnedNote(index) && static_cast<NoteListView *>(m_view)->isPinnedNotesCollapsed()) {

--- a/src/notelistdelegateeditor.cpp
+++ b/src/notelistdelegateeditor.cpp
@@ -135,11 +135,11 @@ NoteListDelegateEditor::~NoteListDelegateEditor()
 void NoteListDelegateEditor::paintBackground(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
 {
     auto bufferSize = rect().size();
-    QPixmap buffer{ bufferSize };
+    QPixmap buffer = utils::makeDevicePixelRatioPixmap(bufferSize, this);
     buffer.fill(Qt::transparent);
     QPainter bufferPainter{ &buffer };
     bufferPainter.setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform);
-    QRect bufferRect = buffer.rect();
+    QRect bufferRect{ QPoint{}, bufferSize };
     auto const *noteListModel = static_cast<NoteListModel *>(m_view->model());
     if (noteListModel->hasPinnedNote() && (noteListModel->isFirstPinnedNote(index) || noteListModel->isFirstUnpinnedNote(index))) {
         int fifthYOffset = 0;
@@ -375,7 +375,7 @@ bool NoteListDelegateEditor::underMouseC() const
 
 QPixmap NoteListDelegateEditor::renderToPixmap()
 {
-    QPixmap result{ rect().size() };
+    QPixmap result = utils::makeDevicePixelRatioPixmap(rect().size(), this);
     result.fill(Qt::yellow);
     QPainter painter(&result);
     painter.setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform);

--- a/src/notelistdelegateeditor.cpp
+++ b/src/notelistdelegateeditor.cpp
@@ -139,7 +139,7 @@ void NoteListDelegateEditor::paintBackground(QPainter *painter, const QStyleOpti
     buffer.fill(Qt::transparent);
     QPainter bufferPainter{ &buffer };
     bufferPainter.setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform);
-    QRect bufferRect{ QPoint{}, bufferSize };
+    QRect bufferRect{ QPoint{ }, bufferSize };
     auto const *noteListModel = static_cast<NoteListModel *>(m_view->model());
     if (noteListModel->hasPinnedNote() && (noteListModel->isFirstPinnedNote(index) || noteListModel->isFirstUnpinnedNote(index))) {
         int fifthYOffset = 0;

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,8 +1,13 @@
 #pragma once
 
+#include <QGuiApplication>
 #include <cmath>
-#include <QString>
 #include <QDateTime>
+#include <QPixmap>
+#include <QScreen>
+#include <QString>
+#include <QWidget>
+#include <QWindow>
 
 namespace utils {
 
@@ -42,6 +47,31 @@ inline QString parseDateTime(const QDateTime &dateTime)
     }
 
     return dateTime.date().toString("M/d/yy");
+}
+
+inline qreal devicePixelRatioForWidget(const QWidget *widget)
+{
+    if (widget != nullptr) {
+        if (auto *topLevelWindow = widget->window(); (topLevelWindow != nullptr) && (topLevelWindow->windowHandle() != nullptr)) {
+            return topLevelWindow->windowHandle()->devicePixelRatio();
+        }
+
+        return widget->devicePixelRatioF();
+    }
+
+    if (auto *screen = QGuiApplication::primaryScreen(); screen != nullptr) {
+        return screen->devicePixelRatio();
+    }
+
+    return qreal(1);
+}
+
+inline QPixmap makeDevicePixelRatioPixmap(const QSize &logicalSize, const QWidget *widget)
+{
+    const qreal scale = devicePixelRatioForWidget(widget);
+    QPixmap pixmap(logicalSize * scale);
+    pixmap.setDevicePixelRatio(scale);
+    return pixmap;
 }
 
 } // namespace utils


### PR DESCRIPTION
## Summary
- set Qt high-DPI scale factor rounding to pass through before creating the application
- create note-list delegate paint buffers with the owning widget/window device-pixel ratio
- use logical buffer geometry while painting cropped row backgrounds/labels, so Windows fractional scaling does not mix physical pixmap pixels with logical item rects

Fixes #164.

## Verification
- `git diff --check`
- `c++ -std=c++17 -fsyntax-only -include arm_acle.h ... src/notelistdelegate.cpp src/notelistdelegateeditor.cpp` against locally installed Qt 6.9.2 headers
- syntax-only check for `QGuiApplication::setHighDpiScaleFactorRoundingPolicy(...)` against Qt 6.9.2 headers

I could not run the full CMake build locally because `cmake` is not installed in this environment, and `clang-format` is also unavailable locally.