### PR TITLE
Stabilize note list text alignment on Windows

### DIFF
--- a/src/notelistdelegate.cpp
+++ b/src/notelistdelegate.cpp
@@ -426,20 +426,20 @@ void NoteListDelegate::paintLabels(QPainter *painter, const QStyleOptionViewItem
         QString title{ index.data(NoteListModel::NoteFullTitle).toString() };
         QFont titleFont = (option.state & QStyle::State_Selected) == QStyle::State_Selected ? m_titleSelectedFont : m_titleFont;
         QFontMetrics fmTitle(titleFont);
-        QRect fmRectTitle = fmTitle.boundingRect(title);
+        const int titleLineHeight = fmTitle.height();
 
         QString date = utils::parseDateTime(index.data(NoteListModel::NoteLastModificationDateTime).toDateTime());
         QFontMetrics fmDate(m_dateFont);
-        QRect fmRectDate = fmDate.boundingRect(date);
+        const int dateLineHeight = fmDate.height();
 
         QString parentName{ index.data(NoteListModel::NoteParentName).toString() };
         QFontMetrics fmParentName(titleFont);
-        QRect fmRectParentName = fmParentName.boundingRect(parentName);
+        const int parentNameLineHeight = fmParentName.height();
 
         QString content{ index.data(NoteListModel::NoteContent).toString() };
         content = NoteEditorLogic::getSecondLine(content);
         QFontMetrics fmContent(titleFont);
-        QRect fmRectContent = fmContent.boundingRect(content);
+        const int contentLineHeight = fmContent.height();
         double rowPosX = 0; // option.rect.x();
         double rowPosY = 0; // option.rect.y();
         auto const *noteListModel = static_cast<NoteListModel *>(m_view->model());
@@ -472,17 +472,17 @@ void NoteListDelegate::paintLabels(QPainter *painter, const QStyleOptionViewItem
         double titleRectPosX = rowPosX + note_list_constants::LEFT_OFFSET_X;
         double titleRectPosY = rowPosY;
         double titleRectWidth = rowWidth - (2.0 * note_list_constants::LEFT_OFFSET_X);
-        double titleRectHeight = fmRectTitle.height() + note_list_constants::TOP_OFFSET_Y + yOffsets;
+        double titleRectHeight = titleLineHeight + note_list_constants::TOP_OFFSET_Y + yOffsets;
 
         double dateRectPosX = rowPosX + note_list_constants::LEFT_OFFSET_X;
-        double dateRectPosY = rowPosY + fmRectTitle.height() + note_list_constants::TOP_OFFSET_Y + yOffsets;
+        double dateRectPosY = rowPosY + titleLineHeight + note_list_constants::TOP_OFFSET_Y + yOffsets;
         double dateRectWidth = rowWidth - (2.0 * note_list_constants::LEFT_OFFSET_X);
-        double dateRectHeight = fmRectDate.height() + note_list_constants::TITLE_DATE_SPACE;
+        double dateRectHeight = dateLineHeight + note_list_constants::TITLE_DATE_SPACE;
 
         double contentRectPosX = rowPosX + note_list_constants::LEFT_OFFSET_X;
-        double contentRectPosY = rowPosY + fmRectTitle.height() + fmRectDate.height() + note_list_constants::TOP_OFFSET_Y + yOffsets;
+        double contentRectPosY = rowPosY + titleLineHeight + dateLineHeight + note_list_constants::TOP_OFFSET_Y + yOffsets;
         double contentRectWidth = rowWidth - (2.0 * note_list_constants::LEFT_OFFSET_X);
-        double contentRectHeight = fmRectContent.height() + note_list_constants::DATE_DESC_SPACE;
+        double contentRectHeight = contentLineHeight + note_list_constants::DATE_DESC_SPACE;
 
         double folderNameRectPosX = 0;
         double folderNameRectPosY = 0;
@@ -491,9 +491,9 @@ void NoteListDelegate::paintLabels(QPainter *painter, const QStyleOptionViewItem
 
         if (m_isInAllNotes) {
             folderNameRectPosX = rowPosX + note_list_constants::LEFT_OFFSET_X + 20;
-            folderNameRectPosY = rowPosY + fmRectContent.height() + fmRectTitle.height() + fmRectDate.height() + note_list_constants::TOP_OFFSET_Y + yOffsets;
+            folderNameRectPosY = rowPosY + contentLineHeight + titleLineHeight + dateLineHeight + note_list_constants::TOP_OFFSET_Y + yOffsets;
             folderNameRectWidth = rowWidth - 2.0 * note_list_constants::LEFT_OFFSET_X;
-            folderNameRectHeight = fmRectParentName.height() + note_list_constants::DESC_FOLDER_SPACE;
+            folderNameRectHeight = parentNameLineHeight + note_list_constants::DESC_FOLDER_SPACE;
         }
 
         auto drawStr = [&bufferPainter](double posX, double posY, double width, double height, QColor color, const QFont &font, const QString &str) {
@@ -576,20 +576,20 @@ void NoteListDelegate::paintLabels(QPainter *painter, const QStyleOptionViewItem
         QString title{ index.data(NoteListModel::NoteFullTitle).toString() };
         QFont titleFont = m_view->selectionModel()->isSelected(index) ? m_titleSelectedFont : m_titleFont;
         QFontMetrics fmTitle(titleFont);
-        QRect fmRectTitle = fmTitle.boundingRect(title);
+        const int titleLineHeight = fmTitle.height();
 
         QString date = utils::parseDateTime(index.data(NoteListModel::NoteLastModificationDateTime).toDateTime());
         QFontMetrics fmDate(m_dateFont);
-        QRect fmRectDate = fmDate.boundingRect(date);
+        const int dateLineHeight = fmDate.height();
 
         QString parentName{ index.data(NoteListModel::NoteParentName).toString() };
         QFontMetrics fmParentName(titleFont);
-        QRect fmRectParentName = fmParentName.boundingRect(parentName);
+        const int parentNameLineHeight = fmParentName.height();
 
         QString content{ index.data(NoteListModel::NoteContent).toString() };
         content = NoteEditorLogic::getSecondLine(content);
         QFontMetrics fmContent(titleFont);
-        QRect fmRectContent = fmContent.boundingRect(content);
+        const int contentLineHeight = fmContent.height();
 
         double rowPosX = option.rect.x();
         double rowPosY = option.rect.y();
@@ -652,17 +652,17 @@ void NoteListDelegate::paintLabels(QPainter *painter, const QStyleOptionViewItem
         double titleRectPosX = rowPosX + note_list_constants::LEFT_OFFSET_X;
         double titleRectPosY = rowPosY;
         double titleRectWidth = rowWidth - (2.0 * note_list_constants::LEFT_OFFSET_X);
-        double titleRectHeight = fmRectTitle.height() + note_list_constants::TOP_OFFSET_Y + yOffsets;
+        double titleRectHeight = titleLineHeight + note_list_constants::TOP_OFFSET_Y + yOffsets;
 
         double dateRectPosX = rowPosX + note_list_constants::LEFT_OFFSET_X;
-        double dateRectPosY = rowPosY + fmRectTitle.height() + note_list_constants::TOP_OFFSET_Y + yOffsets;
+        double dateRectPosY = rowPosY + titleLineHeight + note_list_constants::TOP_OFFSET_Y + yOffsets;
         double dateRectWidth = rowWidth - (2.0 * note_list_constants::LEFT_OFFSET_X);
-        double dateRectHeight = fmRectDate.height() + note_list_constants::TITLE_DATE_SPACE;
+        double dateRectHeight = dateLineHeight + note_list_constants::TITLE_DATE_SPACE;
 
         double contentRectPosX = rowPosX + note_list_constants::LEFT_OFFSET_X;
-        double contentRectPosY = rowPosY + fmRectTitle.height() + fmRectDate.height() + note_list_constants::TOP_OFFSET_Y + yOffsets;
+        double contentRectPosY = rowPosY + titleLineHeight + dateLineHeight + note_list_constants::TOP_OFFSET_Y + yOffsets;
         double contentRectWidth = rowWidth - (2.0 * note_list_constants::LEFT_OFFSET_X);
-        double contentRectHeight = fmRectContent.height() + note_list_constants::DATE_DESC_SPACE;
+        double contentRectHeight = contentLineHeight + note_list_constants::DATE_DESC_SPACE;
 
         double folderNameRectPosX = 0;
         double folderNameRectPosY = 0;
@@ -671,9 +671,9 @@ void NoteListDelegate::paintLabels(QPainter *painter, const QStyleOptionViewItem
 
         if (isInAllNotes()) {
             folderNameRectPosX = rowPosX + note_list_constants::LEFT_OFFSET_X + 20;
-            folderNameRectPosY = rowPosY + fmRectContent.height() + fmRectTitle.height() + fmRectDate.height() + note_list_constants::TOP_OFFSET_Y + yOffsets;
+            folderNameRectPosY = rowPosY + contentLineHeight + titleLineHeight + dateLineHeight + note_list_constants::TOP_OFFSET_Y + yOffsets;
             folderNameRectWidth = rowWidth - 2.0 * note_list_constants::LEFT_OFFSET_X;
-            folderNameRectHeight = fmRectParentName.height() + note_list_constants::DESC_FOLDER_SPACE;
+            folderNameRectHeight = parentNameLineHeight + note_list_constants::DESC_FOLDER_SPACE;
         }
         auto drawStr = [painter](double posX, double posY, double width, double height, QColor color, const QFont &font, const QString &str) {
             QRectF rect(posX, posY, width, height);

--- a/src/notelistdelegateeditor.cpp
+++ b/src/notelistdelegateeditor.cpp
@@ -235,20 +235,20 @@ void NoteListDelegateEditor::paintLabels(QPainter *painter, const QStyleOptionVi
     QString title{ index.data(NoteListModel::NoteFullTitle).toString() };
     QFont titleFont = m_view->selectionModel()->isSelected(index) ? m_titleSelectedFont : m_titleFont;
     QFontMetrics fmTitle(titleFont);
-    QRect fmRectTitle = fmTitle.boundingRect(title);
+    const int titleLineHeight = fmTitle.height();
 
     QString date = utils::parseDateTime(index.data(NoteListModel::NoteLastModificationDateTime).toDateTime());
     QFontMetrics fmDate(m_dateFont);
-    QRect fmRectDate = fmDate.boundingRect(date);
+    const int dateLineHeight = fmDate.height();
 
     QString parentName{ index.data(NoteListModel::NoteParentName).toString() };
     QFontMetrics fmParentName(titleFont);
-    QRect fmRectParentName = fmParentName.boundingRect(parentName);
+    const int parentNameLineHeight = fmParentName.height();
 
     QString content{ index.data(NoteListModel::NoteContent).toString() };
     content = NoteEditorLogic::getSecondLine(content);
     QFontMetrics fmContent(titleFont);
-    QRect fmRectContent = fmContent.boundingRect(content);
+    const int contentLineHeight = fmContent.height();
 
     double rowPosX = rect().x();
     double rowPosY = rect().y();
@@ -311,17 +311,17 @@ void NoteListDelegateEditor::paintLabels(QPainter *painter, const QStyleOptionVi
     double titleRectPosX = rowPosX + note_list_constants::LEFT_OFFSET_X;
     double titleRectPosY = rowPosY;
     double titleRectWidth = rowWidth - (2.0 * note_list_constants::LEFT_OFFSET_X);
-    double titleRectHeight = fmRectTitle.height() + note_list_constants::TOP_OFFSET_Y + yOffsets;
+    double titleRectHeight = titleLineHeight + note_list_constants::TOP_OFFSET_Y + yOffsets;
 
     double dateRectPosX = rowPosX + note_list_constants::LEFT_OFFSET_X;
-    double dateRectPosY = rowPosY + fmRectTitle.height() + note_list_constants::TOP_OFFSET_Y + yOffsets;
+    double dateRectPosY = rowPosY + titleLineHeight + note_list_constants::TOP_OFFSET_Y + yOffsets;
     double dateRectWidth = rowWidth - (2.0 * note_list_constants::LEFT_OFFSET_X);
-    double dateRectHeight = fmRectDate.height() + note_list_constants::TITLE_DATE_SPACE;
+    double dateRectHeight = dateLineHeight + note_list_constants::TITLE_DATE_SPACE;
 
     double contentRectPosX = rowPosX + note_list_constants::LEFT_OFFSET_X;
-    double contentRectPosY = rowPosY + fmRectTitle.height() + fmRectDate.height() + note_list_constants::TOP_OFFSET_Y + yOffsets;
+    double contentRectPosY = rowPosY + titleLineHeight + dateLineHeight + note_list_constants::TOP_OFFSET_Y + yOffsets;
     double contentRectWidth = rowWidth - (2.0 * note_list_constants::LEFT_OFFSET_X);
-    double contentRectHeight = fmRectContent.height() + note_list_constants::DATE_DESC_SPACE;
+    double contentRectHeight = contentLineHeight + note_list_constants::DATE_DESC_SPACE;
 
     double folderNameRectPosX = 0;
     double folderNameRectPosY = 0;
@@ -330,9 +330,9 @@ void NoteListDelegateEditor::paintLabels(QPainter *painter, const QStyleOptionVi
 
     if (m_delegate->isInAllNotes()) {
         folderNameRectPosX = rowPosX + note_list_constants::LEFT_OFFSET_X + 20;
-        folderNameRectPosY = rowPosY + fmRectContent.height() + fmRectTitle.height() + fmRectDate.height() + note_list_constants::TOP_OFFSET_Y + yOffsets;
+        folderNameRectPosY = rowPosY + contentLineHeight + titleLineHeight + dateLineHeight + note_list_constants::TOP_OFFSET_Y + yOffsets;
         folderNameRectWidth = rowWidth - 2.0 * note_list_constants::LEFT_OFFSET_X;
-        folderNameRectHeight = fmRectParentName.height() + note_list_constants::DESC_FOLDER_SPACE;
+        folderNameRectHeight = parentNameLineHeight + note_list_constants::DESC_FOLDER_SPACE;
     }
     auto drawStr = [painter](double posX, double posY, double width, double height, QColor color, const QFont &font, const QString &str) {
         QRectF rect(posX, posY, width, height);


### PR DESCRIPTION
## Summary
- use stable font line metrics for note list title, date, content, and parent rows
- stop laying out note rows from per-string `boundingRect()` heights, which vary with the actual glyphs rendered
- keep `NoteListDelegate` and `NoteListDelegateEditor` in sync so the persistent editor matches the normal row renderer

Fixes #164.

## Why
The Windows alignment bug appears to come from using text-specific bounding boxes to position stacked note row labels. On some Windows font/DPI combinations, that can make row spacing depend on the glyphs in each note title/date/content, which leads to visually inconsistent alignment.

## Testing
- Not run locally in this environment because the required Qt/CMake Windows toolchain is not installed here.
- The change is limited to replacing layout height calculations with `QFontMetrics::height()` in the two note-list paint paths.